### PR TITLE
Explicitly specify Heroku stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "timdex-ui",
+  "stack": "heroku-22"
+}


### PR DESCRIPTION
#### Why these changes are being introduced:

We do not currently declare the stack we want to use for PR builds.
This is fine as TIMDEX-UI is already using Heroku 22, but it may
be useful for future stack upgrades.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-180

#### How this addresses that need:

This adds an app.json file that declares the target stack and app
name.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
