### PR TITLE
Update 'no results' partial

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -18,7 +18,7 @@ class SearchController < ApplicationController
     # The @pagination instance variable includes info about next/previous pages (where they exist) to assist the UI.
     @pagination = Analyzer.new(@enhanced_query, response).pagination if @errors.nil?
 
-    # Display stuff
+    # Display results
     @results = extract_results(response)
     @filters = extract_filters(response)
   end
@@ -30,7 +30,10 @@ class SearchController < ApplicationController
   end
 
   def extract_filters(response)
-    response&.data&.search&.to_h&.dig('aggregations')
+    aggs = response&.data&.search&.to_h&.dig('aggregations')
+    return if aggs.blank?
+
+    aggs.select { |_, agg_values| agg_values.present? }
   end
 
   def extract_results(response)

--- a/app/views/search/_result_empty.html.erb
+++ b/app/views/search/_result_empty.html.erb
@@ -1,1 +1,0 @@
-<li>There are no results.</li>

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -48,24 +48,34 @@
 
   <%= render(partial: 'shared/error', collection: @errors) %>
 
-  <div class="layout-1q3q layout-band top-space">
+  <div class="<%= 'layout-1q3q' if @filters.present? %> layout-band top-space">
     <div class="col3q wrap-results">
-      <ul id="results" class="list-unbulleted">
-        <%= render(partial: 'search/result', collection: @results) || render('result_empty') %>
-      </ul>
+      <% if @results.present? %>
+        <ul id="results" class="list-unbulleted">
+          <%= render(partial: 'search/result', collection: @results) %>
+        </ul>
+      <% else %>
+        <div id="results">
+          <p class="hd-2">No results found for your search</p>
+        </div>
+      <% end %>
     </div>
 
-    <aside class="col1q filter-container">
-      <div id="filters">
-        <h2>Available filters</h2>
-        <% @filters&.each do |category, values| %>
-          <%= render(partial: 'search/filter', locals: {category: category, values: values}) %>
-        <% end %>
-      </div>
-    </aside>
+    <% if @filters.present? %>
+      <aside class="col1q filter-container">
+        <div id="filters">
+          <h2>Available filters</h2>
+          <% @filters&.each do |category, values| %>
+            <%= render(partial: 'search/filter', locals: {category: category, values: values}) %>
+          <% end %>
+        </div>
+      </aside>
+    <% end %>
   </div>
 
-  <div id="pagination">  
-    <%= render partial: "pagination" %>
-  </div>
+  <% if @results.present? %>
+    <div id="pagination">  
+      <%= render partial: "pagination" %>
+    </div>
+  <% end %>
 </div>

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -201,13 +201,20 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
                      match_requests_on: %i[method uri body]) do
       get '/results?q=asdfiouwenlasd'
       assert_response :success
+
       # Result list contents state "no results"
       assert_select '#results'
       assert_select '#results', { count: 1 }
-      assert_select '#results li', 'There are no results.'
+      assert_select '#results p', 'No results found for your search'
+
+      # Filter sidebar is not shown
+      assert_select '#filters', { count: 0 }
+
       # Filters are not shown
-      assert_select '#filters'
       assert_select '#filters .category h3', { count: 0 }
+
+      # Pagination is not shown
+      assert_select '#pagination', { count: 0 }
     end
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

When a search returns no results, the filter sidebar should be omitted and the 'no results' text should be larger. This change was requested as part of the GDT project, but it should apply to all TIMDEX UI apps.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-133

#### How this addresses that need:

Updates the 'no results' text and implements the requested styling changes. The filter logic changes a bit to hide the sidebar:

* In the search controller, empty aggregations are no longer extracted from the response.
* In the results view, a few conditionals have been added to hide the filter sidebar, omit the `layout1q3q` class from the results wrapper, and render the 'no results' message as a header rather than a list element.

#### Side effects of this change:

* The results view is somewhat less elegant as a result of these changes.
* It felt strange to me to make the 'no results' message an element in an unordered list, but I'm not sure it's any less so to make it an `h2`. If others agree, I can wrap it in a `p` tag instead with some CSS to add weight.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
