### PR TITLE
Adds Enhancers to Basic Search flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ end
 
 group :development do
   gem 'annotate'
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'dotenv-rails'
   gem 'rubocop'
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,13 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.8.1)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -87,6 +93,7 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     climate_control (1.0.1)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
@@ -94,6 +101,7 @@ GEM
     debug (1.5.0)
       irb (>= 1.3.6)
       reline (>= 0.2.7)
+    debug_inspector (1.1.0)
     digest (3.1.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -290,6 +298,8 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  better_errors
+  binding_of_caller
   bootsnap
   capybara
   climate_control

--- a/app/controllers/basic_search_controller.rb
+++ b/app/controllers/basic_search_controller.rb
@@ -4,17 +4,14 @@ class BasicSearchController < ApplicationController
   def index; end
 
   def results
-    timdex = TimdexWrapper.new
-
-    search_string = params[:q]
-
     # hand off to Enhancer chain
-    # For this phase, the Enhancer will just pass the input through as output.
+    @enhanced_query = Enhancer.new(params).enhanced_query
 
     # hand off enhanced query to builder
-    query = QueryBuilder.new(search_string).query
+    query = QueryBuilder.new(@enhanced_query).query
 
     # builder hands off to wrapper which returns raw results here
+    timdex = TimdexWrapper.new
     response = timdex.search(query)
 
     # Analyze results

--- a/app/models/enhancer_patterns.rb
+++ b/app/models/enhancer_patterns.rb
@@ -21,8 +21,8 @@ class EnhancerPatterns
   # term_patterns are regex patterns to be applied to the basic search box input
   def term_patterns
     {
-      isbn: /(ISBN-*(1[03])* *(: ){0,1})*(([0-9Xx][- ]*){13}|([0-9Xx][- ]*){10})/,
-      issn: /[0-9]{4}-[0-9]{3}[0-9xX]/
+      isbn: /\b(ISBN-*(1[03])* *(: ){0,1})*(([0-9Xx][- ]*){13}|([0-9Xx][- ]*){10})\b/,
+      issn: /\b[0-9]{4}-[0-9]{3}[0-9xX]\b/
     }
   end
 end

--- a/app/models/query_builder.rb
+++ b/app/models/query_builder.rb
@@ -1,7 +1,8 @@
 class QueryBuilder
   attr_reader :query
 
-  def initialize(term)
+  def initialize(enhanced_query)
+    term = enhanced_query[:q]
     @query = {}
     @query['q'] = clean_term(term)
     @query['full'] = false

--- a/app/views/basic_search/_isbn.html.erb
+++ b/app/views/basic_search/_isbn.html.erb
@@ -1,0 +1,19 @@
+<% return unless @enhanced_query[:isbn].present? %>
+
+<div id="isbn-fact" class="fact">
+  <div class="panel panel-success">
+    <div class="panel-heading">
+      ISBN Detected
+    </div>
+
+    <div class="panel-body">
+      <ul>
+        <li><%= @enhanced_query[:isbn] %></li>
+      </ul>
+    </div>
+
+    <div class="panel-footer">
+      <a href="#">Yes this</a> -- <a href="#">Not relevant to my search</a>
+    </div>
+  </div>
+</div>

--- a/app/views/basic_search/_issn.html.erb
+++ b/app/views/basic_search/_issn.html.erb
@@ -1,0 +1,19 @@
+<% return unless @enhanced_query[:issn].present? %>
+
+<div id="issn-fact" class="fact">
+  <div class="panel panel-success">
+    <div class="panel-heading">
+      ISSN Detected
+    </div>
+
+    <div class="panel-body">
+      <ul>
+        <li><%= @enhanced_query[:issn] %>
+      </ul>
+    </div>
+
+    <div class="panel-footer">
+      <a href="#">Yes this</a> -- <a href="#">Not relevant to my search</a>
+    </div>
+  </div>
+</div>

--- a/app/views/basic_search/results.html.erb
+++ b/app/views/basic_search/results.html.erb
@@ -10,8 +10,12 @@
     </p>
   </div>
 
-  <div id="hint" class="box-content">  
+  <div id="hint" class="box-content">
     <p>Hint/Info cards go here</p>
+
+    <%= render(partial: 'basic_search/issn') %>
+    <%= render(partial: 'basic_search/isbn') %>
+
   </div>
   
   <div class="layout-1q3q layout-band">
@@ -25,7 +29,7 @@
     </div>
 
     <aside class="col1q">
-      <div id="facets">
+      <div id="facets" class="box-content">
         <h3>Available filters</h3>
         <%= render(partial: 'basic_search/facet', collection: @facets) || render('facet_empty') %>
       </div>

--- a/test/controllers/basic_search_controller_test.rb
+++ b/test/controllers/basic_search_controller_test.rb
@@ -112,4 +112,26 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
       assert_select '#facets .category ul.category-terms li.term', { count: 0 }
     end
   end
+
+  test 'searches with ISSN display issn fact card' do
+    VCR.use_cassette('timdex 1234-5678',
+                     allow_playback_repeats: true) do
+      get '/results?q=1234-5678'
+      assert_response :success
+
+      assert_select '#issn-fact', { count: 1 }
+      assert_select '#isbn-fact', { count: 0 }
+    end
+  end
+
+  test 'searches with ISBN display isbn fact card' do
+    VCR.use_cassette('timdex 9781509053278',
+                     allow_playback_repeats: true) do
+      get '/results?q=9781509053278'
+      assert_response :success
+
+      assert_select '#issn-fact', { count: 0 }
+      assert_select '#isbn-fact', { count: 1 }
+    end
+  end
 end

--- a/test/models/enhancer_patterns_test.rb
+++ b/test/models/enhancer_patterns_test.rb
@@ -46,6 +46,20 @@ class EnhancerPatternsTest < ActiveSupport::TestCase
     end
   end
 
+  test 'ISBNs need boundaries' do
+    enhanced_query = {}
+
+    samples = ['990026671500206761', '979-0-9752298-0-XYZ']
+    # note, there is a theoretical case of `asdf979-0-9752298-0-X` returning as an ISBN 10 even though it doesn't
+    # have a word boundary because the `-` is treated as a boundary so `0-9752298-0-X` would be an ISBN10. We can
+    # consider whether we care in the future as we look for incorrect real-world matches.
+
+    samples.each do |notisbn|
+      actual = EnhancerPatterns.new(enhanced_query, notisbn).enhanced_query
+      assert_nil(actual[:isbn])
+    end
+  end
+
   test 'ISSNs detected in a string' do
     enhanced_query = {}
 
@@ -73,5 +87,12 @@ class EnhancerPatternsTest < ActiveSupport::TestCase
       actual = EnhancerPatterns.new(enhanced_query, notissn).enhanced_query
       assert_nil(actual[:issn])
     end
+  end
+
+  test 'ISSNs need boundaries' do
+    enhanced_query = {}
+
+    actual = EnhancerPatterns.new(enhanced_query, '12345-5678 1234-56789').enhanced_query
+    assert_nil(actual[:issn])
   end
 end

--- a/test/models/query_builder_test.rb
+++ b/test/models/query_builder_test.rb
@@ -3,31 +3,31 @@ require 'test_helper'
 class QueryBuilderTest < ActiveSupport::TestCase
   test 'url returns a querystring' do
     expected = 'full=false&page=1&q=blah'
-    search = 'blah'
+    search = { q: 'blah' }
     assert_equal(expected, QueryBuilder.new(search).querystring)
   end
 
   test 'query builder trims spaces' do
     expected = 'full=false&page=1&q=blah'
-    search = ' blah '
+    search = { q: ' blah ' }
     assert_equal(expected, QueryBuilder.new(search).querystring)
   end
 
   test 'query builder escapes single quotes' do
     expected = 'full=false&page=1&q=don%27t'
-    search = "don't"
+    search = { q: "don't" }
     assert_equal(expected, QueryBuilder.new(search).querystring)
   end
 
   test 'query builder converts double quotes to single quotes' do
     expected = 'full=false&page=1&q=say+%27ahh%27+please'
-    search = 'say "ahh" please'
+    search = { q: 'say "ahh" please' }
     assert_equal(expected, QueryBuilder.new(search).querystring)
   end
 
   test 'query builder deals with phrases' do
     expected = 'full=false&page=1&q=buttered+popcorn'
-    search = 'buttered popcorn'
+    search = { q: 'buttered popcorn' }
     assert_equal(expected, QueryBuilder.new(search).querystring)
   end
 end

--- a/test/vcr_cassettes/timdex_1234-5678.yml
+++ b/test/vcr_cassettes/timdex_1234-5678.yml
@@ -1,0 +1,257 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://timdex.mit.edu/api/v1/search?full=false&page=1&q=1234-5678
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - close
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Tue, 19 Apr 2022 19:59:12 GMT
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"a94be5be1a22aad7867eff8b39ace0af"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6982db98-d263-4194-9298-de816975e0cf
+      X-Runtime:
+      - '0.930415'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"hits":189,"request_limit":500,"request_count":1,"limit_info":"Register
+        for a free account and provide your JWT token to remove all request limitations.","results":[{"id":"9935052474106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935052474106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935052474106761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2019","title":"1234-2019 - IEEE Std 1234-2019
+        (Revision of IEEE Std 1234-2007) - Redline","isbns":["1-5044-6189-4"],"imprint":["IEEE"]},{"id":"9935088936206761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935088936206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935088936206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1660","title":"Annotata ad libros propheticos
+        Veteris Testamenti, sive, Criticorum sacrorum tomus IV.","contributors":[{"kind":"contributor","value":"Pearson,
+        John, 1613-1686."}],"oclcs":["ocm12903389e","12903389"],"imprint":["Londini
+        : Oxonii : Cantabrigiæ : Excudebat Jacobus Flesher : Prostant apud Cornelium
+        Bee, Guilielmum Wells, Richardum Royston, Samuelum Thomson ; Thomam Robinson
+        ; Guilielmum Morden, 1660."]},{"id":"990008104800106761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma990008104800106761","full_record_link":"https://timdex.mit.edu/api/v1/record/990008104800106761","content_type":"Text","content_format":["Print
+        volume"],"realtime_holdings_link":"Not Yet Implemented","publication_date":"1997","title":"1996
+        Future Car Challenge.","contributors":[{"kind":"contributor","value":"Society
+        of Automotive Engineers."},{"kind":"contributor","value":"SAE International
+        Congress \u0026 Exposition Detroit, Mich.) (1997 :"}],"subjects":["Automobiles
+        Design and construction Competitions."],"summary_holdings":[{"location":"Library
+        Storage Annex","collection":"Off Campus Collection","call_number":"TL1.S672
+        no.1234","summary":"MCM","format":"Print volume"}],"lccn":"96071843","oclcs":["36713876"],"isbns":["1560919469"],"imprint":["Warendale,
+        PA : Society of Automotive Engineers, c1997."]},{"id":"9935173604106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935173604106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935173604106761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2008","title":"The history of medieval
+        canon law in the classical period, 1140-1234 from Gratian to the decretals
+        of Pope Gregory IX /","contributors":[{"kind":"contributor","value":"Hartmann,
+        Wilfried, 1942-"},{"kind":"contributor","value":"Pennington, Kenneth."}],"subjects":["Canon
+        law History To 1500."],"oclcs":["922996794","707925920"],"isbns":["0-8132-1845-4"],"imprint":["Washington,
+        D.C. : Catholic University of America Press, 2008."]},{"id":"9935152081306761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935152081306761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935152081306761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2018","title":"In the Wake of the Mongols
+        : The Making of a New Social Order in North China, 1200-1600 /","contributors":[{"kind":"author","value":"Wang,
+        Jinping, author."}],"subjects":["Social structure History. China","Mongols
+        History. China","Mongols.","Social conditions.","Social structure."],"oclcs":["1227051728"],"isbns":["1-68417-100-8"],"imprint":["Boston
+        : Harvard University Asia Center, 2018.","Leiden;  Boston : BRILL, 2018."]},{"id":"9935174258806761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935174258806761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935174258806761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2012","title":"The Chinese literati on
+        painting Su Shih (1037-1101) to Tung Ch''i-Ch''ang (1555-1636) /","contributors":[{"kind":"author","value":"Bush,
+        Susan."}],"subjects":["Painting, Chinese."],"oclcs":["827208611"],"isbns":["988-220-874-6"],"imprint":["Hong
+        Kong : Hong Kong University Press, 2012."]},{"id":"9935165509706761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935165509706761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935165509706761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2018","title":"Gratian and the schools
+        of law, 1140-1234 /","contributors":[{"kind":"author","value":"Kuttner, Stephan,
+        author. 1907-1996,"},{"kind":"contributor","value":"Landau, Peter, editor."}],"subjects":["Gratian,
+        active 12th century.","Canon law History."],"oclcs":["1064712278","(OCoLC-P)1064712278"],"isbns":["1-351-05894-0","1-351-05895-9","1-351-05893-2"],"imprint":["Abingdon,
+        Oxon ; New York, NY : Routledge, 2018."]},{"id":"9935173850406761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935173850406761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935173850406761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2008","title":"Calendar of the fine rolls
+        of the reign of Henry III preserved in the National Archives. Volume II, 9
+        to 18 Henry III ; 1224-1234 /","contributors":[{"kind":"contributor","value":"Dryburgh,
+        Paul."},{"kind":"contributor","value":"Hartland, Beth."},{"kind":"contributor","value":"Ciula,
+        Arianna."},{"kind":"contributor","value":"National Archives (Great Britain)"}],"subjects":["Henry
+        III, King of England, 1207-1272.","Fine-rolls.","Great Britain Sources. History
+        13th century","England Genealogy."],"oclcs":["818846651"],"isbns":["1-282-62067-3","9786612620676","1-84615-616-5"],"imprint":["Woodbridge,
+        Suffolk, UK : London : Boydell Press ; The National Archives, 2008."]},{"id":"9935114875806761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935114875806761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935114875806761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2019","title":"IEEE Std 1234-2019 (Revision
+        of IEEE Std 1234-2007): IEEE Guide for Fault-Locating Techniques on Shielded
+        Power Cable Systems","isbns":["1-5044-5691-2"],"imprint":["IEEE"]},{"id":"9935172118806761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935172118806761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935172118806761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2004","title":"The kings and their hawks
+        falconry in medieval England /","contributors":[{"kind":"author","value":"Oggins,
+        Robin S., 1931-"}],"subjects":["Falconry History To 1500. England","Great
+        Britain Kings and rulers Recreation."],"oclcs":["1013948467","923588372"],"isbns":["1-281-72242-1","9786611722425","0-300-13038-4"],"imprint":["New
+        Haven : Yale University Press, c2004."]},{"id":"9935046812106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935046812106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935046812106761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1615","title":"The estates, empires,
+        \u0026 principallities of the world Represented by ye description of countries,
+        maners of inhabitants, riches of prouinces, forces, gouernment, religion;
+        and the princes that haue gouerned in euery estate. With the begin[n]ing of
+        all militarie and religious orders. Translated out of French by Edw: Grimstone,
+        sargeant at armes.","contributors":[{"kind":"author","value":"Avity, Pierre
+        d'', sieur de Montmartin, 1573-1635."},{"kind":"contributor","value":"Elstracke,
+        Renold, engraver. fl. 1590-1630,"},{"kind":"contributor","value":"Grimeston,
+        Edward."}],"subjects":["World history Early works to 1800.","Geography Early
+        works to 1800.","Orders of knighthood and chivalry Early works to 1800.","Monasticism
+        and religious orders Early works to 1800.","Europe Early works to 1800."],"imprint":["London
+        : Printed by Adam: Islip; for Mathewe: Lownes; and Iohn: Bill, 1615."]},{"id":"9935188682806761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935188682806761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935188682806761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"1234","title":"The Bacon Quota Discussed.","subjects":["Food
+        Policy","Food History","Agricultural policy","Pork"],"imprint":["[Place of
+        publication not identified] : [publisher not identified], 1234."]},{"id":"990010176360106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma990010176360106761","full_record_link":"https://timdex.mit.edu/api/v1/record/990010176360106761","content_type":"Text","content_format":["Print
+        volume"],"realtime_holdings_link":"Not Yet Implemented","publication_date":"2001","title":"Strategic
+        and performance planning for the Office of the Chancellor for Education and
+        Professional Development in the Department of Defense /","links":[{"kind":"unknown","url":"http://www.rand.org/pubs/monograph_reports/MR1234/"}],"contributors":[{"kind":"contributor","value":"Levy,
+        Dina G."},{"kind":"contributor","value":"Rand Corporation."},{"kind":"contributor","value":"National
+        Defense Research Institute (U.S.)"}],"subjects":["United States. Office of
+        the Chancellor for Education and Professional Development.","Military education
+        United States.","United States Armed Forces Civilian employees Training of."],"summary_holdings":[{"location":"Dewey
+        Library","collection":"Stacks","call_number":"UB153.S77 2001","format":"Print
+        volume"}],"lccn":"2001048138","oclcs":["47658940"],"isbns":["083303037X"],"imprint":["Santa
+        Monica, CA : Rand, 2001."]},{"id":"990005333760106761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma990005333760106761","full_record_link":"https://timdex.mit.edu/api/v1/record/990005333760106761","content_type":"Text","content_format":["Print
+        volume"],"realtime_holdings_link":"Not Yet Implemented","publication_date":"1942","title":"A
+        treasury of great poems, English and American, from the foundations of the
+        English spirit to the outstanding poetry of our own time, with lives of the
+        poets and historical settings","contributors":[{"kind":"author","value":"Untermeyer,
+        Louis, 1885-1977."}],"subjects":["English poetry.","American poetry."],"summary_holdings":[{"location":"Library
+        Storage Annex","collection":"Off Campus Collection","call_number":"PR1175.U61","summary":"MCM","format":"Print
+        volume"}],"lccn":"42022424 //r83","oclcs":["00798794"],"imprint":["New York,
+        Simon and Schuster, 1942."]},{"id":"9935135158206761","source":"MIT Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935135158206761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935135158206761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2012","title":"Administrative assistant''s
+        and secretary''s handbook","contributors":[{"kind":"author","value":"Stroman,
+        James."},{"kind":"contributor","value":"Wilson, K. (Kevin), 1958-"},{"kind":"contributor","value":"Wauson,
+        Jennifer."}],"subjects":["Secretaries Handbooks, manuals, etc.","Office practice
+        Handbooks, manuals, etc."],"oclcs":["754794698"],"isbns":["1-78402-233-0","1-283-31962-4","9786613319623","0-8144-1761-2"],"imprint":["New
+        York : American Management Association, c2012."]},{"id":"9935097793506761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935097793506761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935097793506761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2009","title":"Advanced Data Mining and
+        Applications 5th International Conference, ADMA 2009, Chengdu, China, August
+        17-19, 2009, Proceedings /","contributors":[{"kind":"author","value":"ADMA
+        2009 Beijing, China) (2009 :"},{"kind":"contributor","value":"Huang, Ronghuai.
+        editor."},{"kind":"contributor","value":"Yang, Qiang. editor."},{"kind":"contributor","value":"Pei,
+        Jian. editor."},{"kind":"contributor","value":"Gama, João. editor."},{"kind":"contributor","value":"Meng,
+        Xiaofeng. editor."},{"kind":"contributor","value":"Li, Xue. editor."}],"subjects":["Data
+        mining.","Information storage and retrieval.","Computers.","Application software.","Pattern
+        recognition.","Artificial intelligence.","https://scigraph.springernature.com/ontologies/product-market-codes/I18030
+        Data Mining and Knowledge Discovery.","https://scigraph.springernature.com/ontologies/product-market-codes/I18032
+        Information Storage and Retrieval.","https://scigraph.springernature.com/ontologies/product-market-codes/I18008
+        Information Systems and Communication Service.","https://scigraph.springernature.com/ontologies/product-market-codes/I18040
+        Information Systems Applications (incl. Internet).","https://scigraph.springernature.com/ontologies/product-market-codes/I2203X
+        Pattern Recognition.","https://scigraph.springernature.com/ontologies/product-market-codes/I21000
+        Artificial Intelligence."],"isbns":["1-280-38316-X","9786613561084","3-642-03348-2"],"imprint":["Berlin,
+        Heidelberg : Springer Berlin Heidelberg : Imprint: Springer, 2009."]},{"id":"9935068497606761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935068497606761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935068497606761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2016","title":"Recent progress in quantum
+        Monte Carlo /","contributors":[{"kind":"contributor","value":"Tanaka, Shigenori,
+        editor."},{"kind":"contributor","value":"Roy, Pierre-Nicholas, editor."},{"kind":"contributor","value":"Mitas,
+        Lubos, editor."},{"kind":"contributor","value":"American Chemical Society.
+        Division of Physical Chemistry, contributor."}],"subjects":["Monte Carlo method.","Quantum
+        chemistry.","Catalysis Mathematical models.","Many-body problem."],"isbns":["0-8412-3178-8"],"imprint":["Washington,
+        District of Columbia : American Chemical Society, [2016]","©2016"]},{"id":"9935157750906761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935157750906761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935157750906761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2010","title":"A Practical Guide to Frozen
+        Section Technique","contributors":[{"kind":"contributor","value":"Peters,
+        Stephen R. editor."}],"subjects":["Pathology.","Laboratory medicine.","https://scigraph.springernature.com/ontologies/product-market-codes/H4800X
+        Pathology.","https://scigraph.springernature.com/ontologies/product-market-codes/B15007
+        Laboratory Medicine."],"oclcs":["728705337","732598342"],"isbns":["1-282-82798-7","9786612827983","1-4419-1234-7"],"imprint":["New
+        York, NY : Springer New York : Imprint: Springer, 2010."]},{"id":"9935140457306761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935140457306761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935140457306761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2007","title":"Mathematical Methods in
+        Engineering","contributors":[{"kind":"contributor","value":"Tas, K. editor."},{"kind":"contributor","value":"Tenreiro
+        Machado, J.A. editor."},{"kind":"contributor","value":"Baleanu, D. editor."}],"subjects":["Applied
+        mathematics.","Engineering mathematics.","Computer simulation.","Integral
+        transforms.","Operational calculus.","Special functions.","System theory.","https://scigraph.springernature.com/ontologies/product-market-codes/T11006
+        Mathematical and Computational Engineering.","https://scigraph.springernature.com/ontologies/product-market-codes/I19000
+        Simulation and Modeling.","https://scigraph.springernature.com/ontologies/product-market-codes/M12112
+        Integral Transforms, Operational Calculus.","https://scigraph.springernature.com/ontologies/product-market-codes/M1221X
+        Special Functions.","https://scigraph.springernature.com/ontologies/product-market-codes/M13070
+        Systems Theory, Control."],"oclcs":["403793902"],"isbns":["1-281-13434-1","9786611134341","1-4020-5678-8"],"imprint":["Dordrecht
+        : Springer Netherlands : Imprint: Springer, 2007."]},{"id":"9935084419106761","source":"MIT
+        Alma","source_link":"https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT\u0026docid=alma9935084419106761","full_record_link":"https://timdex.mit.edu/api/v1/record/9935084419106761","content_type":"Text","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2000","title":"Developmental Biology
+        of Flowering Plants","contributors":[{"kind":"author","value":"Raghavan, V.
+        author."}],"subjects":["Plant physiology.","Plant science.","Botany.","Microbiology.","Human
+        physiology.","https://scigraph.springernature.com/ontologies/product-market-codes/L33020
+        Plant Physiology.","https://scigraph.springernature.com/ontologies/product-market-codes/L24000
+        Plant Sciences.","https://scigraph.springernature.com/ontologies/product-market-codes/L23004
+        Microbiology.","https://scigraph.springernature.com/ontologies/product-market-codes/B13004
+        Human Physiology."],"isbns":["1-4612-1234-0"],"imprint":["New York, NY : Springer
+        New York : Imprint: Springer, 2000."]}],"aggregations":{"source":[{"name":"mit
+        alma","count":182},{"name":"dspace@mit","count":6},{"name":"mit archivesspace","count":1}],"content_format":[{"name":"print
+        volume","count":21},{"name":"microfiche","count":1},{"name":"musical score","count":1}],"content_type":[{"name":"text","count":174},{"name":"article","count":5},{"name":"sound
+        recording","count":5},{"name":"moving image","count":2},{"name":"archival
+        collection","count":1},{"name":"musical score","count":1}],"collection":[{"name":"mit
+        open access articles","count":5},{"name":"ai memos (1959 - 2004)","count":1},{"name":"artificial
+        intelligence lab publications","count":1},{"name":"computer science and artificial
+        intelligence lab (csail)","count":1}],"contributor":[{"name":"liszt, franz,
+        1811-1886.","count":6},{"name":"dod, john, 1549?-1645.","count":5},{"name":"boismortier,
+        joseph bodin de, 1689-1755.","count":4},{"name":"dent, arthur, d. 1607.","count":4},{"name":"cleaver,
+        robert, 1561 or 2-ca. 1625.","count":3},{"name":"boutilier, michael stephen
+        hatcher","count":2},{"name":"de kadt, daniel nicolas jacques","count":2},{"name":"deckelbaum,
+        alan t.","count":2},{"name":"dionysius, periegetes.","count":2},{"name":"dodson,
+        thomas, master of arts.","count":2}],"subject":[{"name":"sermons, english
+        17th century.","count":6},{"name":"almanacs, english.","count":5},{"name":"astrology
+        early works to 1800.","count":4},{"name":"ephemerides.","count":4},{"name":"catholic
+        church controversial literature early works to 1800.","count":3},{"name":"art
+        exhibitions. trinidad and tobago","count":2},{"name":"artificial intelligence.","count":2},{"name":"cancer
+        research.","count":2},{"name":"canon law history.","count":2},{"name":"catechisms,
+        english.","count":2}],"language":[{"name":"english","count":167},{"name":"latin","count":5},{"name":"in
+        english.","count":4},{"name":"en_us","count":3},{"name":"greek, ancient (to
+        1453)","count":3},{"name":"no linguistic content","count":3},{"name":"en","count":2},{"name":"french","count":2},{"name":"latgreheb","count":2},{"name":"sung
+        in english.","count":2}],"literary_form":[{"name":"nonfiction","count":93},{"name":"fiction","count":89}]}}'
+  recorded_at: Tue, 19 Apr 2022 19:59:12 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_9781509053278.yml
+++ b/test/vcr_cassettes/timdex_9781509053278.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://timdex.mit.edu/api/v1/search?full=false&page=1&q=9781509053278
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - close
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Tue, 19 Apr 2022 19:59:12 GMT
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"24508633e2401a8944dc06184ae63121"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a42e4f7d-b29f-4e91-82e0-cc970fff095a
+      X-Runtime:
+      - '0.111094'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"hits":1,"request_limit":500,"request_count":2,"limit_info":"Register
+        for a free account and provide your JWT token to remove all request limitations.","results":[{"id":"oai:dspace.mit.edu:1721.1-113566","source":"DSpace@MIT","source_link":"https://hdl.handle.net/1721.1/113566","full_record_link":"https://timdex.mit.edu/api/v1/record/oai:dspace.mit.edu:1721.1-113566","content_type":"Article","realtime_holdings_link":"Not
+        Yet Implemented","publication_date":"2017-08","title":"Variable-Inverter-Rectifier-Transformer:
+        A Hybrid Electronic and Magnetic Structure Enabling Adjustable High Step-Down
+        Conversion Ratios","links":[{"kind":"Digital object URI","text":"Digital object
+        URI","url":"http://hdl.handle.net/1721.1/113566"}],"contributors":[{"kind":"author","value":"Moon,
+        Intae"},{"kind":"author","value":"Ranjram, Mike Kavian"},{"kind":"author","value":"Perreault,
+        David J"},{"kind":"department","value":"Massachusetts Institute of Technology.
+        Department of Electrical Engineering and Computer Science"},{"kind":"approver","value":"Perreault,
+        David J."},{"kind":"mitauthor","value":"Moon, Intae"},{"kind":"mitauthor","value":"Ranjram,
+        Mike Kavian"},{"kind":"mitauthor","value":"Perreault, David J"}],"isbns":["9781509053278"],"collections":["MIT
+        Open Access Articles"]}],"aggregations":{"source":[{"name":"dspace@mit","count":1}],"content_format":[],"content_type":[{"name":"article","count":1}],"collection":[{"name":"mit
+        open access articles","count":1}],"contributor":[{"name":"moon, intae","count":2},{"name":"perreault,
+        david j","count":2},{"name":"ranjram, mike kavian","count":2},{"name":"massachusetts
+        institute of technology. department of electrical engineering and computer
+        science","count":1},{"name":"perreault, david j.","count":1}],"subject":[],"language":[{"name":"en_us","count":1}],"literary_form":[]}}'
+  recorded_at: Tue, 19 Apr 2022 19:59:12 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Why are these changes being introduced:

* The initial implementation of QueryBuilder and Enhancer was done in
parallel. This brings that work together.

Relevant ticket(s):

https://github.com/MITLibraries/timdex-ui/issues/30

How does this address that need:

* Add Enhancer to the BasicSearch controller
* Refactors QueryBuilder to use Enhancer instead of Params as input
* Displays example fact cards for ISSN/ISBN

Document any side effects to this change:

* QueryBuilder doesn't do anything interesting with the Enhancer data
  that is passed in yet
* The ISSN/ISBN fact cards are not useful yet. If we don't have anything
  interesting to do with these detected Facts, we'll stop displaying
  them but for now it is nice to have an example so we can start
  thinking about what Facts we can detect and what we'd like to display
  about the facts in the UI when we detect them

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
