### PR TITLE
Updates to full record view

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -1,4 +1,29 @@
 module RecordHelper
+  def doi(metadata)
+    dois = metadata['identifiers'].select { |id| id['kind'].downcase == 'doi' }
+    return unless dois.present?
+
+    dois.first['value']
+  end
+
+  def date_parse(date)
+    return unless date.present?
+
+    Date.parse(date).to_fs(:long)
+  rescue Date::Error
+    date
+  end
+
+  def date_range(range)
+    return unless range.present?
+
+    "#{date_parse(range['gte'])} to #{date_parse(range['lte'])}"
+  end
+
+  def publication_date(metadata)
+    metadata['dates'].select { |date| date['kind'] == 'Publication date' }.first['value']
+  end
+
   # Display the machine-format key in human-readable text.
   def render_key(string)
     string.capitalize.gsub('_', ' ').gsub('Mit', 'MIT')
@@ -10,7 +35,7 @@ module RecordHelper
 
     markupclass = 'field-list'
 
-    title = "<h2>#{render_key(element)}</h2>"
+    title = "<h3>#{render_key(element)}</h3>"
     values = if record[element].length == 1
                "<p class='#{markupclass}'>#{record[element][0]}</p>".html_safe
              else
@@ -24,7 +49,7 @@ module RecordHelper
 
     markupclass = 'field-object'
 
-    title = "<h2>#{render_key(element)}</h2>"
+    title = "<h3>#{render_key(element)}</h3>"
     values = "<ul class='#{markupclass}'>#{render_kind_value(record[element])}</ul>"
     (title + values).html_safe
   end
@@ -34,13 +59,17 @@ module RecordHelper
 
     markupclass = 'field-string'
 
-    "<h2>#{render_key(element)}</h2><p class='#{markupclass}'>#{record[element]}</p>".html_safe
+    "<h3>#{render_key(element)}</h3><p class='#{markupclass}'>#{record[element]}</p>".html_safe
   end
 
-  def field_table(record, element, fields)
+  def field_table(record, element, fields, label = '')
     return unless record[element].present?
 
-    title = "<h2>#{render_key(element)}</h2>"
+    title = if label.present?
+              "<h3>#{label}</h3>"
+            else
+              "<h3>#{render_key(element)}</h3>"
+            end
     labels = "<table><thead><tr>#{render_table_header(fields)}</tr></thead>"
     values = "<tbody>#{render_table_row(record[element], fields)}</tbody></table>"
     (title + labels + values).html_safe

--- a/app/views/fact/doi.html.erb
+++ b/app/views/fact/doi.html.erb
@@ -1,9 +1,11 @@
 <% return unless @json.present? %>
 
-<div id="doi-fact" class="panel panel-info fact">
-  <div class="panel-heading">
-    <%= @json[:title] %> <br />
-  </div>
+<div id="doi-fact" class="panel fact">
+  <% unless params[:slim].present? %>
+    <div class="panel-heading">
+      <%= @json[:title] %> <br />
+    </div>
+  <% end %>
 
   <div class="panel-body">
     In: <%= @json[:journal_name] %>, <%= @json[:year] %>

--- a/app/views/record/_misc.html.erb
+++ b/app/views/record/_misc.html.erb
@@ -1,0 +1,33 @@
+<hr />
+
+<div class="alert alert-banner warning">
+  <p>Much of the data past this point we don't have good examples of yet. Please share in #rdi slack if you have good examples for anything that appears below. Thanks!</p>
+</div>
+    
+<%= field_table(@record, 'fundingInformation', %w[awardNumber awardUri funderIdentifier funderIdentifierType funderName], 'Funding Information') %>
+
+<%= field_object(@record, 'alternateTitles' ) %>
+
+<%= field_list(@record, 'callNumbers' ) %>
+
+<%= field_string(@record, 'collection') %>
+
+<%= field_list(@record, 'contents' ) %>
+
+<%= field_list(@record, 'fileFormats') %>
+
+<%= field_string(@record, 'format') %>
+
+<%= field_table(@record, 'holdings', %w[call_number collection format location note]) %>
+
+<%= field_string(@record, 'literaryForm') %>
+
+<%= field_table(@record, 'locations', %w[kind value geopoint]) %>
+
+<%= field_string(@record, 'numbering') %>
+
+<%= field_string(@record, 'physicalDescription') %>
+
+<%= field_list(@record, 'publicationFrequency') %>
+
+<%= field_table(@record, 'relatedItems', %w[description item_type relationship uri]) %>

