### PR TITLE
First work towards full record display

### DIFF
--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -1,0 +1,32 @@
+class RecordController < ApplicationController
+  before_action :validate_id!, only: %i[view]
+
+  include RecordHelper
+
+  def view
+    # If there are formatting requirements for a received ID value, they should be enforced here.
+    @id = params[:id]
+
+    timdex = TimdexWrapper.new
+    response = timdex.record(@id)
+
+    # Detection of unexpected response from the API would go here...
+
+    # Manipulation of returned record:
+    # The API includes three housekeeping fields which are not part of the record.
+    %w[request_limit request_count limit_info].each do |value|
+      response.delete(value)
+    end
+
+    @record = response
+  end
+
+  private
+
+  def validate_id!
+    return if params[:id]&.strip.present?
+
+    flash[:error] = 'A record identifier is required.'
+    redirect_to root_url
+  end
+end

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -4,19 +4,14 @@ class RecordController < ApplicationController
   include RecordHelper
 
   def view
-    # If there are formatting requirements for a received ID value, they should be enforced here.
-    @id = params[:id]
+    id = params[:id]
 
     timdex = TimdexWrapper.new
-    response = timdex.record(@id)
+    response = timdex.record(id)
 
     # Detection of unexpected response from the API would go here...
 
-    # Manipulation of returned record:
-    # The API includes three housekeeping fields which are not part of the record.
-    %w[request_limit request_count limit_info].each do |value|
-      response.delete(value)
-    end
+    # Manipulation of returned record would go here...
 
     @record = response
   end

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -1,6 +1,6 @@
 module RecordHelper
-  # Display formatters
-  def render_field(string)
+  # Display the machine-format key in human-readable text.
+  def render_key(string)
     string.capitalize.gsub('_', ' ').gsub('Mit', 'MIT')
   end
 
@@ -10,7 +10,7 @@ module RecordHelper
 
     markupclass = 'field-list'
 
-    title = "<h2>#{render_field(element)}</h2>"
+    title = "<h2>#{render_key(element)}</h2>"
     values = if record[element].length == 1
                "<p class='#{markupclass}'>#{record[element][0]}</p>".html_safe
              else
@@ -24,7 +24,7 @@ module RecordHelper
 
     markupclass = 'field-object'
 
-    title = "<h2>#{render_field(element)}</h2>"
+    title = "<h2>#{render_key(element)}</h2>"
     values = "<ul class='#{markupclass}'>#{render_kind_value(record[element])}</ul>"
     (title + values).html_safe
   end
@@ -34,13 +34,13 @@ module RecordHelper
 
     markupclass = 'field-string'
 
-    "<h2>#{render_field(element)}</h2><p class='#{markupclass}'>#{record[element]}</p>".html_safe
+    "<h2>#{render_key(element)}</h2><p class='#{markupclass}'>#{record[element]}</p>".html_safe
   end
 
   def field_table(record, element, fields)
     return unless record[element].present?
 
-    title = "<h2>#{render_field(element)}</h2>"
+    title = "<h2>#{render_key(element)}</h2>"
     labels = "<table><thead><tr>#{render_table_header(fields)}</tr></thead>"
     values = "<tbody>#{render_table_row(record[element], fields)}</tbody></table>"
     (title + labels + values).html_safe
@@ -57,7 +57,7 @@ module RecordHelper
   end
 
   def render_table_header(list)
