### PR TITLE
Updates link text for source on record pages

### DIFF
--- a/app/views/record/_record.html.erb
+++ b/app/views/record/_record.html.erb
@@ -59,7 +59,7 @@
     <h3 class="section-title">Links</h3>
     <ul class="list-links">
       <li>
-        <span class="label">Source:</span> <%= link_to(@record['source'], @record['sourceLink']) %>
+        <%= link_to("Item record", @record['sourceLink']) %> in <%= @record['source'] %>
       </li>
 
       <% if @record['links'].present? %>


### PR DESCRIPTION
Why are these changes being introduced:

* As currently displayed, the full record view Source links could be
  interpreted as going to the root of the source repository rather than
  the individual record within the repository and thus might seem of
  little value to end users.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-240

How does this address that need:

* Provides a clearer link label to the Item record in the source

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
