### PR TITLE
Add starter workflow

### DIFF
--- a/.github/workflows/mit-libraries-ruby-ci.yml
+++ b/.github/workflows/mit-libraries-ruby-ci.yml
@@ -1,0 +1,10 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  mitlibraries-ruby-ci:
+    uses: mitlibraries/actions-workflows/.github/workflows/ruby-ci.yml@main

--- a/.github/workflows/mit-libraries-ruby-ci.yml
+++ b/.github/workflows/mit-libraries-ruby-ci.yml
@@ -6,5 +6,5 @@ on:
     branches: [ main ]
 
 jobs:
-  mitlibraries-ruby-ci:
-    uses: mitlibraries/actions-workflows/.github/workflows/ruby-ci.yml@main
+  shared:
+    uses: mitlibraries/.github/.github/workflows/ruby-shared-ci.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-debug.log*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -70,5 +70,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "simplecov"
+  gem "simplecov-lcov"
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       irb (>= 1.3.6)
       reline (>= 0.2.7)
     digest (3.1.0)
+    docile (1.4.0)
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -178,6 +179,13 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -226,6 +234,8 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)
   selenium-webdriver
+  simplecov
+  simplecov-lcov
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,13 @@
 ENV["RAILS_ENV"] ||= "test"
+require 'simplecov'
+ require 'simplecov-lcov'
+ SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+ SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = 'coverage.lcov'
+ SimpleCov.formatters = [
+   SimpleCov::Formatter::HTMLFormatter,
+   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+ ]
+ SimpleCov.start('rails')
 require_relative "../config/environment"
 require "rails/test_help"
 


### PR DESCRIPTION
This attempts to follow the instructions from https://github.com/MITLibraries/actions-workflows for this repository:

- Adds the workflow from the Actions screen, looking for workflows from the MIT Libraries
- Appends to that commit with the instructions from the linked repository above. 

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
