### PR TITLE
Remove stickiness from facet sidebar

### DIFF
--- a/app/assets/stylesheets/partials/_facets.scss
+++ b/app/assets/stylesheets/partials/_facets.scss
@@ -1,8 +1,3 @@
-.facet-container {
-  position: sticky;
-  top: 1em;
-}
-
 #facets {
   h3 {
     margin-bottom: 0;


### PR DESCRIPTION
#### Why are these changes being introduced:

* After further review, we no longer want the facets in the sidebar to
  be sticky.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/rdi-162

#### How does this address that need:

* Removes the two stylesheet rules which make the facet sidebar sticky,
  allowing that content to scroll consistently with other page content.

#### Document any side effects to this change:

* None

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
