### PR TITLE
Initial refinements to search results UI

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -9,5 +9,6 @@
 @import "partials/_facets";
 @import "partials/_panels";
 @import "partials/_search";
+@import "partials/_results";
 @import "partials/_typography";
 @import "timdexui";

--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -1,0 +1,38 @@
+.wrap-results {
+  margin-bottom: 3rem;
+  background-color: $white-t;
+  padding: 15px;
+}
+
+.result {
+  padding: 2rem;
+  border-top: 1px solid $brand-primary;
+
+  &:hover,
+  &:focus {
+    border-right: 1px solid $gray-l3;
+    border-left: 1px solid $gray-l3;
+    background-color: $gray-l4;
+  }
+
+  a:visited {
+    color: $brand-secondary;
+  }
+
+  .pub-info {
+    font-size: $fs-small;
+    color:  $gray-d1;
+    span:first-child:after {
+      content:  " | ";
+    }
+  }
+
+  .result-get {
+    padding-top: 5px;
+    font-size: 1.4rem;
+    a:visited {
+      color: $white;
+      background-color:  green;
+    }
+  }
+}

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,40 +1,28 @@
-<li>
+<li class="result">
   <h2 class="record-title">
     <span class="sr">Title: </span><%= link_to(result['title'], record_path(result['timdexRecordId'])) %>
   </h2>
 
-  <% result['contentType']&.each do |type| %>
-    <p>
-      <%= type %>
-    <p>
-  <% end %>
+  <p class="pub-info">
+    <span><%= result['contentType']&.each { |type| type['value'] }.join(' ; ') %></span>
+    <span>
+      <% result['dates']&.each do |date| %>
+        <%= date['value'] if date['kind'] == 'Publication date' %>
+      <% end %>
+    </span>
+  </p>
 
   <% contributors = [] %>
   <% result['contributors']&.each do |contributor| %>
-    <% contributors << "#{contributor['value']} (#{contributor['kind']})" %>
+    <% contributors << contributor['value'] %>
   <% end %>
 
   <p class="result-authors">
     <span class="sr">Authors: </span>
-    <%= contributors.join('; ') %>
+    <%= contributors.uniq.map { |contrib| link_to contrib, results_path({ advanced: true, contributors: contrib }) }.join(' ; ').html_safe %>
   </p>
 
-  <% result['publicationInformation']&.each do |pub| %>
-    <p>
-      <span class="sr">Publication Information: </span>
-      <%= pub %>
-    </p>
-  <% end %>
-
-  <% result['dates']&.each do |date| %>
-    <p>
-      <%= date['kind'] %>: <%= date['value'] %>
-    </p>
-  <% end %>
-
-  <p>
-    Identifier: <%= result['timdexRecordId'] %>
-  </p>
-
-  <hr />
+  <div class="result-get">
+    <%= link_to 'View online', "##{Random.rand(100000)}", class: 'button button-primary green' %>
+  </div>
 </li>

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -50,7 +50,7 @@
   <%= render(partial: 'shared/error', collection: @errors) %>
 
   <div class="layout-1q3q layout-band top-space">
-    <div class="col3q">
+    <div class="col3q wrap-results">
       <ul id="results" class="list-unbulleted">
         <%= render(partial: 'search/result', collection: @results) || render('result_empty') %>
       </ul>


### PR DESCRIPTION
#### Why these changes are being introduced:

This work was prompted by the initial set of UI iterations.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/RDI-99

#### How this addresses that need:

This proposes a path for the results UI design, focused on the
minimal information needed to identify whether a resource is useful.

Since we will have a full record view, these brief results include
only title, content type, publication date, contributors, and
full-text link. Unlike Bento, they do not include subjects, as I
couldn't discern a use case for this in the brief results. (More on
this in the ticket if you're curious.)

This makes some improvements to a11y, including highlighting
links and adding `:visited` classes. The colors of these are
subject to change; I'm specifically interested in the
reviewer's opinion of the green used for the 'View online' button;
this is borrowed from Bento, but I wonder if it has implications
for color-blind people.

These changes are very much a starting point. I anticipate
additional iteration on the design, and I welcome whatever changes
the reviewer recommends to this current state.

#### Side effects of this change:

* Adds byebug and updates the gitignore accordingly.
* Contributor types have been removed, but I'm very open to adding
them back in, or possibly changing the number/type of contributors
shown.
* The 'View online' links don't actually go anywhere yet.
* There are some additional features that I think are needed, but
seemed out of scope of this ticket:
    * Search term highlighting;
    * Conditional metadata display for different content types;
    * Full-text links.
* I still have many open questions on this approach, primarily
around the assumptions made re: affordances and metadata. See my
comment in the ticket for more info.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