--- a/app/views/record/_record.html.erb
+++ b/app/views/record/_record.html.erb
@@ -1,59 +1,183 @@
-<h1><%= @record['title'] %></h1>
+<div class="gridband layout-3q1q wrap-full-record">
+  <div class="col3q box-content region full-record" data-region="Full record">
 
-<%= field_object(@record, 'alternateTitles' ) %>
+    <h2 class="record-title">
+      <span class="sr">Title: </span>
+      <% if @record['title'].present? %>
+        <%= @record['title'] %>
+      <% else %>
+        No title provided for this item.
+      <% end %>
+    </h2>
 
-<%= field_list(@record, 'callNumbers' ) %>
+    <p>
+      <span class="record-type">
+        <% # we need to create separate displays for different types of content types, see https://github.com/MITLibraries/bento/pull/908/files#diff-6718f9b88f6f93e59d8c2509512dc40a62088430ff3cce1165ab414565949415L22-L57 for starting point but we should anticipate wanting to expand to many more unique content types %>
+        <span class="sr">Type</span> <%= @record['contentType'].join %>
+      </span>
 
-<%= field_string(@record, 'citation' ) %>
+      <% if @record['citation'].present? %>
 
-<%= field_list(@record, 'contentType' ) %>
+        <span class="record-citation">
+          <%= @record['citation'] %>
+        </span>
 
-<%= field_list(@record, 'contents' ) %>
+      <% else %>
 
-<%= field_table(@record, 'contributors', %w[value kind affiliation identifier mit_affiliated]) %>
+        <% if @record['dates'].map{|date| date if date['kind'] == 'Publication date'}.compact.present? %>
+          <span class="record-year">
+            : Published <%= date_parse(publication_date(@record)) %>
+          </span>
+        <% end %>
+        <% if @record['edition'].present? %>
+          <span class="record-edition">
+            : Edition <%= @record['edition'] %>
+          </span>
+        <% end %>
+      <% end %>
+    </p>
 
-<%= field_table(@record, 'dates', %w[kind value range note]) %>
+    <% # we should helper this up to handle insanely large lists of authors %>
+    <% if @record['contributors'].present? %>
+      <p class="record-authors">
+        <span class="sr"><%= "Author".pluralize(@record['contributors'].count) %>: </span>
+          <% @record['contributors'].each do |author| %>
+            <span class="record-author">
+              <%= author['value'] %> 
+              <% if author['affiliation'].present? %>
+                (<%= author['affiliation'].join %>)
+              <% end %>;
+            </span>
+          <% end %>
+        </span>
+      </p>
+    <% end %>
 
-<%= field_string(@record, 'edition') %>
+    <% # NOTE: link resolver links are not very useful to most of the content in timdex currently. For dspace and all RDI sources, the source link is better than a link resolver link %>
+    <h3 class="section-title">Links</h3>
+    <ul class="list-links">
+      <li>
+        <span class="label">Source:</span> <%= link_to(@record['source'], @record['sourceLink']) %>
+      </li>
 
-<%= field_list(@record, 'fileFormats') %>
+      <% if @record['links'].present? %>
+        <% @record['links'].each do |link| %>
+          <li>
+            <%= link_to(link['text'] || 'unknown', link['url']) %>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
 
-<%= field_string(@record, 'format') %>
+    <% if @record['summary'].present? %>
+      <h3 class="section-title">Summary</h3>
+      <% @record['summary'].each do |paragraph| %>
+        <p>
+          <%= sanitize paragraph, tags: %w(p strong em a), attributes: %w(href) %>
+        </p>
+      <% end %>
+    <% end %>
 
-<%= field_table(@record, 'fundingInformation', %w[award_number award_uri funder_identifier funder_identifier_type funder_name]) %>
+    <h3 class="section-title">More information</h3>
 
-<%= field_table(@record, 'holdings', %w[call_number collection format location note]) %>
+    <ul class="list-moreinfo">
+      <%# pub type%>
 