-    list.map { |item| "<th scope='col'>#{render_field(item)}</th>" }.join
+    list.map { |item| "<th scope='col'>#{render_key(item)}</th>" }.join
   end
 
   def render_table_row(object, order)

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -1,0 +1,74 @@
+module RecordHelper
+  # Display formatters
+  def render_field(string)
+    string.capitalize.gsub('_', ' ').gsub('Mit', 'MIT')
+  end
+
+  # Field type helpers
+  def field_list(record, element)
+    return unless record[element].present?
+
+    markupclass = 'field-list'
+
+    title = "<h2>#{render_field(element)}</h2>"
+    values = if record[element].length == 1
+               "<p class='#{markupclass}'>#{record[element][0]}</p>".html_safe
+             else
+               "<ul class='#{markupclass}'>#{render_list_items(record[element])}</ul>"
+             end
+    (title + values).html_safe
+  end
+
+  def field_object(record, element)
+    return unless record[element].present?
+
+    markupclass = 'field-object'
+
+    title = "<h2>#{render_field(element)}</h2>"
+    values = "<ul class='#{markupclass}'>#{render_kind_value(record[element])}</ul>"
+    (title + values).html_safe
+  end
+
+  def field_string(record, element)
+    return unless record[element].present?
+
+    markupclass = 'field-string'
+
+    "<h2>#{render_field(element)}</h2><p class='#{markupclass}'>#{record[element]}</p>".html_safe
+  end
+
+  def field_table(record, element, fields)
+    return unless record[element].present?
+
+    title = "<h2>#{render_field(element)}</h2>"
+    labels = "<table><thead><tr>#{render_table_header(fields)}</tr></thead>"
+    values = "<tbody>#{render_table_row(record[element], fields)}</tbody></table>"
+    (title + labels + values).html_safe
+  end
+
+  private
+
+  def render_kind_value(list)
+    list.map { |item| "<li>#{item['kind']}: #{render_list(item['value'])}</li>" }.join
+  end
+
+  def render_list_items(list)
+    list.map { |item| "<li>#{item}</li>" }.join
+  end
+
+  def render_table_header(list)
+    list.map { |item| "<th scope='col'>#{render_field(item)}</th>" }.join
+  end
+
+  def render_table_row(object, order)
+    object.map { |row| "<tr>#{order.map { |field| "<td>#{render_list(row[field])}</td>" }.join}</tr>" }.join
+  end
+
+  def render_list(list)
+    return if list.nil?
+    return list.to_s if list.instance_of?(String)
+    return list[0].to_s if list.length == 1
+
+    "<ul>#{render_list_items(list)}</ul>"
+  end
+end

--- a/app/models/timdex_wrapper.rb
+++ b/app/models/timdex_wrapper.rb
@@ -54,10 +54,6 @@ class TimdexWrapper
   end
 
   def timdex_url
-    if ENV['TIMDEX_BASE'].present?
-      ENV['TIMDEX_BASE'].to_s
-    else
-      'https://timdex-stage.herokuapp.com/api/v2/'
-    end
+    ENV.fetch('TIMDEX_BASE', 'http://localhost:3000/api/v2/')
   end
 end

--- a/app/models/timdex_wrapper.rb
+++ b/app/models/timdex_wrapper.rb
@@ -8,6 +8,19 @@ class TimdexWrapper
                            Origin: ENV.fetch('TIMDEX-UI-ORIGIN', 'http://localhost:3000'))
   end
 
+  # Look up the record associated with an identifier
+  # @param identifier [String]
+  # @return [Hash] A Hash containing a record
+  def record(identifier)
+    @record = @timdex.timeout(http_timeout)
+                     .get(record_url(identifier))
+    JSON.parse(@record.to_s)
+  rescue StandardError => e
+    error = {}
+    error['error'] = e.to_s
+    error
+  end
+
   # Run a search
   # @param query [Hash] The output of the QueryBuilder
   # @return [Hash] A Hash with search metadata and an Array of {Result}s
@@ -32,6 +45,10 @@ class TimdexWrapper
     end
   end
 
+  def record_url(identifier)
+    timdex_url + "record/#{identifier}"
+  end
+
   def search_url(query)
     timdex_url + "search?#{query.to_query}"
   end
@@ -40,7 +57,7 @@ class TimdexWrapper
     if ENV['TIMDEX_BASE'].present?
       ENV['TIMDEX_BASE'].to_s
     else
-      'https://timdex.mit.edu/api/v1/'
+      'https://timdex-stage.herokuapp.com/api/v2/'
     end
   end
 end

--- a/app/views/basic_search/_result.html.erb
+++ b/app/views/basic_search/_result.html.erb
@@ -1,5 +1,5 @@
 <h4 class="record-title">
-  <span class="sr">Title: </span><%= result['title'] %>
+  <span class="sr">Title: </span><%= link_to(result['title'], record_path(result['id'])) %>
 </h4>
 
 <% result['content_type']&.each do |type| %>

