### PR TITLE
Delimit content types in a readable format

### DIFF
--- a/app/views/record/_record.html.erb
+++ b/app/views/record/_record.html.erb
@@ -14,7 +14,7 @@
       <% if @record['contentType'].present? %>
         <span class="record-type">
           <% # we need to create separate displays for different types of content types, see https://github.com/MITLibraries/bento/pull/908/files#diff-6718f9b88f6f93e59d8c2509512dc40a62088430ff3cce1165ab414565949415L22-L57 for starting point but we should anticipate wanting to expand to many more unique content types %>
-          <span class="sr">Type</span> <%= @record['contentType'].join %>
+          <span class="sr">Type</span> <%= @record['contentType'].join(' ; ') %>
         </span>
       <% end %>
 


### PR DESCRIPTION
#### Why these changes are being introduced:

The record view does not join the content type field on a character,
so multiple content types are displayed in an unreadable format.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/RDI-242

#### How this addresses that need:

This joins the content type field on a semicolon to render it
the same as the result view.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
