### PR TITLE
Display complete input values in advanced search form

### DIFF
--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -30,37 +30,37 @@ end
       <div class="field-container">
         <div class="field-wrap">
           <label for="advanced-citation" class="field-label">Citation</label>
-          <input type="text" class="field field-text wide" id="advanced-citation" name="citation" placeholder="Citation" value=<%= params[:citation] %>>
+          <input type="text" class="field field-text wide" id="advanced-citation" name="citation" placeholder="Citation" value="<%= params[:citation] %>">
         </div>
 
         <div class="field-wrap">
           <label for="advanced-contributors" class="field-label">Contributors</label>
-          <input type="text" class="field field-text wide" id="advanced-contributors" name="contributors" placeholder="Contributors" value=<%= params[:contributors] %>>
+          <input type="text" class="field field-text wide" id="advanced-contributors" name="contributors" placeholder="Contributors" value="<%= params[:contributors] %>">
         </div>
 
         <div class="field-wrap">
           <label for="advanced-fundingInformation" class="field-label">Funding information</label>
-          <input type="text" class="field field-text wide" id="advanced-fundingInformation" name="fundingInformation" placeholder="Funding information" value=<%= params[:fundingInformation] %>>
+          <input type="text" class="field field-text wide" id="advanced-fundingInformation" name="fundingInformation" placeholder="Funding information" value="<%= params[:fundingInformation] %>">
         </div>
 
         <div class="field-wrap">
           <label for="advanced-identifiers" class="field-label">Identifiers</label>
-          <input type="text" class="field field-text wide" id="advanced-identifiers" name="identifiers" placeholder="Identifiers" value=<%= params[:identifiers] %>>
+          <input type="text" class="field field-text wide" id="advanced-identifiers" name="identifiers" placeholder="Identifiers" value="<%= params[:identifiers] %>">
         </div>
 
         <div class="field-wrap">
           <label for="advanced-locations" class="field-label">Locations</label>
-          <input type="text" class="field field-text wide" id="advanced-locations" name="locations" placeholder="Locations" value=<%= params[:locations] %>>
+          <input type="text" class="field field-text wide" id="advanced-locations" name="locations" placeholder="Locations" value="<%= params[:locations] %>">
         </div>
 
         <div class="field-wrap">
           <label for="advanced-subjects" class="field-label">Subjects</label>
-          <input type="text" class="field field-text wide" id="advanced-subjects" name="subjects" placeholder="Subjects" value=<%= params[:subjects] %>>
+          <input type="text" class="field field-text wide" id="advanced-subjects" name="subjects" placeholder="Subjects" value="<%= params[:subjects] %>">
         </div>
 
         <div class="field-wrap">
           <label for="advanced-title" class="field-label">Title</label>
-          <input type="text" class="field field-text wide" id="advanced-title" name="title" placeholder="Title" value=<%= params[:title] %>>
+          <input type="text" class="field field-text wide" id="advanced-title" name="title" placeholder="Title" value="<%= params[:title] %>">
         </div>
 
         <div class="field-wrap list-checkboxes">

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -321,6 +321,36 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'advanced search form retains values with spaces' do
+    VCR.use_cassette('advanced all spaces',
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
+      query = {
+        q: 'some data',
+        citation: 'a citation',
+        contributors: 'some contribs',
+        fundingInformation: 'a fund',
+        identifiers: 'some ids',
+        locations: 'some locs',
+        subjects: 'some subs',
+        title: 'a title',
+        advanced: 'true'
+      }.to_query
+      get "/results?#{query}"
+      assert_response :success
+      assert_nil flash[:error]
+
+      assert_select 'input#basic-search-main', value: 'some data'
+      assert_select 'input#advanced-citation', value: 'a citation'
+      assert_select 'input#advanced-contributors', value:'some contribs'
+      assert_select 'input#advanced-fundingInformation', value: 'a fund'
+      assert_select 'input#advanced-identifiers', value: 'some ids'
+      assert_select 'input#advanced-locations', value: 'some locs'
+      assert_select 'input#advanced-subjects', value: 'some subs'
+      assert_select 'input#advanced-title', value: 'a title'
+    end
+  end
+
   def source_facet_count(controller)
     controller.view_context.assigns['facets']['source'].count
   end

--- a/test/vcr_cassettes/advanced_all_spaces.yml
+++ b/test/vcr_cassettes/advanced_all_spaces.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://FAKE_TIMDEX_HOST/graphql/
+    body:
+      encoding: UTF-8
+      string: '{"query":"query TimdexSearch__Query($q: String, $citation: String,
+        $contributors: String, $fundingInformation: String, $identifiers: String,
+        $locations: String, $subjects: String, $title: String, $sourceFacet: [String!],
+        $index: String, $from: String, $contentType: String) {\n  search(searchterm:
+        $q, citation: $citation, contributors: $contributors, fundingInformation:
+        $fundingInformation, identifiers: $identifiers, locations: $locations, subjects:
+        $subjects, title: $title, sourceFacet: $sourceFacet, index: $index, from:
+        $from, contentTypeFacet: $contentType) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
+        {\n        kind\n        value\n      }\n      publicationInformation\n      dates
+        {\n        kind\n        value\n      }\n      notes {\n        kind\n        value\n      }\n      highlight
+        {\n        matchedField\n        matchedPhrases\n      }\n    }\n    aggregations
+        {\n      contentType {\n        key\n        docCount\n      }\n      source
+        {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"from":"0","q":"some
+        data","citation":"a citation","contributors":"some contribs","fundingInformation":"a
+        fund","identifiers":"some ids","locations":"some locs","subjects":"some subs","title":"a
+        title"},"operationName":"TimdexSearch__Query"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - MIT Libraries Client
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Thu, 28 Jul 2022 17:41:40 GMT
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"88f19da89e3e632cd9bf69fa32cb1045"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 77e3a210-a774-4cbf-aa48-53a705a725ba
+      X-Runtime:
+      - '0.231628'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"search":{"hits":0,"records":[],"aggregations":{"contentType":[],"source":[]}}}}'
+  recorded_at: Thu, 28 Jul 2022 17:41:40 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
#### Why these changes are being introduced:

When the advanced search form is submitted, the full search term
is not retained if it includes a space.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/RDI-237

#### How this addresses that need:

This wraps advanced search value attributes with quotations, so Rails
knows to retain the full param.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