--- a/app/views/record/view.html.erb
+++ b/app/views/record/view.html.erb
@@ -1,8 +1,6 @@
 <%= content_for(:title, "Search Results | MIT Libraries") %>
 
-<p class="id">
-  You requested record: <%= @id %>
-</p>
+<%= field_string(@record, 'error') %>
 
 <h1><%= @record['title'] %></h1>
 
@@ -29,6 +27,8 @@
 <%= field_table(@record, 'funding_information', %w[award_number award_uri funder_identifier funder_identifier_type funder_name]) %>
 
 <%= field_table(@record, 'holdings', %w[call_number collection format location note]) %>
+
+<%= field_string(@record, 'id') %>
 
 <%= field_object(@record, 'identifiers') %>
 
@@ -61,12 +61,3 @@
 <%= field_object(@record, 'subjects') %>
 
 <%= field_list(@record, 'summary') %>
-
-<%= field_string(@record, 'timdex_record_id') %>
-
-<!-- Raw response - this should be removed before we go to production -->
-<div class="record" style="font-family: monospace; background-color: rgb(255,215,0); margin: -1em; margin-top: 0em; padding: 1em;">
-<% @record.sort.to_h.each do |field| %>
-<p><strong><%= field[0] %></strong>: <%= field[1] %></p>
-<% end %>
-</div>

--- a/app/views/record/view.html.erb
+++ b/app/views/record/view.html.erb
@@ -1,0 +1,72 @@
+<%= content_for(:title, "Search Results | MIT Libraries") %>
+
+<p class="id">
+  You requested record: <%= @id %>
+</p>
+
+<h1><%= @record['title'] %></h1>
+
+<%= field_object(@record, 'alternate_titles' ) %>
+
+<%= field_list(@record, 'call_numbers' ) %>
+
+<%= field_string(@record, 'citation' ) %>
+
+<%= field_list(@record, 'content_type' ) %>
+
+<%= field_list(@record, 'contents' ) %>
+
+<%= field_table(@record, 'contributors', %w[value kind affiliation identifier mit_affiliated]) %>
+
+<%= field_table(@record, 'dates', %w[kind value range note]) %>
+
+<%= field_string(@record, 'edition') %>
+
+<%= field_list(@record, 'file_formats') %>
+
+<%= field_string(@record, 'format') %>
+
+<%= field_table(@record, 'funding_information', %w[award_number award_uri funder_identifier funder_identifier_type funder_name]) %>
+
+<%= field_table(@record, 'holdings', %w[call_number collection format location note]) %>
+
+<%= field_object(@record, 'identifiers') %>
+
+<%= field_list(@record, 'languages') %>
+
+<%= field_table(@record, 'links', %w[kind text url restrictions]) %>
+
+<%= field_string(@record, 'literary_form') %>
+
+<%= field_table(@record, 'locations', %w[kind value geopoint]) %>
+
+<%= field_object(@record, 'notes') %>
+
+<%= field_string(@record, 'numbering') %>
+
+<%= field_string(@record, 'physical_description') %>
+
+<%= field_list(@record, 'publication_frequency') %>
+
+<%= field_list(@record, 'publication_information') %>
+
+<%= field_table(@record, 'related_items', %w[description item_type relationship uri]) %>
+
+<%= field_table(@record, 'rights', %w[description kind uri]) %>
+
+<%= field_string(@record, 'source') %>
+
+<%= field_string(@record, 'source_link') %>
+
+<%= field_object(@record, 'subjects') %>
+
+<%= field_list(@record, 'summary') %>
+
+<%= field_string(@record, 'timdex_record_id') %>
+
+<!-- Raw response - this should be removed before we go to production -->
+<div class="record" style="font-family: monospace; background-color: rgb(255,215,0); margin: -1em; margin-top: 0em; padding: 1em;">
+<% @record.sort.to_h.each do |field| %>
+<p><strong><%= field[0] %></strong>: <%= field[1] %></p>
+<% end %>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,9 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  # Set a high threshhold for parallelizing tests.
+  config.active_support.test_parallelization_threshold = 999
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   root "basic_search#index"
 
