### PR TITLE
Adds actionable links to DOI fact panel

### DIFF
--- a/app/models/fact_doi.rb
+++ b/app/models/fact_doi.rb
@@ -1,16 +1,30 @@
 class FactDoi
   def info(doi)
-    json = fetch(doi)
-    return if json == 'Error'
+    external_data = fetch(doi)
+    return if external_data == 'Error'
 
+    metadata = extract_metadata(external_data)
+    metadata[:doi] = doi
+    metadata[:link_resolver_url] = link_resolver_url(metadata)
+    metadata
+  end
+
+  def extract_metadata(external_data)
     {
-      title: json['message']['title'],
-      publisher: json['message']['publisher']
+      genre: external_data['genre'],
+      title: external_data['title'],
+      year: external_data['year'],
+      publisher: external_data['publisher'],
+      oa: external_data['is_oa'],
+      oa_status: external_data['oa_status'],
+      best_oa_location: external_data['best_oa_location'],
+      journal_issns: external_data['journal_issns'],
+      journal_name: external_data['journal_name']
     }
   end
 
   def url(doi)
-    "https://api.crossref.org/works/#{doi}"
+    "https://api.unpaywall.org/v2/#{doi}?email=timdex@mit.edu"
   end
 
   def fetch(doi)
@@ -18,9 +32,13 @@ class FactDoi
     if resp.status == 200
       JSON.parse(resp.to_s)
     else
-      Rails.logger.debug("Fact lookup error. DOI #{doi} detected but crossref returned no data")
+      Rails.logger.debug("Fact lookup error. DOI #{doi} detected but unpaywall returned no data")
       Rails.logger.debug("URL: #{url(doi)}")
       'Error'
     end
+  end
+
+  def link_resolver_url(metadata)
+    "https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.timdex.ui&rft.atitle=#{metadata[:title]}&rft.date=#{metadata[:year]}&rft.genre=#{metadata[:genre]}&rft.jtitle=#{metadata[:journal_name]}&rft_id=info:doi/#{metadata[:doi]}&vid=01MIT_INST:MIT"
   end
 end

--- a/app/views/fact/doi.html.erb
+++ b/app/views/fact/doi.html.erb
@@ -2,16 +2,28 @@
 
 <div id="doi-fact" class="panel panel-info fact">
   <div class="panel-heading">
-    <%= @json[:title] %>
+    <%= @json[:title] %> <br />
   </div>
 
   <div class="panel-body">
-    <ul>
-      <li><%= @json[:publisher] %></li>
-    </ul>
-  </div>
+    In: <%= @json[:journal_name] %>, <%= @json[:year] %>
 
-  <div class="panel-footer">
-    <a href="#">Yes this</a> -- <a href="#">Not relevant to my search</a>
+    <ul>
+      <li>
+        Open Access: 
+        <% if @json[:oa] %>
+          <%= @json[:oa_status] %>
+        <% else %>
+          unknown
+        <% end %>
+      </li>
+      <li>Publisher: <%= @json[:publisher] %></li>
+
+      <% if @json[:oa] %>
+        <li><%= link_to('Open Access Link', @json[:best_oa_location]["url"]) %>
+      <% end %>
+
+      <li><%= link_to('Check MIT Subscription Access', @json[:link_resolver_url]) %>
+    </ul>
   </div>
 </div>

--- a/test/controllers/fact_controller_test.rb
+++ b/test/controllers/fact_controller_test.rb
@@ -8,7 +8,7 @@ class FactControllerTest < ActionDispatch::IntegrationTest
     refute @response.body.present?
   end
 