-<%= field_object(@record, 'identifiers') %>
+      <%# pub info%>
+      <% if @record['publicationInformation'] %>
+        <li>Publication Information: <%= @record['publicationInformation'].join('; ') %></li>
+      <% end %>
 
-<%= field_list(@record, 'languages') %>
+      <%# identifiers %>
+      <% if @record['identifiers'].present? %>
 
-<%= field_table(@record, 'links', %w[kind text url restrictions]) %>
+        <% @record['identifiers'].each do |id| %>
+          <li>
+            <span class="label"><%= id['kind'].upcase %>:</span> 
+            <span class="<%= id['kind']%>"><%= id['value'] %></span>
+          </li>
+        <% end%>
+      <% end %>
 
-<%= field_string(@record, 'literaryForm') %>
+      <%# language %>
+      <% if @record['languages'].present? %>
+        <li>
+          <span class="label"><%= "Language".pluralize(@record['languages'].count) %>:</span> <%= @record['languages'].join(',') %>
+        </li>
+      <% end %>
+    </ul>
 
-<%= field_table(@record, 'locations', %w[kind value geopoint]) %>
+    <%# subjects%>
+    <% if @record['subjects'].present? %>
+      <h3 class="section-title">Subjects</h3>
+        <ul class="list-subjects">
+          <% @record['subjects'].each do |subject| %>
+            <li>
+              <%= "#{subject['kind']}: " if subject['kind'] != "Subject scheme not provided" %>
+              <%= subject['value'].join(', ') %>
+            </li>
+          <% end %>
+        </ul>
+    <% end %>
 
-<%= field_object(@record, 'notes') %>
+    <%# dates%>
+    <% if @record['dates'].present? %>
+      <h3 class="section-title">Dates</h3>
+        <ul class="list-dates">
+          <% @record['dates'].each do |date| %>
+            <li>
+              <%= date['kind'] %>: <%= date_parse(date['value']) %><%= date_range(date['range']) %>
+              <%= " Note: #{date['note']}" if date['note'].present? %>
+            </li>
+          <% end %>
+        </ul>
+    <% end %>
 
-<%= field_string(@record, 'numbering') %>
+    <% if @record['notes'].present? %>
+      <h3 class="section-title">Notes</h3>
+      <% @record['notes'].each do |note| %>
+        <% if note['kind'].present? %>
+          <%= note['kind'] %>:
+        <% end %>
+        <% note['value'].each do |paragraph| %>
+          <%= sanitize paragraph, tags: %w(p strong em a), attributes: %w(href) %>
+        <% end %>
+      <% end %>
+    <% end %>
 
-<%= field_string(@record, 'physicalDescription') %>
+    <% if @record['rights'].present? %>
+      <h3 class="section-title">Rights</h3>
+      <ul>
+      <% @record['rights'].each do |right| %>
+        <li>
+          <% if right['kind'].present? %>
+            <%= right['kind'] %>:
+          <% end %>
+          <% if right['uri'].present? %>
 
-<%= field_list(@record, 'publicationFrequency') %>
+            <% # note: not all URIs are URLs. Only treat URL-like URIs as links. %>
+            <% if right['uri'].start_with?('http')%>
+              <%= link_to(right['uri'], right['uri']) %>
+            <% else %>
+              <%= right['uri'] %>
+            <% end %>
 
-<%= field_list(@record, 'publicationInformation') %>
+          <% end %>
+          <% if right['description'].present? %>
+            <%= right['description'] %>
+          <% end %>
+        </li>
+      <% end %>
+      </ul>
+    <% end %>
 
-<%= field_table(@record, 'relatedItems', %w[description item_type relationship uri]) %>
+    <%= render('misc') %>
+  </div>
 
-<%= field_table(@record, 'rights', %w[description kind uri]) %>
+  <%= render('sidebar') %>
 
-<%= field_string(@record, 'source') %>
+</div>
 
-<%= field_string(@record, 'sourceLink') %>
-
-<%= field_object(@record, 'subjects') %>
-
-<%= field_list(@record, 'summary') %>
-
-<%= field_string(@record, 'timdexRecordId') %>
+<% if params[:debug].present? %>
+  <%= debug(@record) %>
+<% end %>