+  get 'record/(:id)',
+      to: 'record#view',
+      as: 'record',
+      :constraints => { :id => /[0-z\.\-\_~\(\)]+/ }
   get 'results', to: 'basic_search#results'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,14 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+end

--- a/test/controllers/basic_search_controller_test.rb
+++ b/test/controllers/basic_search_controller_test.rb
@@ -97,6 +97,16 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'results with valid query include links' do
+    VCR.use_cassette('data',
+                     allow_playback_repeats: true) do
+      get '/results?q=data'
+      assert_select '#results .record-title a' do |value|
+        refute_nil(value.xpath('./@href').text)
+      end
+    end
+  end
+
   test 'searches with zero results are handled gracefully' do
     VCR.use_cassette('timdex no results',
                      allow_playback_repeats: true) do

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -29,7 +29,7 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('timdex record sample',
                      allow_playback_repeats: true) do
       get "/record/#{needle_id}"
-      assert_select 'p.id', /(.*)#{needle_id}(.*)/
+      assert_select '#content-main', /(.*)#{needle_id}(.*)/
     end
   end
 
@@ -39,18 +39,7 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
                      allow_playback_repeats: true) do
       get "/record/#{needle_id}"
       message = 'record not found'
-      assert_select 'div.record', /(.*)#{message}(.*)/
-    end
-  end
-
-  test 'full record display does not include housekeeping fields' do
-    needle_id = 'jpal:doi:10.7910-DVN-MNIBOL'
-    VCR.use_cassette('timdex record sample',
-                     allow_playback_repeats: true) do
-      get "/record/#{needle_id}"
-      assert_select 'div.record', { count: 0, text: /(.*)'request_limit'(.*)/ }
-      assert_select 'div.record', { count: 0, text: /(.*)'request_count'(.*)/ }
-      assert_select 'div.record', { count: 0, text: /(.*)'limit_info'(.*)/ }
+      assert_select '#content-main', /(.*)#{message}(.*)/
     end
   end
 end

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class RecordControllerTest < ActionDispatch::IntegrationTest
+  test 'record with no id returns an error' do
+    get '/record'
+    assert_response :redirect
+    assert_equal 'A record identifier is required.', flash[:error]
+  end
+
+  test 'full record path with an id does not return an error' do
+    VCR.use_cassette('timdex record sample',
+                     allow_playback_repeats: true) do
+      get '/record/jpal:doi:10.7910-DVN-MNIBOL'
+      assert_response :success
+    end
+  end
+
+  test 'record ids can include multiple periods' do
+    needle_id = 'there.is.no.record'
+    VCR.use_cassette('timdex record no record',
+                     allow_playback_repeats: true) do
+      get "/record/#{needle_id}"
+      assert_response :success
+    end
+  end
+
+  test 'full record display includes the record id itself' do
+    needle_id = 'jpal:doi:10.7910-DVN-MNIBOL'
+    VCR.use_cassette('timdex record sample',
+                     allow_playback_repeats: true) do
+      get "/record/#{needle_id}"
+      assert_select 'p.id', /(.*)#{needle_id}(.*)/
+    end
+  end
+
+  test 'full record display where no record exists displays an error' do
+    needle_id = 'there.is.no.record'
+    VCR.use_cassette('timdex record no record',
+                     allow_playback_repeats: true) do
+      get "/record/#{needle_id}"
+      message = 'record not found'
+      assert_select 'div.record', /(.*)#{message}(.*)/
+    end
+  end
+
+  test 'full record display does not include housekeeping fields' do
+    needle_id = 'jpal:doi:10.7910-DVN-MNIBOL'
+    VCR.use_cassette('timdex record sample',
+                     allow_playback_repeats: true) do
+      get "/record/#{needle_id}"
+      assert_select 'div.record', { count: 0, text: /(.*)'request_limit'(.*)/ }
+      assert_select 'div.record', { count: 0, text: /(.*)'request_count'(.*)/ }
+      assert_select 'div.record', { count: 0, text: /(.*)'limit_info'(.*)/ }
+    end
+  end
+end

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class RecordHelperTest < ActionView::TestCase
+  include RecordHelper
+
+  # Display formatters
+  test 'render_field converts keys into human readable values' do
+    assert_equal 'Simple', render_field('Simple')
+    assert_equal 'Simple', render_field('simple')
+    assert_equal 'Two words', render_field('two_words')
+  end
+
+  # Field type helpers
+  # - Lists
+  test 'field_list returns nothing if the element does not exist' do
+    sample = {}
+    assert_nil field_list(sample, 'none')
+  end
+
+  test 'field_list returns a single key name and value with one element' do
+    sample = {}
+    sample['foo'] = ['bar']
+    assert_equal "<h2>Foo</h2><p class='field-list'>bar</p>", field_list(sample, 'foo')
+  end
+
+  test 'field_list returns a key name and a list of values with multiple elements' do
+    sample = {}
+    sample['foo'] = %w[bar baz]
+    assert_equal "<h2>Foo</h2><ul class='field-list'><li>bar</li><li>baz</li></ul>", field_list(sample, 'foo')
+  end
+
+  # - Objects of kind and value
+  test 'field_object returns nil if the element does not exist' do
+    sample = {}
+    assert_nil field_object(sample, 'none')
+  end
+
+  test 'field_object returns a list of kind/value pairs' do
+    sample_item = {}
+    sample_item['kind'] = 'DOI'
+    sample_item['value'] = '10.7910/DVN/48GFKU'
+    sample = { 'identifiers' => [sample_item] }
+    assert_equal "<h2>Identifiers</h2><ul class='field-object'><li>DOI: 10.7910/DVN/48GFKU</li></ul>",
+                 field_object(sample, 'identifiers')
+    sample = { 'identifiers' => [sample_item, sample_item] }
+    assert_equal "<h2>Identifiers</h2><ul class='field-object'><li>DOI: 10.7910/DVN/48GFKU</li><li>DOI: 10.7910/DVN/48GFKU</li></ul>",
+                 field_object(sample, 'identifiers')
+  end
+
+  test 'field_object can deal with lists of values' do
+    sample_item = {}
+    sample_item['kind'] = 'food'
+    # List of one item
+    sample_item['value'] = ['loaf of bread']
+    sample = { 'shopping' => [sample_item] }
+    assert_equal "<h2>Shopping</h2><ul class='field-object'><li>food: loaf of bread</li></ul>",
+                 field_object(sample, 'shopping')
+
+    sample_item['value'] = ['loaf of bread', 'container of milk', 'stick of butter']
+    sample = { 'shopping' => [sample_item] }
+    assert_equal "<h2>Shopping</h2><ul class='field-object'><li>food: <ul><li>loaf of bread</li><li>container of milk</li><li>stick of butter</li></ul></li></ul>",
+                 field_object(sample, 'shopping')
+  end
+
+  # - Strings
+  test 'field_string returns nil if the element does not exist' do
+    sample = {}
+    assert_nil field_string(sample, 'none')
+  end
+
+  test 'field_string returns a key name and value in HTML' do
+    sample = {}
+    sample['foo'] = 'lowercase'
+    assert_equal "<h2>Foo</h2><p class='field-string'>lowercase</p>", field_string(sample, 'foo')
+    sample['foo'] = 'Capitalized'
+    assert_equal "<h2>Foo</h2><p class='field-string'>Capitalized</p>", field_string(sample, 'foo')
+  end
+
+  # - Tables
+  test 'field_table returns nil if the element does not exist' do
+    sample = {}
+    assert_nil field_table(sample, 'none', %w[foo bar baz])
+  end
+
+  test 'field_table returns a table of information' do
+    sample_item = {}
+    sample_item['foo'] = 'column'
+    sample_item['bar'] = 'custom'
+    sample_item['baz'] = 'order'
+    sample = { 'construct' => [sample_item] }
+    assert_equal "<h2>Construct</h2><table><thead><tr><th scope='col'>Bar</th><th scope='col'>Foo</th><th scope='col'>Baz</th></tr></thead><tbody><tr><td>custom</td><td>column</td><td>order</td></tr></tbody></table>",
+                 field_table(sample, 'construct', %w[bar foo baz])
+  end
+end

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -4,10 +4,10 @@ class RecordHelperTest < ActionView::TestCase
   include RecordHelper
 
   # Display formatters
