### PR TITLE
First steps toward Query Wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '3.1.1'
 
 gem 'bootsnap', require: false
+gem 'http'
 gem 'importmap-rails'
 gem 'jbuilder'
 gem 'mitlibraries-theme', '~> 0.7.0'
@@ -24,6 +25,8 @@ group :development, :test do
 end
 
 group :development do
+  gem 'annotate'
+  gem 'dotenv-rails'
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'web-console'
@@ -34,5 +37,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-lcov'
+  gem 'vcr'
   gem 'webdrivers'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     bindex (0.8.1)
     bootsnap (1.11.1)
@@ -84,16 +87,36 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug (1.5.0)
       irb (>= 1.3.6)
       reline (>= 0.2.7)
     digest (3.1.0)
     docile (1.4.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
+    http (5.0.4)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.0.3)
@@ -106,6 +129,9 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -231,7 +257,11 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.1)
     unicode-display_width (2.1.0)
+    vcr (6.1.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -241,6 +271,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -254,9 +288,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   capybara
   debug
+  dotenv-rails
+  http
   importmap-rails
   jbuilder
   mitlibraries-theme (~> 0.7.0)
@@ -273,8 +310,10 @@ DEPENDENCIES
   stimulus-rails
   turbo-rails
   tzinfo-data
+  vcr
   web-console
   webdrivers
+  webmock
 
 RUBY VERSION
    ruby 3.1.1p18

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 # TIMDEX UI
 
 A discovery interface backed by [the TIMDEX API](https://github.com/MITLibraries/timdex).
+
+## Optional Environment Variables
+
+- `TIMDEX_BASE`: value to override the default url for the TIMDEX API.
+- `TIMDEX_TIMEOUT`: value to override the 6 second default for TIMDEX timeout.

--- a/app/models/query_builder.rb
+++ b/app/models/query_builder.rb
@@ -1,0 +1,18 @@
+class QueryBuilder
+  def initialize(term)
+    @query = {}
+    @query['q'] = clean_term(term)
+    @query['full'] = false
+    @query['page'] = 1
+  end
+
+  def querystring
+    @query.to_query
+  end
+
+  private
+
+  def clean_term(term)
+    term.gsub('"', '\'').strip
+  end
+end

--- a/app/models/timdex_wrapper.rb
+++ b/app/models/timdex_wrapper.rb
@@ -1,0 +1,44 @@
+class TimdexWrapper
+  def initialize
+    @timdex_http = HTTP.headers(accept: 'application/json',
+                                'Accept-Encoding': 'gzip, deflate, br',
+                                'Content-Type': 'application/json',
+                                Origin: 'https://lib.mit.edu')
+  end
+
+  # Run a search
+  # @param term [string] The string we are searching for
+  # @return [Hash] A Hash with search metadata and an Array of {Result}s
+  def search(term)
+    @results = @timdex_http.timeout(http_timeout)
+                           .get(search_url(term))
+    JSON.parse(@results.to_s)
+  rescue StandardError => e
+    error = {}
+    error['error'] = e.to_s
+    error
+  end
+
+  private
+
+  # https://github.com/httprb/http/wiki/Timeouts
+  def http_timeout
+    if ENV['TIMDEX_TIMEOUT'].present?
+      ENV['TIMDEX_TIMEOUT'].to_f
+    else
+      6
+    end
+  end
+
+  def search_url(term)
+    timdex_url + "search?#{QueryBuilder.new(term).querystring}"
+  end
+
+  def timdex_url
+    if ENV['TIMDEX_BASE'].present?
+      ENV['TIMDEX_BASE'].to_s
+    else
+      'https://timdex.mit.edu/api/v1/'
+    end
+  end
+end

--- a/test/models/query_builder_test.rb
+++ b/test/models/query_builder_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class QueryBuilderTest < ActiveSupport::TestCase
+  test 'url returns a querystring' do
+    expected = 'full=false&page=1&q=blah'
+    search = 'blah'
+    assert_equal(expected, QueryBuilder.new(search).querystring)
+  end
+
+  test 'query builder trims spaces' do
+    expected = 'full=false&page=1&q=blah'
+    search = ' blah '
+    assert_equal(expected, QueryBuilder.new(search).querystring)
+  end
+
+  test 'query builder escapes single quotes' do
+    expected = 'full=false&page=1&q=don%27t'
+    search = "don't"
+    assert_equal(expected, QueryBuilder.new(search).querystring)
+  end
+
+  test 'query builder converts double quotes to single quotes' do
+    expected = 'full=false&page=1&q=say+%27ahh%27+please'
+    search = 'say "ahh" please'
+    assert_equal(expected, QueryBuilder.new(search).querystring)
+  end
+
+  test 'query builder deals with phrases' do
+    expected = 'full=false&page=1&q=buttered+popcorn'
+    search = 'buttered popcorn'
+    assert_equal(expected, QueryBuilder.new(search).querystring)
+  end
+end

--- a/test/models/timdex_wrapper_test.rb
+++ b/test/models/timdex_wrapper_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class TimdexWrapperTest < ActiveSupport::TestCase
+  def setup
+    ENV['TIMDEX_BASE'] = nil
+    ENV['TIMDEX_TIMEOUT'] = nil
+  end
+
+  def after
+    ENV['TIMDEX_BASE'] = nil
+    ENV['TIMDEX_TIMEOUT'] = nil
+  end
+
+  test 'timdex url is read from env' do
+    # Default value
+    needle = 'https://timdex.mit.edu/api/v1/'
+    ENV['TIMDEX_BASE'] = nil
+    assert_equal(needle, TimdexWrapper.new.send(:timdex_url))
+
+    # Override
+    needle = 'https://example.org/'
+    ENV['TIMDEX_BASE'] = needle
+    assert_equal(needle, TimdexWrapper.new.send(:timdex_url))
+  end
+
+  test 'http timeout is controlled by env' do
+    # Default value
+    needle = 6
+    ENV['TIMDEX_TIMEOUT'] = nil
+    assert_equal(needle, TimdexWrapper.new.send(:http_timeout))
+
+    needle = 30
+    ENV['TIMDEX_TIMEOUT'] = needle.to_s
+    assert_equal(needle, TimdexWrapper.new.send(:http_timeout))
+  end
+
+  test 'search method returns results' do
+    VCR.use_cassette('timdex popcorn',
+                     allow_playback_repeats: true) do
+      wrapper = TimdexWrapper.new
+      result = wrapper.search('popcorn')
+      assert_operator(0, :<, result['hits'].to_i)
+    end
+  end
+
+  test 'quoted searches do not error' do
+    VCR.use_cassette('timdex quoted',
+                     allow_playback_repeats: true) do
+      wrapper = TimdexWrapper.new
+      result = wrapper.search('"allegedly"')
+      assert_operator(0, :<, result['hits'].to_i)
+      refute(result.key?('error'))
+    end
+  end
+
+  test 'multi-world searches do not error' do
+    VCR.use_cassette('timdex multiword',
+                     allow_playback_repeats: true) do
+      wrapper = TimdexWrapper.new
+      result = wrapper.search('carbon nanotubes')
+      assert_operator(0, :<, result['hits'].to_i)
+      refute(result.key?('error'))
+    end
+  end
+
+  test 'error handling if timdex does not respond' do
+    ENV['TIMDEX_BASE'] = 'https://tiimdex.mit.edu/api/v1/'
+    VCR.use_cassette('timdex down',
+                     allow_playback_repeats: true) do
+      wrapper = TimdexWrapper.new
+      result = wrapper.search('timdex is down')
+      # Only test that an error is thrown - specifics of how the error is implemented are not relevant now.
+      assert(result.key?('error'))
+    end
+  end
+
+  test 'error handing of 404' do
+    ENV['TIMDEX_BASE'] = 'https://timdex.mit.edu/oops/v1/'
+    VCR.use_cassette('timdex 404',
+                     allow_playback_repeats: true) do
+      wrapper = TimdexWrapper.new
+      result = wrapper.search('timdex is down')
+      # Only test that an error is thrown - specifics of how the error is implemented are not relevant now.
+      assert(result.key?('error'))
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,12 @@ SimpleCov.start('rails')
 require_relative '../config/environment'
 require 'rails/test_help'
 
+VCR.configure do |config|
+  config.ignore_localhost = true
+  config.cassette_library_dir = 'test/vcr_cassettes'
+  config.hook_into :webmock
+end
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers

--- a/test/vcr_cassettes/timdex_404.yml
+++ b/test/vcr_cassettes/timdex_404.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://timdex.mit.edu/oops/v1/search?full=false&page=1&q=timdex%20is%20down
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - Keep-Alive
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Fri, 08 Apr 2022 18:36:59 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Request-Id:
+      - e0bbbcb4-0c3f-44d1-a047-86e0c59dd46e
+      X-Runtime:
+      - '0.008150'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '34'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"status":404,"error":"Not Found"}'
+  recorded_at: Fri, 08 Apr 2022 18:37:00 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_multiword.yml
+++ b/test/vcr_cassettes/timdex_multiword.yml
@@ -1,0 +1,236 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://timdex.mit.edu/api/v1/search?full=false&page=1&q=carbon%20nanotubes
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - Keep-Alive
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Fri, 08 Apr 2022 15:38:53 GMT
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"0138715a0cb4c878737a9722daa0868e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4507c5e4-f875-4208-a6fc-64b96cdd692a
+      X-Runtime:
+      - '0.740327'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: "{\"hits\":13571,\"request_limit\":500,\"request_count\":1,\"limit_info\":\"Register
+        for a free account and provide your JWT token to remove all request limitations.\",\"results\":[{\"id\":\"9935122021206761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935122021206761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935122021206761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2011\",\"title\":\"Carbon Nanotubes
+        - Polymer Nanocomposites\",\"isbns\":[\"953-51-4458-8\"],\"imprint\":[\"IntechOpen\"]},{\"id\":\"9935145691106761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935145691106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935145691106761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2018\",\"title\":\"Carbon Nanotubes
+        - Recent Progress\",\"isbns\":[\"1-83881-343-8\",\"1-78923-053-5\"],\"imprint\":[\"IntechOpen\"]},{\"id\":\"990028249340106761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma990028249340106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/990028249340106761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2011\",\"title\":\"Carbon Nanotubes
+        and Carbon Nanotubes /\",\"links\":[{\"kind\":\"unknown\",\"url\":\"https://www.intechopen.com/books/carbon-nanotubes-growth-and-applications\"}],\"contributors\":[{\"kind\":\"author\",\"value\":\"Yong
+        Hu, author.\"},{\"kind\":\"contributor\",\"value\":\"Changfa Guo, author.\"}],\"oclcs\":[\"884046976\",\"1111233648\"],\"isbns\":[\"9789533075662\",\"953307566X\"],\"imprint\":[\"INTECH
+        Open Access Publisher, 2011.\"]},{\"id\":\"9935123510206761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935123510206761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935123510206761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2008\",\"title\":\"Carbon nanotubes
+        advanced topics in the synthesis, structure, properties and applications /\",\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Jorio,
+        A. (Ado)\"},{\"kind\":\"contributor\",\"value\":\"Dresselhaus, G.\"},{\"kind\":\"contributor\",\"value\":\"Dresselhaus,
+        M. S.\"}],\"subjects\":[\"Carbon.\",\"Nanotubes.\"],\"oclcs\":[\"233973272\"],\"isbns\":[\"1-281-18033-5\",\"9786611180331\",\"3-540-72865-1\"],\"imprint\":[\"New
+        York ; Berlin : Springer-Verlag, c2008.\"]},{\"id\":\"9935055804206761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935055804206761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935055804206761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2014\",\"title\":\"Carbon nanotubes
+        and graphene /\",\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Tanaka,
+        K., editor.\"},{\"kind\":\"contributor\",\"value\":\"Iijima, S., editor.\"}],\"subjects\":[\"Carbon.\",\"Carbon
+        nanotubes.\",\"Graphene.\"],\"oclcs\":[\"884646408\"],\"isbns\":[\"0-08-098268-9\"],\"imprint\":[\"Amsterdam,
+        Netherlands : Elsevier, 2014.\",\"©2014\"]},{\"id\":\"9935122021506761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935122021506761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935122021506761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2010\",\"title\":\"Carbon nanotubes
+        /\",\"isbns\":[\"953-51-4554-1\"],\"imprint\":[\"IntechOpen, 2010.\"]},{\"id\":\"990028257300106761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma990028257300106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/990028257300106761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2010\",\"title\":\"Carbon nanotubes
+        /\",\"links\":[{\"kind\":\"unknown\",\"url\":\"https://www.intechopen.com/books/carbon-nanotubes\"}],\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Marulanda,
+        Jose Mauricio.\"}],\"subjects\":[\"Nanotubes.\"],\"oclcs\":[\"817251975\",\"1039339240\",\"1111233245\"],\"isbns\":[\"9789533070544\",\"9533070544\"],\"imprint\":[\"[Place
+        of publication not identified] : InTech, 2010.\"]},{\"id\":\"9935164680706761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935164680706761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935164680706761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2021\",\"title\":\"Carbon Nanotubes\",\"isbns\":[\"0-429-29958-3\"],\"imprint\":[\"CRC
+        Press\"]},{\"id\":\"990008378020106761\",\"source\":\"MIT Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma990008378020106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/990008378020106761\",\"content_type\":\"Text\",\"content_format\":[\"Print
+        volume\"],\"realtime_holdings_link\":\"Not Yet Implemented\",\"publication_date\":\"1996\",\"title\":\"Carbon
+        nanotubes /\",\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Endo,
+        Morinobu.\"},{\"kind\":\"contributor\",\"value\":\"Iijima, Sumio.\"},{\"kind\":\"contributor\",\"value\":\"Dresselhaus,
+        M. S.\"}],\"subjects\":[\"Carbon.\",\"Nanostructured materials.\",\"Tubes.\"],\"summary_holdings\":[{\"location\":\"Hayden
+        Library\",\"collection\":\"Stacks\",\"call_number\":\"TA455.C3.C36 1996\",\"summary\":\"MCM\",\"format\":\"Print
+        volume\"}],\"lccn\":\"97161615\",\"oclcs\":[\"37331799\",\"36462136\"],\"isbns\":[\"0080426824\"],\"imprint\":[\"Oxford
+        ; Tarrytown, N.Y. : Pergamon, 1996.\"]},{\"id\":\"9935129465606761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935129465606761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935129465606761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2016\",\"title\":\"Carbon Nanotubes
+        â\x80\x93 Current Progress of their Polymer Composites\",\"isbns\":[\"953-51-4196-1\",\"953-51-2470-6\"],\"imprint\":[\"IntechOpen\"]},{\"id\":\"9935156020306761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935156020306761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935156020306761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2019\",\"title\":\"Carbon Nanotubes
+        for Targeted Drug Delivery\",\"contributors\":[{\"kind\":\"author\",\"value\":\"Hasnain,
+        Md Saquib. author.\"},{\"kind\":\"contributor\",\"value\":\"Nayak, Amit Kumar.
+        author.\"}],\"subjects\":[\"Nanotechnology.\",\"Pharmaceutical technology.\",\"Pharmacy.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z14000
+        Nanotechnology.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/B21010
+        Pharmaceutical Sciences/Technology.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/T18000
+        Nanotechnology and Microengineering.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/H69010
+        Drug Safety and Pharmacovigilance.\"],\"isbns\":[\"981-15-0910-7\"],\"imprint\":[\"Singapore
+        : Springer Singapore : Imprint: Springer, 2019.\"]},{\"id\":\"9935055768506761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935055768506761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935055768506761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2001\",\"title\":\"Carbon Nanotubes
+        Synthesis, Structure, Properties, and Applications /\",\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Dresselhaus,
+        Mildred S. editor.\"},{\"kind\":\"contributor\",\"value\":\"Dresselhaus, Gene.
+        editor.\"},{\"kind\":\"contributor\",\"value\":\"Avouris, Phaedon. editor.\"}],\"subjects\":[\"Nanotechnology.\",\"Materials
+        science.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z14000
+        Nanotechnology.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z17000
+        Characterization and Evaluation of Materials.\"],\"isbns\":[\"3-540-39947-X\"],\"imprint\":[\"Berlin,
+        Heidelberg : Springer Berlin Heidelberg : Imprint: Springer, 2001.\"]},{\"id\":\"990032742680106761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma990032742680106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/990032742680106761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2016\",\"title\":\"Carbon Nanotubes
+        - Current Progress of their Polymer Composites.\",\"links\":[{\"kind\":\"unknown\",\"url\":\"https://www.intechopen.com/books/carbon-nanotubes-current-progress-of-their-polymer-composites\"}],\"contributors\":[{\"kind\":\"author\",\"value\":\"Inas
+        Hazzaa Hafez, VerfasserIn.\"},{\"kind\":\"contributor\",\"value\":\"Mohamed
+        Reda Berber, VerfasserIn.\"}],\"subjects\":[\"Physics.\"],\"oclcs\":[\"1193046320\"],\"isbns\":[\"9789535124696\",\"9535124692\",\"9789535124702\",\"9535124706\",\"9789535141969\",\"9535141961\"],\"imprint\":[\"[Erscheinungsort
+        nicht ermittelbar] IntechOpen 2016\"]},{\"id\":\"990028251290106761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma990028251290106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/990028251290106761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"19uu\",\"title\":\"Carbon Nanotubes
+        - Polymer Nanocomposites.\",\"links\":[{\"kind\":\"unknown\",\"url\":\"https://www.intechopen.com/books/carbon-nanotubes-polymer-nanocomposites\"}],\"oclcs\":[\"1096640945\"],\"isbns\":[\"9533074981\",\"9789533074986\"],\"imprint\":[\"[S.l.]
+        : InTech.\"]},{\"id\":\"9935147868806761\",\"source\":\"MIT Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935147868806761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935147868806761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2017\",\"title\":\"Carbon Nanotubes
+        for Interconnects Process, Design and Applications /\",\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Todri-Sanial,
+        Aida. editor.\"},{\"kind\":\"contributor\",\"value\":\"Dijon, Jean. editor.\"},{\"kind\":\"contributor\",\"value\":\"Maffucci,
+        Antonio. editor.\"}],\"subjects\":[\"Electronic circuits.\",\"Microprocessors.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/T24068
+        Circuits and Systems.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/I13014
+        Processor Architectures.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/P31010
+        Electronic Circuits and Devices.\"],\"isbns\":[\"3-319-29746-5\"],\"imprint\":[\"Cham
+        : Springer International Publishing : Imprint: Springer, 2017.\"]},{\"id\":\"9935155697306761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935155697306761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935155697306761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2006\",\"title\":\"Carbon Nanotubes:
+        From Basic Research to Nanotechnology\",\"contributors\":[{\"kind\":\"author\",\"value\":\"NATO
+        Advanced Study Institute on Carbon Nanotubes: From Basic Research to Nanotechnology
+        Corporate Author\"},{\"kind\":\"author\",\"value\":\"NATO Advanced Study Institute
+        on Carbon Nanotubes: From Basic Research to Nanotechnology Sozopol, Bulgaria)
+        (2005 :\"},{\"kind\":\"contributor\",\"value\":\"Popov, Valentin N. editor.\"},{\"kind\":\"contributor\",\"value\":\"Lambin,
+        Philippe. editor.\"},{\"kind\":\"contributor\",\"value\":\"North Atlantic
+        Treaty Organization.\"},{\"kind\":\"contributor\",\"value\":\"NATO Advanced
+        Study Institute on Carbon Nanotubes: From Basic Research to Nanotechnology\"}],\"subjects\":[\"Materials
+        science.\",\"Nanotechnology.\",\"Structural materials.\",\"Optical materials.\",\"Electronic
+        materials.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z00000
+        Materials Science, general.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/T18000
+        Nanotechnology and Microengineering.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z14000
+        Nanotechnology.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z11000
+        Structural Materials.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z12000
+        Optical and Electronic Materials.\"],\"oclcs\":[\"209936677\"],\"isbns\":[\"1-281-10753-0\",\"9786611107536\",\"1-4020-4574-3\"],\"imprint\":[\"Dordrecht
+        : Springer Netherlands : Imprint: Springer, 2006.\"]},{\"id\":\"9935155838706761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935155838706761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935155838706761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2018\",\"title\":\"Carbon Nanotubes
+        for Clean Water\",\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Das,
+        Rasel. editor.\"}],\"subjects\":[\"Nanotechnology.\",\"Water quality.\",\"Water
+        pollution.\",\"Catalysis.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/Z14000
+        Nanotechnology.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/212000
+        Water Quality/Water Pollution.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/C29000
+        Catalysis.\",\"https://scigraph.springernature.com/ontologies/product-market-codes/U35040
+        Waste Water Technology / Water Pollution Control / Water Management / Aquatic
+        Pollution.\"],\"isbns\":[\"3-319-95603-5\"],\"imprint\":[\"Cham : Springer
+        International Publishing : Imprint: Springer, 2018.\"]},{\"id\":\"9935079958106761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935079958106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935079958106761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2010\",\"title\":\"Carbon Nanotubes
+        Methods and Protocols /\",\"contributors\":[{\"kind\":\"contributor\",\"value\":\"Balasubramanian,
+        Kannan. editor.\"},{\"kind\":\"contributor\",\"value\":\"Burghard, Marko.
+        editor.\"}],\"subjects\":[\"Engineering.\",\"Biochemistry.\",\"Materials.\",\"Biomaterials.\",\"http://scigraph.springernature.com/things/product-market-codes/T18000
+        Nanotechnology and Microengineering.\",\"http://scigraph.springernature.com/things/product-market-codes/L14005
+        Biochemistry, general.\",\"http://scigraph.springernature.com/things/product-market-codes/Z00000
+        Materials Science, general.\",\"http://scigraph.springernature.com/things/product-market-codes/Z13000
+        Biomaterials.\"],\"isbns\":[\"1-60761-579-7\"],\"imprint\":[\"Totowa, NJ :
+        Humana Press : Imprint: Humana, 2010.\"]},{\"id\":\"990028252920106761\",\"source\":\"MIT
+        Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma990028252920106761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/990028252920106761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"19uu\",\"title\":\"Carbon Nanotubes
+        - Synthesis, Characterization, Applications.\",\"links\":[{\"kind\":\"unknown\",\"url\":\"https://www.intechopen.com/books/carbon-nanotubes-synthesis-characterization-applications\"}],\"oclcs\":[\"1096659570\"],\"isbns\":[\"9533074973\",\"9789533074979\"],\"imprint\":[\"[S.l.]
+        : InTech.\"]},{\"id\":\"9935122021306761\",\"source\":\"MIT Alma\",\"source_link\":\"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\\u0026docid=alma9935122021306761\",\"full_record_link\":\"https://timdex.mit.edu/api/v1/record/9935122021306761\",\"content_type\":\"Text\",\"realtime_holdings_link\":\"Not
+        Yet Implemented\",\"publication_date\":\"2011\",\"title\":\"Carbon Nanotubes
+        - Growth and Applications\",\"isbns\":[\"953-51-4462-6\"],\"imprint\":[\"IntechOpen\"]}],\"aggregations\":{\"source\":[{\"name\":\"mit
+        alma\",\"count\":11054},{\"name\":\"dspace@mit\",\"count\":2512},{\"name\":\"mit
+        archivesspace\",\"count\":5}],\"content_format\":[{\"name\":\"print volume\",\"count\":3146},{\"name\":\"cd-rom\",\"count\":29},{\"name\":\"microfiche\",\"count\":21},{\"name\":\"atlas\",\"count\":2},{\"name\":\"compact
+        disc\",\"count\":2}],\"content_type\":[{\"name\":\"text\",\"count\":10867},{\"name\":\"thesis\",\"count\":1158},{\"name\":\"article\",\"count\":1113},{\"name\":\"moving
+        image\",\"count\":164},{\"name\":\"technical report\",\"count\":91},{\"name\":\"working
+        paper\",\"count\":82},{\"name\":\"sound recording\",\"count\":19},{\"name\":\"archival
+        collection\",\"count\":5},{\"name\":\"other\",\"count\":5},{\"name\":\"computer
+        file\",\"count\":2}],\"collection\":[{\"name\":\"mit libraries\",\"count\":1153},{\"name\":\"mit
+        theses\",\"count\":1153},{\"name\":\"mit open access articles\",\"count\":1094},{\"name\":\"theses
+        - dept. of mechanical engineering\",\"count\":220},{\"name\":\"center for
+        global change science\",\"count\":129},{\"name\":\"theses - chemical engineering\",\"count\":120},{\"name\":\"theses
+        - dept. of chemical engineering\",\"count\":120},{\"name\":\"theses - dept.
+        of materials science and engineering\",\"count\":118},{\"name\":\"theses -
+        civil and environmental engineering\",\"count\":107},{\"name\":\"theses -
+        dept. of civil and environmental engineering\",\"count\":107}],\"contributor\":[{\"name\":\"massachusetts
+        institute of technology. department of mechanical engineering.\",\"count\":272},{\"name\":\"massachusetts
+        institute of technology. dept. of mechanical engineering.\",\"count\":210},{\"name\":\"massachusetts
+        institute of technology. department of earth, atmospheric, and planetary sciences\",\"count\":180},{\"name\":\"massachusetts
+        institute of technology. department of chemistry\",\"count\":167},{\"name\":\"massachusetts
+        institute of technology. department of mechanical engineering\",\"count\":165},{\"name\":\"woods
+        hole oceanographic institution.\",\"count\":163},{\"name\":\"massachusetts
+        institute of technology. department of chemical engineering\",\"count\":157},{\"name\":\"massachusetts
+        institute of technology. department of civil and environmental engineering\",\"count\":154},{\"name\":\"massachusetts
+        institute of technology. department of chemical engineering.\",\"count\":148},{\"name\":\"massachusetts
+        institute of technology. department of chemistry.\",\"count\":140}],\"subject\":[{\"name\":\"nanotechnology.\",\"count\":487},{\"name\":\"https://scigraph.springernature.com/ontologies/product-market-codes/z14000
+        nanotechnology.\",\"count\":313},{\"name\":\"climate change.\",\"count\":291},{\"name\":\"sustainable
+        development.\",\"count\":284},{\"name\":\"fossil fuels.\",\"count\":278},{\"name\":\"https://scigraph.springernature.com/ontologies/product-market-codes/114000
+        fossil fuels (incl. carbon capture).\",\"count\":275},{\"name\":\"materials
+        science.\",\"count\":272},{\"name\":\"https://scigraph.springernature.com/ontologies/product-market-codes/111000
+        renewable and green energy.\",\"count\":223},{\"name\":\"chemical engineering.\",\"count\":222},{\"name\":\"renewable
+        energy resources.\",\"count\":220}],\"language\":[{\"name\":\"english\",\"count\":10995},{\"name\":\"eng\",\"count\":1166},{\"name\":\"en_us\",\"count\":860},{\"name\":\"en\",\"count\":250},{\"name\":\"in
+        english.\",\"count\":165},{\"name\":\"original language in english.\",\"count\":54},{\"name\":\"german\",\"count\":45},{\"name\":\"english.\",\"count\":31},{\"name\":\"french\",\"count\":17},{\"name\":\"no
+        linguistic content\",\"count\":12}],\"literary_form\":[{\"name\":\"nonfiction\",\"count\":10254},{\"name\":\"fiction\",\"count\":800}]}}"
+  recorded_at: Fri, 08 Apr 2022 15:38:53 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_popcorn.yml
+++ b/test/vcr_cassettes/timdex_popcorn.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://timdex.mit.edu/api/v1/search?full=false&page=1&q=popcorn
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - Keep-Alive
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Thu, 07 Apr 2022 20:06:05 GMT
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"861d7a1415016b12d22d649c5b73e337"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 909bd014-9a76-46a8-9633-331ffdac20fe
+      X-Runtime:
+      - '0.173280'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"hits":131,"request_limit":500,"request_count":1,"limit_info":"Register
+        for a free account and provide your JWT token to remove all request limitations.","results":[{"id":"9935117411606761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117411606761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117411606761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Brazil","imprint":["Datamonitor Plc"]},{"id":"9935117412706761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117412706761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117412706761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Argentina","imprint":["Datamonitor Plc"]},{"id":"9935117410906761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117410906761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117410906761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Denmark","imprint":["Datamonitor Plc"]},{"id":"9935117410106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117410106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117410106761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Germany","imprint":["Datamonitor Plc"]},{"id":"9935117369206761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117369206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117369206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Greece","imprint":["Datamonitor Plc"]},{"id":"9935117367406761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117367406761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117367406761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Japan","imprint":["Datamonitor Plc"]},{"id":"9935117367006761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117367006761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117367006761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Mexico","imprint":["Datamonitor Plc"]},{"id":"9935117366406761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117366406761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117366406761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Norway","imprint":["Datamonitor Plc"]},{"id":"9935117365706761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117365706761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117365706761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Portugal","imprint":["Datamonitor Plc"]},{"id":"9935117365206761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117365206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117365206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Russia","imprint":["Datamonitor Plc"]},{"id":"9935117363906761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117363906761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117363906761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Switzerland","imprint":["Datamonitor Plc"]},{"id":"9935117410706761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117410706761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117410706761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Europe","imprint":["Datamonitor Plc"]},{"id":"9935117409806761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117409806761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117409806761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Global","imprint":["Datamonitor Plc"]},{"id":"9935117366106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117366106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117366106761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Poland","imprint":["Datamonitor Plc"]},{"id":"9935117364606761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117364606761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117364606761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Spain","imprint":["Datamonitor Plc"]},{"id":"9935117364306761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117364306761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117364306761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Sweden","imprint":["Datamonitor Plc"]},{"id":"9935117363406761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117363406761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117363406761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Taiwan","imprint":["Datamonitor Plc"]},{"id":"9935117363006761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117363006761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117363006761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Thailand","imprint":["Datamonitor Plc"]},{"id":"9935117412206761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117412206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117412206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Australia","imprint":["Datamonitor Plc"]},{"id":"9935117412006761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935117412006761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935117412006761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"uuuu","title":"Popcorn Industry Profile:
+        Austria","imprint":["Datamonitor Plc"]}],"aggregations":{"source":[{"name":"mit
+        alma","count":131}],"content_format":[{"name":"print volume","count":13},{"name":"musical
+        score","count":2},{"name":"compact disc","count":1}],"content_type":[{"name":"text","count":95},{"name":"sound
+        recording","count":26},{"name":"moving image","count":7},{"name":"musical
+        score","count":2},{"name":"computer file","count":1}],"collection":[],"contributor":[{"name":"djll,
+        tom.","count":7},{"name":"brown, james, 1933-2006.","count":6},{"name":"james
+        brown orchestra.","count":2},{"name":"muhly, nico.","count":2},{"name":"new
+        york studio orchestra.","count":2},{"name":"aboriginal peoples television
+        network, production company.","count":1},{"name":"anderson, sam, author. 1977-","count":1},{"name":"arling
+        \u0026 cameron (musical group)","count":1},{"name":"arling, gerry.","count":1},{"name":"arnold,
+        linda, performer.","count":1}],"subject":[{"name":"soul music.","count":4},{"name":"children''s
+        songs.","count":3},{"name":"rhythm and blues music.","count":3},{"name":"artificial
+        intelligence.","count":2},{"name":"astronomy miscellanea.","count":2},{"name":"communication
+        in organizations problems, exercises, etc.","count":2},{"name":"https://scigraph.springernature.com/ontologies/product-market-codes/i21000
+        artificial intelligence.","count":2},{"name":"jazz.","count":2},{"name":"acoustical
+        engineering.","count":1},{"name":"african diaspora in literature.","count":1}],"language":[{"name":"english","count":85},{"name":"french","count":36},{"name":"no
+        linguistic content","count":8},{"name":"in english.","count":7},{"name":"original
+        language in english.","count":5},{"name":"   ","count":2},{"name":"english.","count":1},{"name":"in
+        inuktitut with english subtitles.","count":1},{"name":"in portuguese.","count":1},{"name":"inuktitut","count":1}],"literary_form":[{"name":"fiction","count":76},{"name":"nonfiction","count":55}]}}'
+  recorded_at: Thu, 07 Apr 2022 20:06:05 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_quoted.yml
+++ b/test/vcr_cassettes/timdex_quoted.yml
@@ -1,0 +1,169 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://timdex.mit.edu/api/v1/search?full=false&page=1&q=%27allegedly%27
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - Keep-Alive
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Thu, 07 Apr 2022 20:06:06 GMT
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"38c0486670fdadf822ab1e5adc991c47"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7ad7d172-71a4-4fb7-b335-27202587a4b7
+      X-Runtime:
+      - '0.151719'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"hits":209,"request_limit":500,"request_count":2,"limit_info":"Register
+        for a free account and provide your JWT token to remove all request limitations.","results":[{"id":"9935088272806761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935088272806761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935088272806761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1977","title":"Allegedly Nonresponsive
+        Bid"},{"id":"9935088273406761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935088273406761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935088273406761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1978","title":"Allegedly Ambiguous Specifications"},{"id":"9935088272606761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935088272606761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935088272606761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1977","title":"Allegedly Restrictive
+        Solicitation Specifications"},{"id":"9935132919206761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935132919206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935132919206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1983","title":"[Complaint of Allegedly
+        Improper Procurements]"},{"id":"9935150938206761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935150938206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935150938206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1977","title":"Objection to Allegedly
+        Arbitrary Solicitation Provision"},{"id":"9935062928506761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935062928506761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935062928506761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1973","title":"Use Of An Allegedly Restrictive
+        Specification"},{"id":"9935140847106761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935140847106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935140847106761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1953","title":"Investigation of literature
+        allegedly containing objectionable material"},{"id":"9935088273206761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935088273206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935088273206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1977","title":"Allegedly Biased Technical
+        Evaluation of Proposals"},{"id":"9935079220206761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935079220206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935079220206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1978","title":"Request for Reconsideration
+        of Allegedly Defective Specifications"},{"id":"9935088273006761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935088273006761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935088273006761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1977","title":"Allegedly Improper Restrictive
+        Nature of Invitation for Bids"},{"id":"9935194331606761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935194331606761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935194331606761","content_type":"Text","content_format":["Print
+        volume"],"realtime_holdings_link":"Not Yet Implemented","publication_date":"2020","title":"Fly
+        by night physics : how physicists use the backs of envelopes /","contributors":[{"kind":"author","value":"Zee,
+        A., (author)"}],"subjects":["Physics Textbooks.","Physics Problems, exercises,
+        etc.","Reasoning.","Problem solving.","(OCoLC)fst01063025 Physics.","(OCoLC)fst01091282
+        Reasoning."],"summary_holdings":[{"location":"Hayden Library","collection":"Stacks","call_number":"QC21.3.Z44
+        2020","format":"Print volume"}],"lccn":"2020942704","oclcs":["1142961613","on1142961613"],"isbns":["9780691182544
+        (hardcover : alkaline paper)","069118254X (hardcover : alkaline paper)"],"imprint":["Princeton,
+        New Jersey : Princeton University Press, [2020]","©2020"]},{"id":"9935105221406761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935105221406761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935105221406761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1978","title":"Request for Backpay Based
+        on Allegedly Erroneous Classification"},{"id":"9935044978206761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935044978206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935044978206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1978","title":"Claim for Replacement
+        of an Allegedly Lost Check"},{"id":"oai:dspace.mit.edu:1721.1-114956","source":"DSpace@MIT","source_link":"https://hdl.handle.net/1721.1/114956","full_record_link":"https://timdex.mit.edu/api/v1/record/oai:dspace.mit.edu:1721.1-114956","content_type":"Article","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2017-01","title":"Color Relationalism
+        and Relativism","links":[{"kind":"Digital object URI","text":"Digital object
+        URI","url":"http://hdl.handle.net/1721.1/114956"}],"contributors":[{"kind":"author","value":"Hilbert,
+        David R."},{"kind":"author","value":"Byrne, Alexander"},{"kind":"department","value":"Massachusetts
+        Institute of Technology. Department of Linguistics and Philosophy"},{"kind":"mitauthor","value":"Byrne,
+        Alexander"}],"issns":["1756-8757"],"collections":["MIT Open Access Articles"]},{"id":"9935131872006761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935131872006761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935131872006761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1976","title":"Claim for Prompt Payment
+        Discount Allegedly Computed Erroneously Is Disallowed"},{"id":"9935131872506761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935131872506761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935131872506761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1975","title":"Claim for Proceeds of
+        Allotment Checks Allegedly Never Received"},{"id":"9935133961106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935133961106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935133961106761","content_type":"Moving
+        image","realtime_holdings_link":"Not Yet Implemented","publication_date":"2013","title":"Why
+        Would Iranian Hackers Target U.S. Banks? /","subjects":["Strategic Management","Crime","Terrorism","Internet","Computers","Iran"],"oclcs":["890734022"],"imprint":["New
+        York, NY : Bloomberg, 2013."]},{"id":"9935051079806761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935051079806761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935051079806761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1976","title":"Claim for Wages Allegedly
+        Due From General Services Administration"},{"id":"9935051072906761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935051072906761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935051072906761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1987","title":"[Claims for Anticipated
+        Profits Allegedly Lost Under Navy Solicitation for Wrenches]"},{"id":"9935090902306761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935090902306761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935090902306761","content_type":"Moving
+        image","realtime_holdings_link":"Not Yet Implemented","publication_date":"2001","title":"They
+        Mean Business /","contributors":[{"kind":"contributor","value":"Marin, Carol."},{"kind":"contributor","value":"Moseley,
+        Don."},{"kind":"contributor","value":"Moseley, Don, producer"},{"kind":"contributor","value":"CBS
+        News."}],"subjects":["United States. Environmental Protection Agency. Criminal
+        Enforcement Program.","Environmental policy United States.","Offenses against
+        the environment United States.","2000s","Crime","Law enforcement","Environmental
+        law","Environmental policy"],"oclcs":["904558891"],"imprint":["New York, NY
+        : Columbia Broadcasting System, 2001."]}],"aggregations":{"source":[{"name":"mit
+        alma","count":202},{"name":"dspace@mit","count":7}],"content_format":[{"name":"print
+        volume","count":19}],"content_type":[{"name":"text","count":183},{"name":"moving
+        image","count":18},{"name":"thesis","count":5},{"name":"article","count":2},{"name":"sound
+        recording","count":1}],"collection":[{"name":"mit libraries","count":5},{"name":"mit
+        theses","count":5},{"name":"political science - ph.d. / sc.d.","count":2},{"name":"theses
+        - dept. of political science","count":2},{"name":"comparative media studies
+        - master''s degree","count":1},{"name":"comparative media studies/writing
+        (cms/w)","count":1},{"name":"management - master''s degree","count":1},{"name":"mit
+        open access articles","count":1},{"name":"mit sociotechnical systems research
+        center (ssrc)","count":1},{"name":"theses - comparative media studies/writing","count":1}],"contributor":[{"name":"(1909),
+        ed herlihy, narrator","count":2},{"name":"albuquerque, paula, author.","count":2},{"name":"benovsky,
+        jiri, author.","count":2},{"name":"bondeson, jan, author.","count":2},{"name":"byrne,
+        alexander","count":2},{"name":"cbs news.","count":2},{"name":"erlanger, olivia,
+        author.","count":2},{"name":"kearns, michael, author. 1971-","count":2},{"name":"massachusetts
+        institute of technology. department of political science.","count":2},{"name":"massachusetts
+        institute of technology. dept. of urban studies and planning.","count":2}],"subject":[{"name":"political
+        science.","count":3},{"name":"(ocolc)fst00862898 civilization.","count":2},{"name":"2000s","count":2},{"name":"architecture
+        and society history 20th century. united states","count":2},{"name":"computers.","count":2},{"name":"crime","count":2},{"name":"cultural
+        identity","count":2},{"name":"domestic space history 20th century. united
+        states","count":2},{"name":"domino''s pizza (firm)","count":2},{"name":"english
+        literature history and criticism. early modern, 1500-1700","count":2}],"language":[{"name":"english","count":199},{"name":"in
+        english.","count":32},{"name":"original language in english.","count":17},{"name":"eng","count":4},{"name":"latin","count":3},{"name":"en","count":1},{"name":"en_us","count":1},{"name":"eng
+        por","count":1},{"name":"eng spa","count":1},{"name":"french","count":1}],"literary_form":[{"name":"nonfiction","count":136},{"name":"fiction","count":66}]}}'
+  recorded_at: Thu, 07 Apr 2022 20:06:06 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
### Why are these changes being introduced:

* We need a wrapper model for the Timdex API in order to easily send and
process searches against it.
* We also need a separate query builder which can support future
expansion.

### Relevant ticket(s):

* https://github.com/MITLibraries/timdex-ui/issues/18
* https://github.com/MITLibraries/timdex-ui/issues/19

### How does this address that need:

#### TimdexWrapper

* This builds a TimdexWrapper model with a single public method, search.
There are private methods for reading the two environment variables,
as well as for extending the TIMDEX_BASE value to the specific search
endpoint (using the result of the query builder)
* I've chosen to use private methods for all of these as I don't think
the rest of the application will need to interact with those tools
separately? This may not end up being the case, in which case they can
be made public (and have tests written for them).
* The tests for the wrapper use VCR cassettes, and include a limited
range of search types. These can be expanded, but they do risk
duplicating the tests for the querybuilder. The tests should be robust
enough that they don't depend on specific result counts, which should
help needing to constantly update them.
* There is some limited error handling, but more will be needed before
we launch. Currently there is only one rescue step for all errors,
which returns the error key and message.
* The tested errors are Timdex being down, and a returned 404 response.

#### QueryBuilder

* The QueryBuilder model currenty takes a string input, returning a
Hash for all parameters that get passed to Timdex. Future work will
expand this significantly, to handle advanced search and other use
cases. For now, though, this is pretty stripped down.
* The tests for the query builder deal with a similarly limited set of
search cases (multiple words, quotes, and trimming). Eventually
these tests will (should) diverge from what the timdex wrapper is
testing for, but for now they overlap a lot.

### Document any side effects to this change:

* Hopefully none by this point

### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

### Requires database migrations?

NO

### Includes new or updated dependencies?

YES

* annotate
* dotenv-rails
* http
* vcr
* webmock