-  test 'doi with valid doi' do
+  test 'doi with valid doi and no oa copy available' do
     VCR.use_cassette('fact doi 10.1038.nphys1170',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
@@ -21,6 +21,28 @@ class FactControllerTest < ActionDispatch::IntegrationTest
       assert_select '#isbn-fact', { count: 0 }
       assert_select '#issn-fact', { count: 0 }
       assert_select '#pmid-fact', { count: 0 }
+
+      assert_select 'a', text: 'Check MIT Subscription Access', count: 1
+      assert_select 'a', text: 'Open Access Link', count: 0
+    end
+  end
+
+  test 'doi with valid doi and oa copy available' do
+    VCR.use_cassette('fact doi 10.1126 sciadv.abj1076',
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
+      get '/doi?doi=10.1126%2Fsciadv.abj1076'
+      assert_response :success
+
+      assert @response.body.present?
+
+      assert_select '#doi-fact', { count: 1 }
+      assert_select '#isbn-fact', { count: 0 }
+      assert_select '#issn-fact', { count: 0 }
+      assert_select '#pmid-fact', { count: 0 }
+
+      assert_select 'a', text: 'Check MIT Subscription Access', count: 1
+      assert_select 'a', text: 'Open Access Link', count: 1
     end
   end
 

--- a/test/vcr_cassettes/fact_doi_10_1038_nphys1170.yml
+++ b/test/vcr_cassettes/fact_doi_10_1038_nphys1170.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.crossref.org/works/10.1038/nphys1170
+    uri: https://api.unpaywall.org/v2/10.1038/nphys1170?email=timdex@mit.edu
     body:
       encoding: UTF-8
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - api.crossref.org
+      - api.unpaywall.org
       User-Agent:
       - http.rb/5.0.4
   response:
@@ -20,66 +20,35 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Date:
-      - Thu, 09 Jun 2022 17:56:47 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Access-Control-Expose-Headers:
-      - Link
-      Access-Control-Allow-Headers:
-      - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-        Accept-Ranges, Cache-Control
-      Access-Control-Allow-Origin:
-      - "*"
-      Server:
-      - Jetty(9.4.40.v20210413)
-      X-Ratelimit-Limit:
-      - '50'
-      X-Ratelimit-Interval:
-      - 1s
-      X-Api-Pool:
-      - public
-      X-Rate-Limit-Limit:
-      - '50'
-      X-Rate-Limit-Interval:
-      - 1s
-      Permissions-Policy:
-      - interest-cohort=()
       Connection:
       - close
+      Server:
+      - gunicorn
+      Date:
+      - Tue, 21 Jun 2022 20:07:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '733'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Via:
+      - 1.1 vegur
     body:
       encoding: ASCII-8BIT
-      string: '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2022,4,1]],"date-time":"2022-04-01T05:13:35Z","timestamp":1648790015559},"reference-count":10,"publisher":"Springer
-        Science and Business Media LLC","issue":"1","license":[{"start":{"date-parts":[[2009,1,1]],"date-time":"2009-01-01T00:00:00Z","timestamp":1230768000000},"content-version":"tdm","delay-in-days":0,"URL":"http:\/\/www.springer.com\/tdm"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Nature
-        Phys"],"published-print":{"date-parts":[[2009,1]]},"DOI":"10.1038\/nphys1170","type":"journal-article","created":{"date-parts":[[2009,1,3]],"date-time":"2009-01-03T10:16:57Z","timestamp":1230977817000},"page":"11-12","source":"Crossref","is-referenced-by-count":9,"title":["Measured
-        measurement"],"prefix":"10.1038","volume":"5","author":[{"given":"Markus","family":"Aspelmeyer","sequence":"first","affiliation":[]}],"member":"297","reference":[{"key":"BFnphys1170_CR1","doi-asserted-by":"publisher","first-page":"27","DOI":"10.1038\/nphys1133","volume":"5","author":"JS
-        Lundeen","year":"2009","unstructured":"Lundeen, J. S. et al. Nature Phys.
-        5, 27\u201330 (2009).","journal-title":"Nature Phys."},{"key":"BFnphys1170_CR2","volume-title":"Der
-        Teil und das Ganze","author":"W Heisenberg","year":"1969","unstructured":"Heisenberg,
-        W. Der Teil und das Ganze (Piper, Munich, 1969)."},{"key":"BFnphys1170_CR3","doi-asserted-by":"publisher","volume-title":"Quantum
-        State Estimation","author":"MGA Paris","year":"2004","unstructured":"Paris,
-        M. G. A. & Rehacek, J. (eds) Quantum State Estimation (Lecture Notes in Physics
-        Vol. 649) (Springer, 2004).","DOI":"10.1007\/b98673"},{"key":"BFnphys1170_CR4","doi-asserted-by":"publisher","first-page":"052312","DOI":"10.1103\/PhysRevA.64.052312","volume":"64","author":"DFV
-        James","year":"2001","unstructured":"James, D. F. V., Kwiat, P. G., Munro,
-        W. J. & White, A. G. Phys. Rev. A 64, 052312 (2001).","journal-title":"Phys.
-        Rev. A"},{"key":"BFnphys1170_CR5","doi-asserted-by":"publisher","first-page":"R1561","DOI":"10.1103\/PhysRevA.55.R1561","volume":"55","author":"Z
-        Hradil","year":"1997","unstructured":"Hradil, Z. Phys. Rev. A 55, R1561\u2013R1564
-        (1997).","journal-title":"Phys. Rev. A"},{"key":"BFnphys1170_CR6","doi-asserted-by":"publisher","first-page":"010304","DOI":"10.1103\/PhysRevA.61.010304","volume":"61","author":"K
-        Banaszek","year":"1999","unstructured":"Banaszek, K., D''Ariano, G. M., Paris,
-        M. G. A. & Sacchi, M. F. Phys. Rev. A 61, 010304 (1999).","journal-title":"Phys.
-        Rev. A"},{"key":"BFnphys1170_CR7","doi-asserted-by":"publisher","first-page":"2455","DOI":"10.1080\/09500349708231894","volume":"44","author":"IL
-        Chuang","year":"1997","unstructured":"Chuang I. L. & Nielsen, M. A. J. Mod.
-        Opt. 44, 2455\u20132467 (1997).","journal-title":"J. Mod. Opt."},{"key":"BFnphys1170_CR8","doi-asserted-by":"publisher","first-page":"390","DOI":"10.1103\/PhysRevLett.78.390","volume":"78","author":"JF
-        Poyatos","year":"1997","unstructured":"Poyatos J. F., Cirac, J. I. & Zoller,
-        P. Phys. Rev. Lett. 78, 390\u2013393 (1997).","journal-title":"Phys. Rev.
-        Lett."},{"key":"BFnphys1170_CR9","doi-asserted-by":"publisher","first-page":"563","DOI":"10.1126\/science.1162086","volume":"322","author":"M
-        Lobino","year":"2008","unstructured":"Lobino, M. et al. Science 322, 563\u2013566
-        (2008).","journal-title":"Science"},{"key":"BFnphys1170_CR10","doi-asserted-by":"publisher","first-page":"84","DOI":"10.1103\/PhysRevLett.10.84","volume":"10","author":"RJ
-        Glauber","year":"1963","unstructured":"Glauber, R. J. Phys. Rev. Lett. 10,
-        84\u201386 (1963).","journal-title":"Phys. Rev. Lett."}],"container-title":["Nature
-        Physics"],"original-title":[],"language":"en","link":[{"URL":"http:\/\/www.nature.com\/articles\/nphys1170.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"http:\/\/www.nature.com\/articles\/nphys1170","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"http:\/\/www.nature.com\/articles\/nphys1170.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2021,12,2]],"date-time":"2021-12-02T07:10:15Z","timestamp":1638429015000},"score":1,"resource":{"primary":{"URL":"http:\/\/www.nature.com\/articles\/nphys1170"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2009,1]]},"references-count":10,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2009,1]]}},"alternative-id":["BFnphys1170"],"URL":"http:\/\/dx.doi.org\/10.1038\/nphys1170","relation":{},"ISSN":["1745-2473","1745-2481"],"issn-type":[{"value":"1745-2473","type":"print"},{"value":"1745-2481","type":"electronic"}],"subject":["General
-        Physics and Astronomy"],"published":{"date-parts":[[2009,1]]}}}'
-  recorded_at: Thu, 09 Jun 2022 17:56:46 GMT
+      string: '{"doi": "10.1038/nphys1170", "doi_url": "https://doi.org/10.1038/nphys1170",
+        "title": "Measured measurement", "genre": "journal-article", "is_paratext":
+        false, "published_date": "2009-01-01", "year": 2009, "journal_name": "Nature
+        Physics", "journal_issns": "1745-2473,1745-2481", "journal_issn_l": "1745-2473",
+        "journal_is_oa": false, "journal_is_in_doaj": false, "publisher": "Springer
+        Science and Business Media LLC", "is_oa": false, "oa_status": "closed", "has_repository_copy":
+        false, "best_oa_location": null, "first_oa_location": null, "oa_locations":
+        [], "oa_locations_embargoed": [], "updated": "2021-04-01T04:17:18.585258",
+        "data_standard": 2, "z_authors": [{"given": "Markus", "family": "Aspelmeyer",
+        "sequence": "first"}]}'
+  recorded_at: Tue, 21 Jun 2022 20:07:07 GMT
 recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/fact_doi_10_1126_sciadv_abj1076.yml
