### PR TITLE
Refactor TIMDEX models

### DIFF
--- a/app/controllers/basic_search_controller.rb
+++ b/app/controllers/basic_search_controller.rb
@@ -11,7 +11,7 @@ class BasicSearchController < ApplicationController
     query = QueryBuilder.new(@enhanced_query).query
 
     # builder hands off to wrapper which returns raw results here
-    response = Timdex::Client.query(Timdex::SearchQuery, variables: query)
+    response = TimdexBase::Client.query(TimdexSearch::Query, variables: query)
 
     # Analyze results
     # handle errors

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -6,7 +6,7 @@ class RecordController < ApplicationController
   def view
     id = params[:id]
 
-    response = Timdex::Client.query(Timdex::RecordQuery, variables: { id: })
+    response = TimdexBase::Client.query(TimdexRecord::Query, variables: { id: })
 
     # Detection of unexpected response from the API would go here...
 

--- a/app/models/timdex_base.rb
+++ b/app/models/timdex_base.rb
@@ -1,0 +1,14 @@
+require 'graphql/client'
+require 'graphql/client/http'
+
+class TimdexBase
+  HTTP = GraphQL::Client::HTTP.new(ENV.fetch('TIMDEX_GRAPHQL', '')) do
+    def headers(*)
+      { 'User-Agent': 'MIT Libraries Client' }
+    end
+  end
+
+  Schema = GraphQL::Client.load_schema('config/schema/schema.json')
+
+  Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+end

--- a/app/models/timdex_record.rb
+++ b/app/models/timdex_record.rb
@@ -1,20 +1,8 @@
 require 'graphql/client'
 require 'graphql/client/http'
 