-  test 'render_field converts keys into human readable values' do
-    assert_equal 'Simple', render_field('Simple')
-    assert_equal 'Simple', render_field('simple')
-    assert_equal 'Two words', render_field('two_words')
+  test 'render_key converts keys into human readable values' do
+    assert_equal 'Simple', render_key('Simple')
+    assert_equal 'Simple', render_key('simple')
+    assert_equal 'Two words', render_key('two_words')
   end
 
   # Field type helpers

--- a/test/models/timdex_wrapper_test.rb
+++ b/test/models/timdex_wrapper_test.rb
@@ -11,7 +11,7 @@ class TimdexWrapperTest < ActiveSupport::TestCase
 
   test 'timdex url is read from env' do
     # Default value
-    needle = 'https://timdex-stage.herokuapp.com/api/v2/'
+    needle = 'http://localhost:3000/api/v2/'
     ClimateControl.modify(
       TIMDEX_BASE: nil
     ) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,6 @@ VCR.configure do |config|
   config.filter_sensitive_data('http://FAKE_TIMDEX_HOST/api/v2/') { ENV.fetch('TIMDEX_BASE').to_s }
   config.filter_sensitive_data('FAKE_TIMDEX_HOST') { ENV.fetch('TIMDEX_HOST').to_s }
   config.filter_sensitive_data('http://FAKE_ORIGIN') { ENV.fetch('TIMDEX_UI_ORIGIN').to_s }