--- a/app/views/record/_sidebar.html.erb
+++ b/app/views/record/_sidebar.html.erb
@@ -1,0 +1,18 @@
+<div class="col1q-r sidebar">
+  <% if doi(@record) %>
+    <% data_url = "/doi?doi=#{URI.encode_www_form_component(doi(@record))}&slim=true" %>
+
+    <div class="fact-container"
+        data-controller="content-loader"
+        data-content-loader-url-value=<%= data_url %>>
+    </div>
+  <% end %>
+
+  <div class="bit askus">
+    <h3 class="title">Ask Us</h3>
+    <p>Not finding what you're looking for?  We're here to help with anything from quick questions to in-depth research.</p>
+    <p>
+      <a class="btn button-secondary" href="https://libraries.mit.edu/ask/">Ask Us</a>
+    </p>
+  </div>
+</div>

--- a/app/views/record/view.html.erb
+++ b/app/views/record/view.html.erb
@@ -2,6 +2,8 @@
 
 <%= render(partial: 'shared/error', collection: @errors) %>
 
+<%= render(partial: 'search/form')%>
+
 <% if @record.nil? %>
   <%= render('record_empty') %>
 <% else %>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -68,9 +68,10 @@ end
           <select id="advanced-source" class="field field-select" name="source">
             <option></option>
             <option <%= "selected" if params[:source] == "Abdul Latif Jameel Poverty Action Lab Dataverse"%>>Abdul Latif Jameel Poverty Action Lab Dataverse</option>
+            <option <%= "selected" if params[:source] == "DSpace@MIT"%>>DSpace@MIT</option>
+            <option <%= "selected" if params[:source] == "Woods Hole Open Access Server"%>>Woods Hole Open Access Server</option>
             <option <%= "selected" if params[:source] == "Zenodo"%>>Zenodo</option>
             <option>ArchivesSpace@MIT (no data yet)</option>