-class Timdex
-  HTTP = GraphQL::Client::HTTP.new(ENV.fetch('TIMDEX_GRAPHQL', '')) do
-    def headers(*)
-      {
-        'User-Agent': 'MIT Libraries Client'
-      }
-    end
-  end
-
-  Schema = GraphQL::Client.load_schema('config/schema/schema.json')
-
-  Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
-
-  RecordQuery = Timdex::Client.parse <<-'GRAPHQL'
+class TimdexRecord < TimdexBase
+  Query = TimdexBase::Client.parse <<-'GRAPHQL'
     query($id: String!) {
       recordId(id: $id) {
         alternateTitles {
@@ -103,62 +91,6 @@ class Timdex
         summary
         timdexRecordId
         title
-      }
-    }
-  GRAPHQL
-
-  SearchQuery = Timdex::Client.parse <<-'GRAPHQL'
-    query($q: String!) {
-      search(searchterm: $q) {
-        hits
-        records {
-          timdexRecordId
-          title
-          contentType
-          contributors {
-            kind
-            value
-          }
-          publicationInformation
-          dates {
-            kind
-            value
-          }
-          notes {
-            kind
-            value
-          }
-        }
-        aggregations {
-          contentFormat {
-            key
-            docCount
-          }
-          contentType {
-            key
-            docCount
-          }
-          contributors {
-            key
-            docCount
-          }
-          languages {
-            key
-            docCount
-          }
-          literaryForm {
-            key
-            docCount
-          }
-          source {
-            key
-            docCount
-          }
-          subjects {
-            key
-            docCount
-          }
-        }
       }
     }
   GRAPHQL

--- a/app/models/timdex_search.rb
+++ b/app/models/timdex_search.rb
@@ -1,0 +1,60 @@
+require 'graphql/client'
+require 'graphql/client/http'
+
+class TimdexSearch < TimdexBase
+  Query = TimdexBase::Client.parse <<-'GRAPHQL'
+    query($q: String!) {
+      search(searchterm: $q) {
+        hits
+        records {
+          timdexRecordId
+          title
+          contentType
+          contributors {
+            kind
+            value
+          }
+          publicationInformation
+          dates {
+            kind
+            value
+          }
+          notes {
+            kind
+            value
+          }
+        }
+        aggregations {
+          contentFormat {
+            key
+            docCount
+          }
+          contentType {
+            key
+            docCount
+          }
+          contributors {
+            key
+            docCount
+          }
+          languages {
+            key
+            docCount
+          }
+          literaryForm {
+            key
+            docCount
+          }
+          source {
+            key
+            docCount
+          }
+          subjects {
+            key
+            docCount
+          }
+        }
+      }
+    }
+  GRAPHQL
+end

--- a/test/controllers/basic_search_controller_test.rb
+++ b/test/controllers/basic_search_controller_test.rb
@@ -28,7 +28,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query displays the query' do
     VCR.use_cassette('timdex hallo',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=hallo'
       assert_response :success
       assert_nil flash[:error]
@@ -39,7 +40,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query shows search form' do
     VCR.use_cassette('timdex hallo',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=hallo'
       assert_response :success
 
@@ -49,7 +51,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query populates search form with query' do
     VCR.use_cassette('data',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=data'
       assert_response :success
 
@@ -59,7 +62,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query has div for hints' do
     VCR.use_cassette('data',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=data'
       assert_response :success
 
@@ -69,7 +73,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query has div for facets which is populated' do
     VCR.use_cassette('data',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=data'
       assert_response :success
       assert_select '#facets'
@@ -79,7 +84,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query has div for pagination' do
     VCR.use_cassette('data',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=data'
       assert_response :success
 
@@ -89,7 +95,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query has div for results which is populated' do
     VCR.use_cassette('data',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=data'
       assert_response :success
       assert_select '#results'
@@ -99,7 +106,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results with valid query include links' do
     VCR.use_cassette('data',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=data'
       assert_select '#results .record-title a' do |value|
         refute_nil(value.xpath('./@href').text)
@@ -109,7 +117,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'searches with zero results are handled gracefully' do
     VCR.use_cassette('timdex no results',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=asdfiouwenlasd'
       assert_response :success
       # Result list contents state "no results"
@@ -125,7 +134,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'searches with ISSN display issn fact card' do
     VCR.use_cassette('timdex 1234-5678',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=1234-5678'
       assert_response :success
 
@@ -136,7 +146,8 @@ class BasicSearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'searches with ISBN display isbn fact card' do
     VCR.use_cassette('timdex 9781509053278',
-                     allow_playback_repeats: true) do
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
       get '/results?q=9781509053278'
       assert_response :success
 

--- a/test/models/timdex_test.rb
+++ b/test/models/timdex_test.rb
@@ -18,7 +18,7 @@ class TimdexTest < ActiveSupport::TestCase
     VCR.use_cassette('timdex record sample',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
-      response = Timdex::Client.query(Timdex::RecordQuery, variables: basic_record)
+      response = TimdexBase::Client.query(TimdexRecord::Query, variables: basic_record)
       assert response.errors.empty?
       assert_equal 1, response.data.to_h.count
       assert_equal 'Dams, Poverty, Public Goods and Malaria Incidence in India', response.data.to_h['recordId']['title']
@@ -32,7 +32,7 @@ class TimdexTest < ActiveSupport::TestCase
     VCR.use_cassette('timdex record no record',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
-      response = Timdex::Client.query(Timdex::RecordQuery, variables: no_record)
+      response = TimdexBase::Client.query(TimdexRecord::Query, variables: no_record)
       refute response.errors.empty?
       assert response.data.nil?
     end
@@ -45,7 +45,7 @@ class TimdexTest < ActiveSupport::TestCase
     VCR.use_cassette('timdex record null record',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
-      response = Timdex::Client.query(Timdex::RecordQuery, variables: null_record)
+      response = TimdexBase::Client.query(TimdexRecord::Query, variables: null_record)
       refute response.errors.empty?
       assert response.data.nil?
     end
@@ -56,7 +56,7 @@ class TimdexTest < ActiveSupport::TestCase
     VCR.use_cassette('data',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
-      response = Timdex::Client.query(Timdex::SearchQuery, variables: basic_search)
+      response = TimdexBase::Client.query(TimdexSearch::Query, variables: basic_search)
       assert_equal response.class, GraphQL::Client::Response
       refute response.data.search.nil?
       assert response.errors.empty?
@@ -70,7 +70,7 @@ class TimdexTest < ActiveSupport::TestCase
     VCR.use_cassette('timdex null search',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
-      response = Timdex::Client.query(Timdex::SearchQuery, variables: null_search)
+      response = TimdexBase::Client.query(TimdexSearch::Query, variables: null_search)
       assert_equal response.class, GraphQL::Client::Response
       assert response.data.nil?
       refute response.errors.empty?
@@ -85,7 +85,7 @@ class TimdexTest < ActiveSupport::TestCase
     VCR.use_cassette('timdex empty search',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
-      response = Timdex::Client.query(Timdex::SearchQuery, variables: empty_search)
+      response = TimdexBase::Client.query(TimdexSearch::Query, variables: empty_search)
       assert_equal response.class, GraphQL::Client::Response
       refute response.data.search.nil?
       assert response.errors.empty?

--- a/test/vcr_cassettes/data.yml
+++ b/test/vcr_cassettes/data.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__SearchQuery($q: String!) {\n  search(searchterm:
+      string: '{"query":"query TimdexSearch__Query($q: String!) {\n  search(searchterm:
         $q) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
         {\n        kind\n        value\n      }\n      publicationInformation\n      dates
         {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n    }\n    aggregations
         {\n      contentFormat {\n        key\n        docCount\n      }\n      contentType
         {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      languages
         {\n        key\n        docCount\n      }\n      literaryForm {\n        key\n        docCount\n      }\n      source
-        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"data"},"operationName":"Timdex__SearchQuery"}'
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"data"},"operationName":"TimdexSearch__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/timdex_1234-5678.yml
+++ b/test/vcr_cassettes/timdex_1234-5678.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__SearchQuery($q: String!) {\n  search(searchterm:
+      string: '{"query":"query TimdexSearch__Query($q: String!) {\n  search(searchterm:
         $q) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
         {\n        kind\n        value\n      }\n      publicationInformation\n      dates
         {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n    }\n    aggregations
         {\n      contentFormat {\n        key\n        docCount\n      }\n      contentType
         {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      languages
         {\n        key\n        docCount\n      }\n      literaryForm {\n        key\n        docCount\n      }\n      source
-        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"1234-5678"},"operationName":"Timdex__SearchQuery"}'
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"1234-5678"},"operationName":"TimdexSearch__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -30,7 +30,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Thu, 26 May 2022 21:02:06 GMT
+      - Thu, 26 May 2022 17:13:17 GMT
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -54,9 +54,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8c7d69e4-66bb-4f04-b505-e390709bf6f0
+      - 8df91947-07ea-4d7d-8007-41253df3de4c
       X-Runtime:
-      - '0.070215'
+      - '0.080935'
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -66,5 +66,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"search":{"hits":0,"records":[],"aggregations":{"contentFormat":[],"contentType":[],"contributors":[],"languages":[],"literaryForm":[],"source":[],"subjects":[]}}}}'
-  recorded_at: Thu, 26 May 2022 21:02:06 GMT
+  recorded_at: Thu, 26 May 2022 17:13:17 GMT
 recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_9781509053278.yml
+++ b/test/vcr_cassettes/timdex_9781509053278.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__SearchQuery($q: String!) {\n  search(searchterm:
+      string: '{"query":"query TimdexSearch__Query($q: String!) {\n  search(searchterm:
         $q) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
         {\n        kind\n        value\n      }\n      publicationInformation\n      dates
         {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n    }\n    aggregations
         {\n      contentFormat {\n        key\n        docCount\n      }\n      contentType
         {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      languages
         {\n        key\n        docCount\n      }\n      literaryForm {\n        key\n        docCount\n      }\n      source
-        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"9781509053278"},"operationName":"Timdex__SearchQuery"}'
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"9781509053278"},"operationName":"TimdexSearch__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -30,7 +30,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Thu, 26 May 2022 21:02:05 GMT
+      - Thu, 26 May 2022 17:11:20 GMT
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -54,9 +54,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3379c11b-ad8f-464b-9570-a2cc4aa8c226
+      - d446a0fc-f740-4810-8ae1-249d7279c00d
       X-Runtime:
-      - '0.045267'
+      - '0.091387'
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -66,5 +66,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"search":{"hits":0,"records":[],"aggregations":{"contentFormat":[],"contentType":[],"contributors":[],"languages":[],"literaryForm":[],"source":[],"subjects":[]}}}}'
-  recorded_at: Thu, 26 May 2022 21:02:06 GMT
+  recorded_at: Thu, 26 May 2022 17:11:21 GMT
 recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_empty_search.yml
+++ b/test/vcr_cassettes/timdex_empty_search.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__SearchQuery($q: String!) {\n  search(searchterm:
+      string: '{"query":"query TimdexSearch__Query($q: String!) {\n  search(searchterm:
         $q) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
         {\n        kind\n        value\n      }\n      publicationInformation\n      dates
         {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n    }\n    aggregations
         {\n      contentFormat {\n        key\n        docCount\n      }\n      contentType
         {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      languages
         {\n        key\n        docCount\n      }\n      literaryForm {\n        key\n        docCount\n      }\n      source
-        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":""},"operationName":"Timdex__SearchQuery"}'
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":""},"operationName":"TimdexSearch__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/timdex_hallo.yml
+++ b/test/vcr_cassettes/timdex_hallo.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__SearchQuery($q: String!) {\n  search(searchterm:
+      string: '{"query":"query TimdexSearch__Query($q: String!) {\n  search(searchterm:
         $q) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
         {\n        kind\n        value\n      }\n      publicationInformation\n      dates
         {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n    }\n    aggregations
         {\n      contentFormat {\n        key\n        docCount\n      }\n      contentType
         {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      languages
         {\n        key\n        docCount\n      }\n      literaryForm {\n        key\n        docCount\n      }\n      source
-        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"hallo"},"operationName":"Timdex__SearchQuery"}'
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"hallo"},"operationName":"TimdexSearch__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -30,7 +30,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Thu, 26 May 2022 21:02:05 GMT
+      - Thu, 26 May 2022 17:10:38 GMT
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -54,9 +54,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c1ee32a1-6003-4e9e-ab5f-a80688e6ce0b
+      - fd0165ce-bdc0-4d6d-af58-b5d5d1a4e08f
       X-Runtime:
-      - '0.037768'
+      - '0.141399'
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -66,5 +66,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"search":{"hits":0,"records":[],"aggregations":{"contentFormat":[],"contentType":[],"contributors":[],"languages":[],"literaryForm":[],"source":[],"subjects":[]}}}}'
-  recorded_at: Thu, 26 May 2022 21:02:05 GMT
+  recorded_at: Thu, 26 May 2022 17:10:38 GMT
 recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_no_results.yml
+++ b/test/vcr_cassettes/timdex_no_results.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__SearchQuery($q: String!) {\n  search(searchterm:
+      string: '{"query":"query TimdexSearch__Query($q: String!) {\n  search(searchterm:
         $q) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
         {\n        kind\n        value\n      }\n      publicationInformation\n      dates
         {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n    }\n    aggregations
         {\n      contentFormat {\n        key\n        docCount\n      }\n      contentType
         {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      languages
         {\n        key\n        docCount\n      }\n      literaryForm {\n        key\n        docCount\n      }\n      source
-        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"asdfiouwenlasd"},"operationName":"Timdex__SearchQuery"}'
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":"asdfiouwenlasd"},"operationName":"TimdexSearch__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -30,7 +30,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Thu, 26 May 2022 21:02:05 GMT
+      - Thu, 26 May 2022 17:14:14 GMT
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -54,9 +54,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 9da041ff-8987-4fb5-88aa-86c166fde98f
+      - c3773628-47c3-475c-bfe8-f6cd1fce3577
       X-Runtime:
-      - '0.058473'
+      - '0.110734'
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -66,5 +66,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"search":{"hits":0,"records":[],"aggregations":{"contentFormat":[],"contentType":[],"contributors":[],"languages":[],"literaryForm":[],"source":[],"subjects":[]}}}}'
-  recorded_at: Thu, 26 May 2022 21:02:06 GMT
+  recorded_at: Thu, 26 May 2022 17:14:15 GMT
 recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/timdex_null_search.yml
+++ b/test/vcr_cassettes/timdex_null_search.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__SearchQuery($q: String!) {\n  search(searchterm:
+      string: '{"query":"query TimdexSearch__Query($q: String!) {\n  search(searchterm:
         $q) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
         {\n        kind\n        value\n      }\n      publicationInformation\n      dates
         {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n    }\n    aggregations
         {\n      contentFormat {\n        key\n        docCount\n      }\n      contentType
         {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      languages
         {\n        key\n        docCount\n      }\n      literaryForm {\n        key\n        docCount\n      }\n      source
-        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":null},"operationName":"Timdex__SearchQuery"}'
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"q":null},"operationName":"TimdexSearch__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/timdex_record_no_record.yml
+++ b/test/vcr_cassettes/timdex_record_no_record.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__RecordQuery($id: String!) {\n  recordId(id:
+      string: '{"query":"query TimdexRecord__Query($id: String!) {\n  recordId(id:
         $id) {\n    alternateTitles {\n      kind\n      value\n    }\n    callNumbers\n    contentType\n    contents\n    contributors
         {\n      affiliation\n      identifier\n      kind\n      mitAffiliated\n      value\n    }\n    dates
         {\n      kind\n      note\n      range {\n        gte\n        lte\n      }\n      value\n    }\n    edition\n    fundingInformation
@@ -15,7 +15,7 @@ http_interactions:
         {\n      geopoint\n      kind\n      value\n    }\n    notes {\n      kind\n      value\n    }\n    numbering\n    physicalDescription\n    publicationFrequency\n    publicationInformation\n    relatedItems
         {\n      description\n      itemType\n      relationship\n      uri\n    }\n    rights
         {\n      description\n      kind\n      uri\n    }\n    source\n    sourceLink\n    subjects
-        {\n      kind\n      value\n    }\n    summary\n    timdexRecordId\n    title\n  }\n}","variables":{"id":"there.is.no.record"},"operationName":"Timdex__RecordQuery"}'
+        {\n      kind\n      value\n    }\n    summary\n    timdexRecordId\n    title\n  }\n}","variables":{"id":"there.is.no.record"},"operationName":"TimdexRecord__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/timdex_record_null_record.yml
+++ b/test/vcr_cassettes/timdex_record_null_record.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__RecordQuery($id: String!) {\n  recordId(id:
+      string: '{"query":"query TimdexRecord__Query($id: String!) {\n  recordId(id:
         $id) {\n    alternateTitles {\n      kind\n      value\n    }\n    callNumbers\n    contentType\n    contents\n    contributors
         {\n      affiliation\n      identifier\n      kind\n      mitAffiliated\n      value\n    }\n    dates
         {\n      kind\n      note\n      range {\n        gte\n        lte\n      }\n      value\n    }\n    edition\n    fundingInformation
@@ -15,7 +15,7 @@ http_interactions:
         {\n      geopoint\n      kind\n      value\n    }\n    notes {\n      kind\n      value\n    }\n    numbering\n    physicalDescription\n    publicationFrequency\n    publicationInformation\n    relatedItems
         {\n      description\n      itemType\n      relationship\n      uri\n    }\n    rights
         {\n      description\n      kind\n      uri\n    }\n    source\n    sourceLink\n    subjects
-        {\n      kind\n      value\n    }\n    summary\n    timdexRecordId\n    title\n  }\n}","variables":{"id":null},"operationName":"Timdex__RecordQuery"}'
+        {\n      kind\n      value\n    }\n    summary\n    timdexRecordId\n    title\n  }\n}","variables":{"id":null},"operationName":"TimdexRecord__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/test/vcr_cassettes/timdex_record_sample.yml
+++ b/test/vcr_cassettes/timdex_record_sample.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://FAKE_TIMDEX_HOST/graphql
     body:
       encoding: UTF-8
-      string: '{"query":"query Timdex__RecordQuery($id: String!) {\n  recordId(id:
+      string: '{"query":"query TimdexRecord__Query($id: String!) {\n  recordId(id:
         $id) {\n    alternateTitles {\n      kind\n      value\n    }\n    callNumbers\n    contentType\n    contents\n    contributors
         {\n      affiliation\n      identifier\n      kind\n      mitAffiliated\n      value\n    }\n    dates
         {\n      kind\n      note\n      range {\n        gte\n        lte\n      }\n      value\n    }\n    edition\n    fundingInformation
@@ -15,7 +15,7 @@ http_interactions:
         {\n      geopoint\n      kind\n      value\n    }\n    notes {\n      kind\n      value\n    }\n    numbering\n    physicalDescription\n    publicationFrequency\n    publicationInformation\n    relatedItems
         {\n      description\n      itemType\n      relationship\n      uri\n    }\n    rights
         {\n      description\n      kind\n      uri\n    }\n    source\n    sourceLink\n    subjects
-        {\n      kind\n      value\n    }\n    summary\n    timdexRecordId\n    title\n  }\n}","variables":{"id":"jpal:doi:10.7910-DVN-MNIBOL"},"operationName":"Timdex__RecordQuery"}'
+        {\n      kind\n      value\n    }\n    summary\n    timdexRecordId\n    title\n  }\n}","variables":{"id":"jpal:doi:10.7910-DVN-MNIBOL"},"operationName":"TimdexRecord__Query"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3


### PR DESCRIPTION
Why are these changes being introduced:

* The timdex model was handling interactions for both search and
  retrieve, which are separate interactions that don't intersect other
  than the client setup

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-118

How does this address that need:

* The shared timdex graphql client logic is moved to a timdex_base class
  and timdex_search and timdex_record are created.

Side Effects:

There may be some confusion calling the new model `timdex_record` rather than `timdex_retrieve`. However, other parts of this app are already referring to a single record retrieval as `record` and not `retrieve` so for now I think this is the correct name.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
