### PR TITLE
Add GDT feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-/db/*.sqlite3
-/db/*.sqlite3-journal
-/db/*.sqlite3-[0-9]*
+/db/*.sqlite3*
 /coverage/
 
 # Ignore all logfiles and tempfiles.

--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,5 @@ group :test do
   gem 'vcr'
   gem 'webmock'
 end
+
+gem 'flipflop', '~> 2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,9 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    flipflop (2.7.1)
+      activesupport (>= 4.0)
+      terminal-table (>= 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     graphql (2.0.27)
@@ -315,6 +318,8 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
     tilt (2.3.0)
     timeout (0.4.1)
@@ -361,6 +366,7 @@ DEPENDENCIES
   climate_control
   debug
   dotenv-rails
+  flipflop (~> 2.7)
   graphql (~> 2.0.27)
   graphql-client
   http

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ change as part of the work.
 
 - `ABOUT_APP`: If populated, an 'about' partial containing the contents of this variable will render on 
 `basic_search#index`.
+- `GDT`: Enables features related to geospatial data discovery. Setting this variable with any value will trigger GDT
+mode (e.g., `GDT=false` will still enable GDT features). Note that this is currently intended _only_ for the GDT app and
+may have unexpected consequences if applied to other TIMDEX UI apps.
 - `GLOBAL_ALERT`: The main functionality for this comes from our theme gem, but when set the value will be rendered as
   safe html above the main header of the site.
 - `SENTRY_DSN`: Client key for Sentry exception logging.

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,14 @@ Bundler.require(*Rails.groups)
 
 module TimdexUi
   class Application < Rails::Application
+    # Before filter for Flipflop dashboard. Replace with a lambda or method name
+    # defined in ApplicationController to implement access control.
+    config.flipflop.dashboard_access_filter = -> { head :forbidden }
+
+    # By default, when set to `nil`, strategy loading errors are suppressed in test
+    # mode. Set to `true` to always raise errors, or `false` to always warn.
+    config.flipflop.raise_strategy_errors = nil
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,14 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
+  # By default, when set to `nil`, strategy loading errors are suppressed in test
+  # mode. Set to `true` to always raise errors, or `false` to always warn.
+  config.flipflop.raise_strategy_errors = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,14 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
+  # By default, when set to `nil`, strategy loading errors are suppressed in test
+  # mode. Set to `true` to always raise errors, or `false` to always warn.
+  config.flipflop.raise_strategy_errors = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,9 @@
+Flipflop.configure do
+  # Strategies will be used in the order listed here.
+  strategy :session
+  strategy :default
+
+  feature :gdt,
+    default: ENV.fetch('GDT', false),
+    description: "Enable geodata discovery features."
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount Flipflop::Engine => "/flipflop"
   root "basic_search#index"
 
   get 'doi', to: 'fact#doi'

--- a/db/migrate/20240130222044_create_features.rb
+++ b/db/migrate/20240130222044_create_features.rb
@@ -1,0 +1,10 @@
+class CreateFeatures < ActiveRecord::Migration[7.1]
+  def change
+    create_table :flipflop_features do |t|
+      t.string :key, null: false
+      t.boolean :enabled, null: false, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_30_222044) do
+  create_table "flipflop_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.boolean "enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

We need a way to toggle GDT features, so we can manage non-GDT TIMDEX UI apps alongside it.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/GDT-157

#### How this addresses that need:

This adds the `flipflop` gem and a GDT feature.

#### Side effects of this change:

The `flipflop` gem doesn't appear to be very actively maintained these days. We'll want to keep an eye on that and, if it gets abandoned, consider switching to something like `flipper`.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod **(added to `timdex-ui-stage` as well as `timdex-ui-gdt` (prod), since we will likely be using stage for GDT for a while)**
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

YES