-            <option>DSpace@MIT (no data yet)</option>
           </select>
           NOTE: to allow selecting multiple sources we need to change the way we handle this in TIMDEX to treat source as an
           "OR" search not "AND"

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -26,16 +26,6 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'full record display includes the record id itself' do
-    needle_id = 'jpal:doi:10.7910-DVN-MNIBOL'
-    VCR.use_cassette('timdex record sample',
-                     allow_playback_repeats: true,
-                     match_requests_on: %i[method uri body]) do
-      get "/record/#{needle_id}"
-      assert_select '#content-main', /(.*)#{needle_id}(.*)/
-    end
-  end
-
   test 'full record display where no record exists displays an error' do
     needle_id = 'there.is.no.record'
     VCR.use_cassette('timdex record no record',

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -20,13 +20,13 @@ class RecordHelperTest < ActionView::TestCase
   test 'field_list returns a single key name and value with one element' do
     sample = {}
     sample['foo'] = ['bar']
-    assert_equal "<h2>Foo</h2><p class='field-list'>bar</p>", field_list(sample, 'foo')
+    assert_equal "<h3>Foo</h3><p class='field-list'>bar</p>", field_list(sample, 'foo')
   end
 
   test 'field_list returns a key name and a list of values with multiple elements' do
     sample = {}
     sample['foo'] = %w[bar baz]
-    assert_equal "<h2>Foo</h2><ul class='field-list'><li>bar</li><li>baz</li></ul>", field_list(sample, 'foo')
+    assert_equal "<h3>Foo</h3><ul class='field-list'><li>bar</li><li>baz</li></ul>", field_list(sample, 'foo')
   end
 
   # - Objects of kind and value
@@ -40,10 +40,10 @@ class RecordHelperTest < ActionView::TestCase
     sample_item['kind'] = 'DOI'
     sample_item['value'] = '10.7910/DVN/48GFKU'
     sample = { 'identifiers' => [sample_item] }
-    assert_equal "<h2>Identifiers</h2><ul class='field-object'><li>DOI: 10.7910/DVN/48GFKU</li></ul>",
+    assert_equal "<h3>Identifiers</h3><ul class='field-object'><li>DOI: 10.7910/DVN/48GFKU</li></ul>",
                  field_object(sample, 'identifiers')
     sample = { 'identifiers' => [sample_item, sample_item] }
-    assert_equal "<h2>Identifiers</h2><ul class='field-object'><li>DOI: 10.7910/DVN/48GFKU</li><li>DOI: 10.7910/DVN/48GFKU</li></ul>",
+    assert_equal "<h3>Identifiers</h3><ul class='field-object'><li>DOI: 10.7910/DVN/48GFKU</li><li>DOI: 10.7910/DVN/48GFKU</li></ul>",
                  field_object(sample, 'identifiers')
   end
 
@@ -53,12 +53,12 @@ class RecordHelperTest < ActionView::TestCase
     # List of one item
     sample_item['value'] = ['loaf of bread']
     sample = { 'shopping' => [sample_item] }
-    assert_equal "<h2>Shopping</h2><ul class='field-object'><li>food: loaf of bread</li></ul>",
+    assert_equal "<h3>Shopping</h3><ul class='field-object'><li>food: loaf of bread</li></ul>",
                  field_object(sample, 'shopping')
 
     sample_item['value'] = ['loaf of bread', 'container of milk', 'stick of butter']
     sample = { 'shopping' => [sample_item] }
-    assert_equal "<h2>Shopping</h2><ul class='field-object'><li>food: <ul><li>loaf of bread</li><li>container of milk</li><li>stick of butter</li></ul></li></ul>",
+    assert_equal "<h3>Shopping</h3><ul class='field-object'><li>food: <ul><li>loaf of bread</li><li>container of milk</li><li>stick of butter</li></ul></li></ul>",
                  field_object(sample, 'shopping')
   end
 
@@ -71,9 +71,9 @@ class RecordHelperTest < ActionView::TestCase
   test 'field_string returns a key name and value in HTML' do
     sample = {}
     sample['foo'] = 'lowercase'
-    assert_equal "<h2>Foo</h2><p class='field-string'>lowercase</p>", field_string(sample, 'foo')
+    assert_equal "<h3>Foo</h3><p class='field-string'>lowercase</p>", field_string(sample, 'foo')
     sample['foo'] = 'Capitalized'
-    assert_equal "<h2>Foo</h2><p class='field-string'>Capitalized</p>", field_string(sample, 'foo')
+    assert_equal "<h3>Foo</h3><p class='field-string'>Capitalized</p>", field_string(sample, 'foo')
   end
 
   # - Tables
@@ -88,7 +88,17 @@ class RecordHelperTest < ActionView::TestCase
     sample_item['bar'] = 'custom'
     sample_item['baz'] = 'order'
     sample = { 'construct' => [sample_item] }
-    assert_equal "<h2>Construct</h2><table><thead><tr><th scope='col'>Bar</th><th scope='col'>Foo</th><th scope='col'>Baz</th></tr></thead><tbody><tr><td>custom</td><td>column</td><td>order</td></tr></tbody></table>",
+    assert_equal "<h3>Construct</h3><table><thead><tr><th scope='col'>Bar</th><th scope='col'>Foo</th><th scope='col'>Baz</th></tr></thead><tbody><tr><td>custom</td><td>column</td><td>order</td></tr></tbody></table>",
                  field_table(sample, 'construct', %w[bar foo baz])
+  end
+
+  test 'field_table returns a table of information using provided label' do
+    sample_item = {}
+    sample_item['foo'] = 'column'
+    sample_item['bar'] = 'custom'
+    sample_item['baz'] = 'order'
+    sample = { 'construct' => [sample_item] }
+    assert_equal "<h3>Hello I am a label</h3><table><thead><tr><th scope='col'>Bar</th><th scope='col'>Foo</th><th scope='col'>Baz</th></tr></thead><tbody><tr><td>custom</td><td>column</td><td>order</td></tr></tbody></table>",
+                 field_table(sample, 'construct', %w[bar foo baz], 'Hello I am a label')
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Our initial implementation focused on getting the information on the
  page. This takes a first pass at organization the information.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-138

How does this address that need:

* implemented a general organization of data by looking back at some
  full record views we had made in Bento, and combining that with a look
  at the data available in TIMDEX, and then making some initial
  decisions on how to display the data

Document any side effects to this change:

* several fields coming back from TIMDEX are still not fully integrated
  into the page and are instead left at the end.
* DSpace and Woods Hole sources were added to the advanced form filter
* Many data fields still need additional work or edge case handling

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
