### PR TITLE
Support multivalue facets

### DIFF
--- a/app/helpers/facet_helper.rb
+++ b/app/helpers/facet_helper.rb
@@ -1,8 +1,21 @@
 module FacetHelper
   def add_facet(query, facet, term)
-    new_query = query.clone
+    new_query = query.deep_dup
     new_query[:page] = 1
-    new_query[facet.to_sym] = term
+
+    # source is being treated as single value in facet application
+    # even though we allow OR-ing multiple sources via advanced search
+    # This might feel somewhat odd, but until we get feedback from UX this
+    # seems like the best solution as each record only has a single source
+    # in the data so there will never be a case to apply multiple in an AND
+    # which is all we support in facet application.
+    if new_query[facet].present? && facet != 'source'
+      new_query[facet] << term
+      new_query[facet].uniq!
+    else
+      new_query[facet] = [term]
+    end
+
     new_query
   end
 
@@ -14,7 +27,7 @@ module FacetHelper
   end
 
   def remove_facet(query, facet)
-    new_query = query.clone
+    new_query = query.deep_dup
     new_query[:page] = 1
     new_query.delete facet.to_sym
     new_query

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -2,9 +2,9 @@ module FormHelper
   def source_checkbox(source, params)
     "<div class='field-subitem'>
       <label class='field-checkbox'>
-        <input type='checkbox' value='#{source}' name='source[]' class='source'#{if params[:source]&.include?(source)
-                                                                                   ' checked'
-                                                                                 end}>
+        <input type='checkbox' value='#{source.downcase}' name='source[]' class='source'#{if params[:source]&.include?(source.downcase)
+                                                                                            ' checked'
+                                                                                          end}>
         #{source}
       </label>
     </div>".html_safe

--- a/app/models/query_builder.rb
+++ b/app/models/query_builder.rb
@@ -2,8 +2,8 @@ class QueryBuilder
   attr_reader :query
 
   RESULTS_PER_PAGE = 20
-  QUERY_PARAMS = %w[q citation contentType contributors fundingInformation identifiers locations subjects title].freeze
-  FILTER_PARAMS = [:source].freeze
+  QUERY_PARAMS = %w[q citation contributors fundingInformation identifiers locations subjects title].freeze
+  FILTER_PARAMS = %i[source contentType].freeze
 
   def initialize(enhanced_query)
     @query = {}
@@ -31,5 +31,6 @@ class QueryBuilder
   def extract_filters(enhanced_query)
     # NOTE: ui and backend naming are not aligned so we can't loop here. we should fix in UI
     @query['sourceFacet'] = enhanced_query[:source]
+    @query['contentType'] = enhanced_query[:contentType]
   end
 end

--- a/test/helpers/facet_helper_test.rb
+++ b/test/helpers/facet_helper_test.rb
@@ -11,7 +11,7 @@ class FacetHelperTest < ActionView::TestCase
     expected_query = {
       page: 1,
       q: 'data',
-      contentType: 'dataset'
+      'contentType' => ['dataset']
     }
     assert_equal expected_query, add_facet(original_query, 'contentType', 'dataset')
   end
@@ -24,9 +24,37 @@ class FacetHelperTest < ActionView::TestCase
     expected_query = {
       page: 1,
       q: 'data',
-      contentType: 'dataset'
+      'contentType' => ['dataset']
     }
     assert_equal expected_query, add_facet(original_query, 'contentType', 'dataset')
+  end
+
+  test 'add_facet can apply multiple values for each facet group' do
+    original_query = {
+      page: 3,
+      q: 'data',
+      'contentType' => ['still image']
+    }
+    expected_query = {
+      page: 1,
+      q: 'data',
+      'contentType' => ['still image', 'dataset']
+    }
+    assert_equal expected_query, add_facet(original_query, 'contentType', 'dataset')
+  end
+
+  test 'add_facet with source value overwrites existing sources' do
+    original_query = {
+      page: 3,
+      q: 'data',
+      'source' => ['source the first', 'source the second']
+    }
+    expected_query = {
+      page: 1,
+      q: 'data',
+      'source' => ['source the only']
+    }
+    assert_equal expected_query, add_facet(original_query, 'source', 'source the only')
   end
 
   test 'nice_labels allows translation of machine categories to human readable headings' do


### PR DESCRIPTION
NOTE: PR build has been updated to have RDI sources. You can see this in the PR build by:
* advanced search
* click search
* click dataset facet
* click still image facet
* confirm the result set is 9 records

Why are these changes being introduced:

* Being able to apply multiple values to a single facet type when
  supported by the data model is important to be able to drill down
  through results

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-241

How does this address that need:

* Updates the facet helper to support arrays of values instead of only
  supporting strings

Document any side effects to this change:

* Updated form helper to downcase sources to match applied facets for
  source to avoid problems with duplicate values being applied
* moved contentType to FILTER_PARAMS as it is a filter and not a query.
  It's not entirely clear what the difference is intended to mean.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
