### PR TITLE
Add context about application

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,7 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ change as part of the work.
 
 ## Optional Environment Variables
 
+- `ABOUT_APP`: If populated, an 'about' partial containing the contents of this variable will render on 
+`basic_search#index`.
 - `GLOBAL_ALERT`: The main functionality for this comes from our theme gem, but when set the value will be rendered as
   safe html above the main header of the site.
 - `TIMDEX_INDEX`: Name of the index, or alias, to provide to the GraphQL endpoint. Defaults to `nil` which will let TIMDEX determine the best index to use. Wildcard values can be set, for example `rdi*` would search any indexes that begin with `rdi` in the underlying OpenSearch instance behind TIMDEX.

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -76,3 +76,8 @@
     }
   }
 }
+
+/* about section */
+.about {
+  margin-top: 5rem;
+}

--- a/app/views/basic_search/index.html.erb
+++ b/app/views/basic_search/index.html.erb
@@ -1,7 +1,6 @@
 <%= content_for(:title, "Search | MIT Libraries") %>
 
 <div class="space-wrap">
-  <p>Herzliche Glückwunsch!</p>
-
   <%= render partial: "search/form" %>
+  <%= render partial: "static/about" if ENV.fetch('ABOUT_APP', nil) %>
 </div>

--- a/app/views/static/_about.html.erb
+++ b/app/views/static/_about.html.erb
@@ -1,0 +1,4 @@
+<div class="about bit">
+  <h3 class="hd-5">About</h3>
+  <%= ENV.fetch('ABOUT_APP', nil).html_safe %>
+</div>


### PR DESCRIPTION
#### Why these changes are being introduced:

We want to provide users with information about the app. This
should be easily configurable, as we are configuring multiple experimental
interfaces under different URLs.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/RDI-213

#### How this addresses that need:

This adds an 'about' partial that renders the content of the
environment variable `ABOUT_APP`.

#### Side effects of this change:

* Storing context about the app in env is a bit messy, but it seems to
be the best approach here.
* A new platform (`x86_64-darwin-21`) was added to Gemfile.lock as a
result of running `bundle install`. Documenting here in case it causes
problems.

#### Developer

- [x] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO (but note side effect of new platform added to `Gemfile.lock`)
