### PR TITLE
Update advanced search language

### DIFF
--- a/app/javascript/search_form.js
+++ b/app/javascript/search_form.js
@@ -6,7 +6,7 @@ function disableAdvanced() {
   );
   keyword_field.setAttribute('placeholder', 'Enter your search');
   advanced_label.classList = 'closed';
-  advanced_label.innerText = 'Show advanced search fields';
+  advanced_label.innerText = 'Advanced search';
 };
 
 function enableAdvanced() {
@@ -14,7 +14,7 @@ function enableAdvanced() {
   keyword_field.setAttribute('aria-required', false);
   keyword_field.setAttribute('placeholder', 'Keyword anywhere');
   advanced_label.classList = 'open';
-  advanced_label.innerText = 'Clear advanced search fields';
+  advanced_label.innerText = 'Close advanced search';
 };
 
 var advanced_field = document.getElementById('advanced-search-field');

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -6,11 +6,11 @@ if params[:q]
 end
 
 # Initial form setup is determined by the advanced parameter. Thereafter it is altered by javascript.
-advanced_label = "Show advanced search fields"
+advanced_label = "Advanced search"
 advanced_label_class = "closed"
 search_required = true
 if params[:advanced] == "true"
-  advanced_label = "Clear advanced search fields"
+  advanced_label = "Close advanced search"
   advanced_label_class = "open"
   search_required = false
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

UXWS has requested that he simplify the language for the advanced search dropdown.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-126

#### How this addresses that need:

This updates the language as requested: "Advanced search" when the dropdown is closed, and "Close advanced search" when it's open.

#### Side effects of this change:

Though it emerged from the GDT UI design work, this is a general enhancement that will apply to all TIMDEX UI apps.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
