### PR TITLE
Fix name mismatch for fundingInformation

### DIFF
--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -40,7 +40,7 @@ end
 
         <div class="field-wrap">
           <label for="advanced-fundingInformation" class="field-label">Funding information</label>
-          <input type="text" class="field field-text wide" id="advanced-fundingInformation" name="Funding Information" placeholder="Funding information" value=<%= params[:fundingInformation] %>>
+          <input type="text" class="field field-text wide" id="advanced-fundingInformation" name="fundingInformation" placeholder="Funding information" value=<%= params[:fundingInformation] %>>
         </div>
 
         <div class="field-wrap">


### PR DESCRIPTION
#### Why these changes are being introduced:

In the advanced search form, the name attribute for fundingInformation
is incorrectly "Funding information". This passes the wrong field name
to params and causes all fundingInformation searches originating from
the search form to fail.

#### Relevant ticket(s):

N/A.

#### How this addresses that need:

This updates the form partial to use the correct field name.

#### Side effects of this change:

My initial instinct was to write a regression test for this, but it
felt like opening a can of worms to test each input in the advanced
search form. I'd like the reviewer's input on this.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
