### PR TITLE
Add importmap tags to head

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,0 +1,45 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title><%= content_for?(:title) ? yield(:title) : "  MIT Libraries" %></title>
+<%= csrf_meta_tags %>
+<%= csp_meta_tag %>
+
+<%= yield :additional_meta_tag %>
+
+<!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
+<!--[if lt IE 9]>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.1/html5shiv.js" type="text/javascript"></script>
+<![endif]-->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic&subset=latin,latin-ext" type="text/css">
+<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+
+<!-- For all other devices -->
+<!-- Size should be 32 x 32 pixels -->
+<%= favicon_link_tag 'favicon.ico', :rel => 'shortcut icon' %>
+
+<%= render partial: "layouts/js_exception_handler" %>
+<%= javascript_importmap_tags %>
+
+<script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js'></script>
+
+<%= yield :additional_js %>
+
+<% if (ENV['MATOMO_URL'].present? && ENV['MATOMO_SITE_ID'].present?) %>
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u='<%= ENV['MATOMO_URL'] %>';
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '<%= ENV['MATOMO_SITE_ID'] %>']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+<% end %>


### PR DESCRIPTION
#### Why these changes are being introduced:

This came about because of an uncaught syntax error in the browser
console regarding our import statements in application.js. We
suspected that this error indicated that we were not loading
Hotwire/Turbo properly.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/RDI-75

#### How this addresses that need:

This overwrites the mitlibraries-theme template in order to add the
JS importmap tags required for importmap to load our JS properly.

#### Side effects of this change:

* The error that flagged us to this problem persists, but it seems
innocuous as our JS still loads and Turbo frames work as expected.
* In addition to the `javascript_importmap_tags` method, the custom
template includes `csrf_meta_tags`, `csp_meta_tag`, and
`stylesheet_link_tag`, all of which are included in the default
Rails 7 template and seem harmless to add.
* I removed a couple of comments from the autogenerated `importmap.rb`
and `application.js`.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
