### PR TITLE
Adds timdex-ui styles for global alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ change as part of the work.
 
 ## Optional Environment Variables
 
-- TBD
+- `GLOBAL_ALERT`: The main functionality for this comes from our theme gem, but when set the value will be rendered as
+  safe html above the main header of the site.
+- `TIMDEX_SOURCES`: Comma-separated list of sources to display in the advanced-search source selection element. This
+  overrides the default which is set in ApplicationHelper.
 
 ### Test Environment-only Variables
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -7,6 +7,7 @@
 @import "partials/_variables";
 @import "partials/_alerts";
 @import "partials/_facets";
+@import "partials/_global_alerts";
 @import "partials/_pagination";
 @import "partials/_panels";
 @import "partials/_search";

--- a/app/assets/stylesheets/partials/_global_alerts.scss
+++ b/app/assets/stylesheets/partials/_global_alerts.scss
@@ -1,0 +1,9 @@
+.wrap-notices {
+  background-color: $blue-bright;
+  text-align: center;
+
+  .title {
+    font-size: $fs-xlarge;
+    line-height: 1.4;
+  }
+}


### PR DESCRIPTION
Note: The PR build has a `GLOBAL_ALERT` set to make reviewing this easier. You can also set one locally, or change it in the PR build to see these changes.


Why are these changes being introduced:

* The global alert in our theme gem expects some alert classes to be the
  version in the gem. However, timdex-ui overrides those styles. Until
  we merge these new styles back to the theme gem, we need to also
  override a bit of the global alert.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-207

How does this address that need:

* Adds a global_alerts scss partial and styles to support global alerts
* Documents in README that `GLOBAL_ALERT` comes from the theme gem

Document any side effects to this change:

* Adds documentation in README for `TIMDEX_SOURCES` which were
  introduced recently and not documented.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