-
 end
 
 module ActiveSupport

--- a/test/vcr_cassettes/timdex_record_no_record.yml
+++ b/test/vcr_cassettes/timdex_record_no_record.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://FAKE_TIMDEX_HOST/api/v2/record/there.is.no.record
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - http://localhost:3000
+      Connection:
+      - close
+      Host:
+      - FAKE_TIMDEX_HOST
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Fri, 06 May 2022 22:41:03 GMT
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 1285b36b-a33b-4755-ab99-4b3b62998563
+      X-Runtime:
+      - '0.107761'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":"record not found"}'
+  recorded_at: Fri, 06 May 2022 22:41:04 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_record_sample.yml
+++ b/test/vcr_cassettes/timdex_record_sample.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://FAKE_TIMDEX_HOST/api/v2/record/jpal:doi:10.7910-DVN-MNIBOL
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - http://localhost:3000
+      Connection:
+      - close
+      Host:
+      - FAKE_TIMDEX_HOST
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Fri, 06 May 2022 22:41:03 GMT
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"7fe36683746387f2a5e8a7e4c054b3aa"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 737c30d4-98dc-41f0-aa1e-6ab51f6623cf
+      X-Runtime:
+      - '0.116760'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"request_limit":50,"request_count":5,"limit_info":"Register for a
+        free account and provide your JWT token to remove all request limitations.","id":"jpal:doi:10.7910-DVN-MNIBOL","identifiers":[{"kind":"DOI","value":"10.7910/DVN/MNIBOL"}],"source":"Abdul
+        Latif Jameel Poverty Action Lab Dataverse","source_link":"https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/MNIBOL","title":"Dams,
+        Poverty, Public Goods and Malaria Incidence in India","contributors":[{"affiliation":["Massachusetts
+        Institute of Technology"],"kind":"Creator","identifier":["https://orcid.org/0000-0003-0140-9417"],"value":"Duflo,
+        Esther"},{"affiliation":["Harvard University"],"kind":"Creator","identifier":["https://orcid.org/0000-0002-0090-0987"],"value":"Pande,
+        Rohini"},{"affiliation":["Harvard University"],"kind":"ContactPerson","value":"Pande,
+        Rohini"},{"affiliation":["Massachusetts Institute of Technology"],"kind":"ContactPerson","value":"Duflo,
+        Esther"},{"kind":"Producer","value":"Esther Duflo"},{"kind":"Producer","value":"Rohini
+        Pande"},{"kind":"Distributor","value":"Jameel Poverty Action Lab"}],"publication_information":["Harvard
+        Dataverse"],"dates":[{"kind":"Publication date","value":"2007"},{"kind":"Issued","value":"2006"},{"kind":"Created","value":"2006"},{"kind":"Submitted","value":"2006"},{"kind":"Updated","value":"2020-03-31"}],"notes":[{"kind":"Datacite
+        resource type","value":["census data"]},{"kind":"Other","value":["Subject:
+        STANDARD DEPOSIT TERMS 1.0  Type: DATAPASS:TERMS:STANDARD:1.0  Notes: This
+        study was deposited under the of the Data-PASS standard deposit terms. A copy
+        of the usage agreement is included in the file section of this study.;"]}],"content_type":["Dataset"],"edition":"4.2","file_formats":["application/x-stata","text/tab-separated-values","application/pdf","application/pdf","application/x-stata","text/tab-separated-values","application/pdf","application/x-stata","text/tab-separated-values","application/pdf","application/x-stata","text/tab-separated-values","application/pdf","text/tab-separated-values","application/pdf"],"format":"electronic
+        resource","locations":[{"value":"MIT, Cambridge MA"}],"rights":[{"uri":"info:eu-repo/semantics/openAccess"},{"uri":"http://creativecommons.org/publicdomain/zero/1.0"}],"subjects":[{"value":["Social
+        Sciences"]},{"value":["dams and poverty"]},{"value":["The MacArthur Network
+        on Inequality"]},{"value":["JPAL"]},{"kind":"Economic theory and demography","value":["Economic
+        theory"]},{"kind":"Economic theory and demography","value":["Demography"]},{"kind":"Health","value":["Public
+        health"]}],"summary":["The data contains 5 different files, classified by
+        topic. The file india_pov_c81_revise.dta contains variables on the number
+        of dams in each district as well as information about the neighbouring districts.
+        The data set also includes data on local poverty, such as a povertygap measure,
+        the gini coefficient, mean per capita expenditure. The file india_ag_extend
+        contains in addition, data on agricultural produc\r\ntion ( value, yield)
+        for major crops and distinguishes between water-intensive and non-water-intensive
+        crops. The file census.dta contains data on the population size and occupation.
+        The file india_public_updown_doc.dta contains data on the availability of
+        public goods such as water access, power facilities and road. The file malaria_code81.dta
+        contains in addition a variable about malaria incidence."]}'
+  recorded_at: Fri, 06 May 2022 22:41:04 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
#### Why are these changes being introduced:

