### PR TITLE
Support full records without pub_date or id

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -1,6 +1,6 @@
 module RecordHelper
   def doi(metadata)
-    dois = metadata['identifiers'].select { |id| id['kind'].downcase == 'doi' }
+    dois = metadata['identifiers']&.select { |id| id['kind'].downcase == 'doi' }
     return unless dois.present?
 
     dois.first['value']

--- a/app/views/record/_record.html.erb
+++ b/app/views/record/_record.html.erb
@@ -26,7 +26,7 @@
 
       <% else %>
 
-        <% if @record['dates'].map{|date| date if date['kind'] == 'Publication date'}.compact.present? %>
+        <% if @record['dates']&.map{|date| date if date['kind'] == 'Publication date'}&.compact.present? %>
           <span class="record-year">
             : Published <%= date_parse(publication_date(@record)) %>
           </span>

--- a/test/integration/error_resilience_test.rb
+++ b/test/integration/error_resilience_test.rb
@@ -15,4 +15,15 @@ class ErrorResilienceTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  # https://mitlibraries.atlassian.net/browse/TIMX-108
+  # https://timdex-ui-pipeline-dev.herokuapp.com/record/alma:9935254980806761
+  test 'records without publication dates display without errors' do
+    VCR.use_cassette('alma record with no publication date',
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
+      get '/record/alma:9935254980806761'
+      assert_response :success
+    end
+  end
 end

--- a/test/vcr_cassettes/alma_record_with_no_publication_date.yml
+++ b/test/vcr_cassettes/alma_record_with_no_publication_date.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://FAKE_TIMDEX_HOST/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query TimdexRecord__Query($id: String!, $index: String) {\n  recordId(id:
+        $id, index: $index) {\n    alternateTitles {\n      kind\n      value\n    }\n    callNumbers\n    contentType\n    contents\n    contributors
+        {\n      affiliation\n      identifier\n      kind\n      mitAffiliated\n      value\n    }\n    dates
+        {\n      kind\n      note\n      range {\n        gte\n        lte\n      }\n      value\n    }\n    edition\n    fundingInformation
+        {\n      funderName\n      funderIdentifier\n      funderIdentifierType\n      awardUri\n      awardNumber\n    }\n    holdings
+        {\n      callnumber\n      collection\n      format\n      location\n      notes\n      summary\n    }\n    identifiers
+        {\n      kind\n      value\n    }\n    languages\n    links {\n      kind\n      restrictions\n      text\n      url\n    }\n    literaryForm\n    locations
+        {\n      geopoint\n      kind\n      value\n    }\n    notes {\n      kind\n      value\n    }\n    numbering\n    physicalDescription\n    publicationFrequency\n    publicationInformation\n    relatedItems
+        {\n      description\n      itemType\n      relationship\n      uri\n    }\n    rights
+        {\n      description\n      kind\n      uri\n    }\n    source\n    sourceLink\n    subjects
+        {\n      kind\n      value\n    }\n    summary\n    timdexRecordId\n    title\n  }\n}","variables":{"id":"alma:9935254980806761","index":"FAKE_TIMDEX_INDEX"},"operationName":"TimdexRecord__Query"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - MIT Libraries Client
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Tue, 18 Oct 2022 13:36:29 GMT
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"171fd3c2accb1e070d5774672e8abf54"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8e0cbe82-a523-4d9d-ba85-2fc9c0a2d341
+      X-Runtime:
+      - '0.064076'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJkYXRhIjp7InJlY29yZElkIjp7ImFsdGVybmF0ZVRpdGxlcyI6bnVsbCwiY2FsbE51bWJlcnMiOm51bGwsImNvbnRlbnRUeXBlIjpbIk5vdCBzcGVjaWZpZWQiXSwiY29udGVudHMiOm51bGwsImNvbnRyaWJ1dG9ycyI6bnVsbCwiZGF0ZXMiOm51bGwsImVkaXRpb24iOm51bGwsImZ1bmRpbmdJbmZvcm1hdGlvbiI6bnVsbCwiaG9sZGluZ3MiOm51bGwsImlkZW50aWZpZXJzIjpudWxsLCJsYW5ndWFnZXMiOm51bGwsImxpbmtzIjpudWxsLCJsaXRlcmFyeUZvcm0iOm51bGwsImxvY2F0aW9ucyI6bnVsbCwibm90ZXMiOm51bGwsIm51bWJlcmluZyI6bnVsbCwicGh5c2ljYWxEZXNjcmlwdGlvbiI6bnVsbCwicHVibGljYXRpb25GcmVxdWVuY3kiOm51bGwsInB1YmxpY2F0aW9uSW5mb3JtYXRpb24iOm51bGwsInJlbGF0ZWRJdGVtcyI6bnVsbCwicmlnaHRzIjpudWxsLCJzb3VyY2UiOiJNSVQgQWxtYSIsInNvdXJjZUxpbmsiOiJodHRwczovL21pdC5wcmltby5leGxpYnJpc2dyb3VwLmNvbS9kaXNjb3ZlcnkvZnVsbGRpc3BsYXk/dmlkPTAxTUlUX0lOU1Q6TUlUXHUwMDI2ZG9jaWQ9YWxtYTk5MzUyNTQ5ODA4MDY3NjEiLCJzdWJqZWN0cyI6bnVsbCwic3VtbWFyeSI6bnVsbCwidGltZGV4UmVjb3JkSWQiOiJhbG1hOjk5MzUyNTQ5ODA4MDY3NjEiLCJ0aXRsZSI6IkEgbGEgZnJhbmPMp2Fpc2UifX19
+  recorded_at: Tue, 18 Oct 2022 13:36:30 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Why are these changes being introduced:

* Some records don't have publication date information (which is expected)

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-108

How does this address that need:

* Adds nil protection for publication dates

Document any side effects to this change:

* After handling the publication date nil, an error occurred for identifier not being present. I believe this is unexpected and is a result of incomplete Alma mappings in dev1 at this time. Handling nils for identifers seemed fine to include even if the data will likely all include at least one identifier per record.

Sample record to verify the change:
https://timdex-ui-pi-timx-108-p-nalqak.herokuapp.com/record/alma:9935254843506761

If you'd like to see the change locally, make sure you are connected to dev1 graphql and are using the `all-current` alias as your TIMDEX_INDEX and then searching for any alma record should work. Doing the same on the main branch should throw errors.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
