### PR TITLE
Adds initial Enhancer class and two examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # dotenv
 .env
+.env.development
 
 ## Environment normalization:
 /.bundle
@@ -33,3 +34,4 @@ yarn-debug.log*
 /config/master.key
 
 .DS_Store
+.vscode/

--- a/app/models/enhancer.rb
+++ b/app/models/enhancer.rb
@@ -1,0 +1,16 @@
+class Enhancer
+  attr_accessor :enhanced_query
+
+  # accepts all params as each enhancer may require different data
+  def initialize(params)
+    @enhanced_query = {}
+    @enhanced_query[:q] = params[:q] if params[:q]
+    patterns(params) if params[:q]
+  end
+
+  private
+
+  def patterns(params)
+    @enhanced_query = EnhancerPatterns.new(@enhanced_query, params[:q]).enhanced_query
+  end
+end

--- a/app/models/enhancer_patterns.rb
+++ b/app/models/enhancer_patterns.rb
@@ -1,0 +1,28 @@
+class EnhancerPatterns
+  attr_accessor :enhanced_query
+
+  def initialize(enhanced_query, term)
+    @enhanced_query = enhanced_query
+    term_pattern_checker(term)
+  end
+
+  private
+
+  def term_pattern_checker(term)
+    term_patterns.each_pair do |type, pattern|
+      @enhanced_query[type.to_sym] = match(pattern, term) if match(pattern, term).present?
+    end
+  end
+
+  def match(pattern, term)
+    pattern.match(term).to_s.strip
+  end
+
+  # term_patterns are regex patterns to be applied to the basic search box input
+  def term_patterns
+    {
+      isbn: /(ISBN-*(1[03])* *(: ){0,1})*(([0-9Xx][- ]*){13}|([0-9Xx][- ]*){10})/,
+      issn: /[0-9]{4}-[0-9]{3}[0-9xX]/
+    }
+  end
+end

--- a/test/models/enhancer_patterns_test.rb
+++ b/test/models/enhancer_patterns_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class EnhancerPatternsTest < ActiveSupport::TestCase
+  test 'ISBN detected in a string' do
+    enhanced_query = {}
+
+    actual = EnhancerPatterns.new(enhanced_query, 'test 978-3-16-148410-0 test').enhanced_query
+    assert_equal('978-3-16-148410-0', actual[:isbn])
+  end
+
+  test 'ISBN-10 examples' do
+    enhanced_query = {}
+
+    # from wikipedia
+    samples = ['99921-58-10-7', '9971-5-0210-0', '960-425-059-0', '80-902734-1-6', '85-359-0277-5',
+               '1-84356-028-3', '0-684-84328-5', '0-8044-2957-X', '0-85131-041-9', '93-86954-21-4', '0-943396-04-2',
+               '0-9752298-0-X']
+
+    samples.each do |isbn|
+      actual = EnhancerPatterns.new(enhanced_query, isbn).enhanced_query
+      assert_equal(isbn, actual[:isbn])
+    end
+  end
+
+  test 'ISBN-13 examples' do
+    enhanced_query = {}
+
+    samples = ['978-99921-58-10-7', '979-9971-5-0210-0', '978-960-425-059-0', '979-80-902734-1-6', '978-85-359-0277-5',
+               '979-1-84356-028-3', '978-0-684-84328-5', '979-0-8044-2957-X', '978-0-85131-041-9', '979-93-86954-21-4',
+               '978-0-943396-04-2', '979-0-9752298-0-X']
+
+    samples.each do |isbn|
+      actual = EnhancerPatterns.new(enhanced_query, isbn).enhanced_query
+      assert_equal(isbn, actual[:isbn])
+    end
+  end
+
+  test 'not ISBNs' do
+    enhanced_query = {}
+
+    samples = ['orange cats like popcorn', '1234-6798', 'another ISBN not found here']
+
+    samples.each do |notisbn|
+      actual = EnhancerPatterns.new(enhanced_query, notisbn).enhanced_query
+      assert_nil(actual[:isbn])
+    end
+  end
+
+  test 'ISSNs detected in a string' do
+    enhanced_query = {}
+
+    actual = EnhancerPatterns.new(enhanced_query, 'test 1234-5678 test').enhanced_query
+    assert_equal('1234-5678', actual[:issn])
+  end
+
+  test 'ISSN examples' do
+    enhanced_query = {}
+
+    samples = %w[2049-3630 0000-0019 1864-0761 1877-959X 1877-7740 1877-5683 1440-172X 1040-5631]
+
+    samples.each do |issn|
+      actual = EnhancerPatterns.new(enhanced_query, issn).enhanced_query
+      assert_equal(issn, actual[:issn])
+    end
+  end
+
+  test 'not ISSN examples' do
+    enhanced_query = {}
+
+    samples = ['orange cats like popcorn', '12346798', 'another ISSN not found here', '99921-58-10-7']
+
+    samples.each do |notissn|
+      actual = EnhancerPatterns.new(enhanced_query, notissn).enhanced_query
+      assert_nil(actual[:issn])
+    end
+  end
+end

--- a/test/models/enhancer_test.rb
+++ b/test/models/enhancer_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class EnhancerTest < ActiveSupport::TestCase
+  test 'enhanced_query with no matched patterns returns raw query and q' do
+    params = {}
+    params[:q] = 'hallo'
+
+    eq = Enhancer.new(params)
+    assert_equal params[:q], eq.enhanced_query[:q]
+  end
+
+  test 'enhanced_query does not set values for unmatched term_patterns' do
+    params = {}
+    params[:q] = 'hallo'
+
+    eq = Enhancer.new(params)
+
+    assert_nil eq.enhanced_query[:issn]
+    assert_nil eq.enhanced_query[:isbn]
+  end
+
+  test 'enhanced_query returns keys and values for matched patterns' do
+    params = {}
+    params[:q] = 'hallo 978-3-16-148410-0 goodbye'
+
+    eq = Enhancer.new(params)
+
+    assert_equal '978-3-16-148410-0', eq.enhanced_query[:isbn]
+  end
+
+  test 'enhanced_query can match multiple patterns' do
+    params = {}
+    params[:q] = 'hallo 978-3-16-148410-0 goodbye 1234-5678 popcorn'
+
+    eq = Enhancer.new(params)
+
+    assert_equal '978-3-16-148410-0', eq.enhanced_query[:isbn]
+    assert_equal '1234-5678', eq.enhanced_query[:issn]
+  end
+end


### PR DESCRIPTION
Why are these changes being introduced:

* We want an way to detect intent from user input and believe analyzing
  the raw input in various ways and categorizing what we know about it
  will be helpful in both building up queries to our search indexes but
  also in detecting when something other than a search index may be
  helpful

Relevant ticket(s):

* https://github.com/MITLibraries/timdex-ui/issues/20

How does this address that need:

* Creates an Enhancer class and EnhancerPatterns class with two initial
  examples (ISBN and ISSN detection)

Document any side effects to this change:

- this is not yet connected to the user input stage or query builder
  stage as there is work underway already that this will somewhat
  conflict with so we'll need to wire it up when it up separately

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