* A lot of fields are now being provided by the API, and those fields
  should be included in the UI.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-81

#### How does this address that need:

* Defines a full record view, because the list of search results is not
  the place to dislay dozens of metadata fields for a single record.
* This full record view then makes use of a number of helper methods,
  each of which are focused on a specific type of data (strings, lists,
  hashes, and a specific format of hash with "kind" and "value"
  sub-properties.
* These primary helpers in turn make use of internal methods, but being
  internal they are not explicitly and separately tested.

#### Document any side effects to this change:

* CodeClimate is flagging repeated code between the `search` and `record` methods in the Timdex wrapper, probably because they are very copy-pasta. There's probably a way to abstract out the error handling to something shared, at least, but right now I'm not feeling that particularly strongly. If we get a third method that would make more sense.
* A link from the search results to the full record view has been added.
* There is now a db/schema.rb file, although we continue to not have an internal database.
* An extraneous line was removed in test/test_helper.rb
* References to the production API have been replaced with the staging API, because that is now running v2 (and this app will only use the v2 API)
* We have bumped the threshold for parallelizing tests to a very high value (999, instead of the default 50). This should be adjusted later, and is the subject of RDI-109.

#### A11y note

I've checked the full record view in ANDI, Wave, and listened to it briefly with VoiceOver. There are no errors, but there are bits that aren't quite as polished as I'd prefer in production (the tables need some additional massaging, for example). However, as there is a future ticket for envisioning what this full record view could _really_ be, I'd rather not spend too much time now optimizing markup that we know is going to change at least one more time.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