+++ b/test/vcr_cassettes/fact_doi_10_1126_sciadv_abj1076.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.unpaywall.org/v2/10.1126/sciadv.abj1076?email=timdex@mit.edu
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.unpaywall.org
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Server:
+      - gunicorn
+      Date:
+      - Tue, 21 Jun 2022 20:07:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5639'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"doi": "10.1126/sciadv.abj1076", "doi_url": "https://doi.org/10.1126/sciadv.abj1076",
+        "title": "Weyl Fermion magneto-electrodynamics and ultralow field quantum
+        limit in TaAs", "genre": "journal-article", "is_paratext": false, "published_date":
+        "2022-01-14", "year": 2022, "journal_name": "Science Advances", "journal_issns":
+        "2375-2548", "journal_issn_l": "2375-2548", "journal_is_oa": true, "journal_is_in_doaj":
+        true, "publisher": "American Association for the Advancement of Science (AAAS)",
+        "is_oa": true, "oa_status": "green", "has_repository_copy": true, "best_oa_location":
+        {"updated": "2022-04-22T12:04:36.250191", "url": "https://dspace.mit.edu/bitstream/1721.1/141955/2/sciadv.abj1076.pdf",
+        "url_for_pdf": "https://dspace.mit.edu/bitstream/1721.1/141955/2/sciadv.abj1076.pdf",
+        "url_for_landing_page": "https://hdl.handle.net/1721.1/141955", "evidence":
+        "oa repository (via OAI-PMH doi match)", "license": "cc-by", "version": "publishedVersion",
+        "host_type": "repository", "is_best": true, "pmh_id": "oai:dspace.mit.edu:1721.1/141955",
+        "endpoint_id": "a996c19dace9d4ac72d", "repository_institution": "Massachusetts
+        Institute of Technology - DSpace@MIT", "oa_date": "2022-04-20"}, "first_oa_location":
+        {"updated": "2022-05-06T03:12:16.943621", "url": "http://arxiv.org/pdf/2111.06182",
+        "url_for_pdf": "http://arxiv.org/pdf/2111.06182", "url_for_landing_page":
+        "http://arxiv.org/abs/2111.06182", "evidence": "oa repository (via OAI-PMH
+        title and first author match)", "license": null, "version": "submittedVersion",
+        "host_type": "repository", "is_best": false, "pmh_id": "oai:arXiv.org:2111.06182",
+        "endpoint_id": "ca8f8d56758a80a4f86", "repository_institution": "Cornell University
+        - arXiv", "oa_date": "2021-11-12"}, "oa_locations": [{"updated": "2022-04-22T12:04:36.250191",
+        "url": "https://dspace.mit.edu/bitstream/1721.1/141955/2/sciadv.abj1076.pdf",
+        "url_for_pdf": "https://dspace.mit.edu/bitstream/1721.1/141955/2/sciadv.abj1076.pdf",
+        "url_for_landing_page": "https://hdl.handle.net/1721.1/141955", "evidence":
+        "oa repository (via OAI-PMH doi match)", "license": "cc-by", "version": "publishedVersion",
+        "host_type": "repository", "is_best": true, "pmh_id": "oai:dspace.mit.edu:1721.1/141955",
+        "endpoint_id": "a996c19dace9d4ac72d", "repository_institution": "Massachusetts
+        Institute of Technology - DSpace@MIT", "oa_date": "2022-04-20"}, {"updated":
+        "2022-06-21T20:07:08.301543", "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8759752",
+        "url_for_pdf": null, "url_for_landing_page": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8759752",
+        "evidence": "oa repository (via pmcid lookup)", "license": null, "version":
+        "publishedVersion", "host_type": "repository", "is_best": false, "pmh_id":
+        null, "endpoint_id": null, "repository_institution": null, "oa_date": null},
+        {"updated": "2022-05-06T03:12:16.943621", "url": "http://arxiv.org/pdf/2111.06182",
+        "url_for_pdf": "http://arxiv.org/pdf/2111.06182", "url_for_landing_page":
+        "http://arxiv.org/abs/2111.06182", "evidence": "oa repository (via OAI-PMH
+        title and first author match)", "license": null, "version": "submittedVersion",
+        "host_type": "repository", "is_best": false, "pmh_id": "oai:arXiv.org:2111.06182",
+        "endpoint_id": "ca8f8d56758a80a4f86", "repository_institution": "Cornell University
+        - arXiv", "oa_date": "2021-11-12"}], "oa_locations_embargoed": [], "updated":
+        "2022-05-06T18:31:58.906538", "data_standard": 2, "z_authors": [{"ORCID":
+        "http://orcid.org/0000-0001-9451-9919", "given": "Zhengguang", "family": "Lu",
+        "sequence": "first", "affiliation": [{"name": "Department of physics, Massachusetts
+        Institute of Technology, Cambridge, MA 02139, USA."}], "authenticated-orcid":
+        true}, {"ORCID": "http://orcid.org/0000-0001-5800-9911", "given": "Patrick",
+        "family": "Hollister", "sequence": "additional", "affiliation": [{"name":
+        "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca,
+        NY 14853, USA."}], "authenticated-orcid": true}, {"ORCID": "http://orcid.org/0000-0002-5470-1158",
+        "given": "Mykhaylo", "family": "Ozerov", "sequence": "additional", "affiliation":
+        [{"name": "National High Magnetic Field Lab, Tallahassee, FL 32310, USA."}],
+        "authenticated-orcid": true}, {"given": "Seongphill", "family": "Moon", "sequence":
+        "additional", "affiliation": [{"name": "National High Magnetic Field Lab,
+        Tallahassee, FL 32310, USA."}, {"name": "Department of Physics, Florida State
+        University, Tallahassee, FL 32306, USA."}]}, {"ORCID": "http://orcid.org/0000-0003-0017-1937",
+        "given": "Eric D.", "family": "Bauer", "sequence": "additional", "affiliation":
+        [{"name": "Los Alamos National Labs, Los Alamos, NM 87544, USA."}], "authenticated-orcid":
+        true}, {"ORCID": "http://orcid.org/0000-0002-2679-7957", "given": "Filip",
+        "family": "Ronning", "sequence": "additional", "affiliation": [{"name": "Los
+        Alamos National Labs, Los Alamos, NM 87544, USA."}], "authenticated-orcid":
+        true}, {"ORCID": "http://orcid.org/0000-0001-6358-3221", "given": "Dmitry",
+        "family": "Smirnov", "sequence": "additional", "affiliation": [{"name": "National
+        High Magnetic Field Lab, Tallahassee, FL 32310, USA."}], "authenticated-orcid":
+        true}, {"ORCID": "http://orcid.org/0000-0002-4691-1315", "given": "Long",
+        "family": "Ju", "sequence": "additional", "affiliation": [{"name": "Department
+        of physics, Massachusetts Institute of Technology, Cambridge, MA 02139, USA."}],
+        "authenticated-orcid": true}, {"ORCID": "http://orcid.org/0000-0002-3222-5007",
+        "given": "B. J.", "family": "Ramshaw", "sequence": "additional", "affiliation":
+        [{"name": "Laboratory of Atomic and Solid State Physics, Cornell University,
+        Ithaca, NY 14853, USA."}], "authenticated-orcid": true}]}'
+  recorded_at: Tue, 21 Jun 2022 20:07:08 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/fact_doi_10_3207_2959859860.yml
+++ b/test/vcr_cassettes/fact_doi_10_3207_2959859860.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.crossref.org/works/10.3207/2959859860
+    uri: https://api.unpaywall.org/v2/10.3207/2959859860?email=timdex@mit.edu
     body:
       encoding: UTF-8
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - api.crossref.org
+      - api.unpaywall.org
       User-Agent:
       - http.rb/5.0.4
   response:
@@ -20,37 +20,31 @@ http_interactions:
       code: 404
       message: Not Found
     headers:
-      Date:
-      - Thu, 09 Jun 2022 17:59:23 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Access-Control-Expose-Headers:
-      - Link
-      Access-Control-Allow-Headers:
-      - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-        Accept-Ranges, Cache-Control
-      Access-Control-Allow-Origin:
-      - "*"
-      Server:
-      - Jetty(9.4.40.v20210413)
-      X-Ratelimit-Limit:
-      - '50'
-      X-Ratelimit-Interval:
-      - 1s
-      X-Api-Pool:
-      - public
-      X-Rate-Limit-Limit:
-      - '50'
-      X-Rate-Limit-Interval:
-      - 1s
-      Permissions-Policy:
-      - interest-cohort=()
       Connection:
       - close
+      Server:
+      - gunicorn
+      Date:
+      - Tue, 21 Jun 2022 20:07:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Via:
+      - 1.1 vegur
     body:
       encoding: ASCII-8BIT
-      string: Resource not found.
-  recorded_at: Thu, 09 Jun 2022 17:59:22 GMT
+      string: |-
+        {
+            "HTTP_status_code": 404,
+            "error": true,
+            "message": "'10.3207/2959859860' isn't in Unpaywall. See https://support.unpaywall.org/a/solutions/articles/44001900286"
+        }
+  recorded_at: Tue, 21 Jun 2022 20:07:07 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
Why are these changes being introduced:

* Useful actions in the Fact panel are a large part of the intent of
  fact panels

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-130

How does this address that need:

* Uses unpaywall instead of crossref to get more information about
  open availability
* Provides a link to an Open Access copy if one is available
* Always provides a link to Primo/Alma link resolver to check MIT access

Document any side effects to this change:

* the html/css needs work, but as we want to normalize these fact
  panels I felt we could address that later

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
