### PR TITLE
Speculative implementation of method-based timdex wrapper

### DIFF
--- a/app/controllers/basic_search_controller.rb
+++ b/app/controllers/basic_search_controller.rb
@@ -11,7 +11,23 @@ class BasicSearchController < ApplicationController
     query = QueryBuilder.new(@enhanced_query).query
 
     # builder hands off to wrapper which returns raw results here
-    response = Timdex::Client.query(Timdex::SearchQuery, variables: query)
+    # BEGIN EDITORIALIZING
+    # The following works in a console:
+    #
+    # $ query = {'q' => 'data'}
+    # $ wrapper = TimdexCandy.new
+    # $ Parsed = wrapper.client.parse(TimdexCandy::SearchQueryText)
+    # $ Parsed.class # Debugging to make sure this worked
+    # => GraphQL::Client::OperationDefinition
+    # $ wrapper.search(Parsed, query)
+    # => #<GraphQL::Client::Response:0x00000001155c0dd0 ...
+    #
+    # However, this parsing of the search query text is not working here in the controller.
+    # The parsed query needs to be a constant, or the library fails with a 'expected definition to be assigned to a
+    # static constant' error - with the URL https://git.io/vXXSE as explanation.
+    #
+    wrapper = TimdexCandy.new
+    response = wrapper.search(wrapper.client.parse(TimdexCandy::SearchQueryText), query)
 
     # Analyze results
     # handle errors

--- a/app/models/timdex_candy.rb
+++ b/app/models/timdex_candy.rb
@@ -1,0 +1,86 @@
+require 'graphql/client'
+require 'graphql/client/http'
+
+class TimdexCandy
+  def search(query, values)
+    client.query(query, variables: values)
+  end
+
+  # The below would be private methods
+
+  def client
+    GraphQL::Client.new(schema:, execute: http)
+  end
+
+  def http
+    GraphQL::Client::HTTP.new(timdex_url) do
+      def headers(*)
+        { 'User-Agent': 'MIT Libraries Client' }
+      end
+    end
+  end
+
+  def schema
+    GraphQL::Client.load_schema('config/schema/schema.json')
+  end
+
+  def timdex_url
+    ENV.fetch('TIMDEX_GRAPHQL', '')
+  end
+
+  SearchQueryText = <<-'GRAPHQL'.freeze
+    query($q: String!) {
+      search(searchterm: $q) {
+        hits
+        records {
+          timdexRecordId
+          title
+          contentType
+          contributors {
+            kind
+            value
+          }
+          publicationInformation
+          dates {
+            kind
+            value
+          }
+          notes {
+            kind
+            value
+          }
+        }
+        aggregations {
+          contentFormat {
+            key
+            docCount
+          }
+          contentType {
+            key
+            docCount
+          }
+          contributors {
+            key
+            docCount
+          }
+          languages {
+            key
+            docCount
+          }
+          literaryForm {
+            key
+            docCount
+          }
+          source {
+            key
+            docCount
+          }
+          subjects {
+            key
+            docCount
+          }
+        }
+      }
+    }
+  GRAPHQL
+end


### PR DESCRIPTION
This creates a parallel model of the Timdex class, using methods
rather than constants where possible. The parallel, TimdexCandy,
will work in the console - but I've been unable to get it working
from the controller.

The steps in the console are:

$ query = {'q' => 'data'}
$ wrapper = TimdexCandy.new
$ Parsed = wrapper.client.parse(TimdexCandy::SearchQueryText)
$ wrapper.search(Parsed, query)

The issue seems to be how to create the Parsed constant - which
needs the Client to exist for the parsing, but need to be stored
as a constant (because if you send a non-constant to the graphql
library you get an ugly error complaining about dynamic query
errors)

Maybe someone else, even future-me, will be able to resolve this.
