### PR TITLE
Redesign local nav for GDT

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -8,6 +8,7 @@
 @import "partials/_alerts";
 @import "partials/_filters";
 @import "partials/_global_alerts";
+@import "partials/_local_nav";
 @import "partials/_pagination";
 @import "partials/_panels";
 @import "partials/_search";

--- a/app/assets/stylesheets/partials/_local_nav.scss
+++ b/app/assets/stylesheets/partials/_local_nav.scss
@@ -1,0 +1,42 @@
+.wrap-outer-header-local {
+  .local-identity {
+    padding: 1rem 0;
+  }
+
+  .wrap-header-local {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+
+    .wrap-local-nav {
+      margin: 0;
+
+      .local-nav {
+        display: flex;
+        font-weight: $fw-bold;
+
+        .wrap-gis-links {
+          text-align: right;
+          margin-left: auto;
+
+          :first-child:after {
+            margin: 0 5px;
+          }
+
+          .nav-item {
+            padding-left: 5px;
+            padding-right: 5px;
+            margin: 0;
+            text-decoration: underline;
+            &:hover,
+            &:active,
+            &:focus {
+              transition: all .25s ease-in-out 0s;
+              color: $brand-primary-accent;
+              background-color: #fff;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -1,14 +1,21 @@
 <div class="wrap-outer-header-local layout-band">
   <div class="wrap-header-local">
-    <div class="local-identity">
-      <h2 class="title title-site"><a href="/">TIMDEX UI</a></h2>
-    </div>
-    <div class="wrap-local-nav">
-      <div class="wrap-bar">
-        <nav class="local-nav" aria-label="Main menu">
-          <%= nav_link_to("Home", root_path) %>
-        </nav>
+    <% unless ENV['PLATFORM_NAME'] %>
+      <div class="local-identity">
+        <h2 class="title title-site"><a href="/">TIMDEX UI</a></h2>
       </div>
+    <% end %>
+    <div class="wrap-local-nav">
+      <nav class="local-nav" aria-label="Main menu">
+        <%= nav_link_to("Home", root_path) %>
+        <% if Flipflop.enabled?(:gdt) %>
+          <div class="wrap-gis-links">
+            <%= nav_link_to("GIS at MIT", "https://libraries.mit.edu/gis") %>
+            <span class="nav-divider" aria-hidden="true">|</span>
+            <%= nav_link_to("Ask GIS", "https://libraries.mit.edu/ask-gis") %>
+          </div>
+        <% end %>
+      </nav>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### Why these changes are being introduced:

The Geodata app requires links to GIS resources at MIT in the local nav. It also no longer requires the app name in the local nav, as GDT-125 moved this to the main header.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-125
* https://mitlibraries.atlassian.net/browse/GDT-124

#### How this addresses that need:

This updates the local nav as specified, provided the GDT feature is enabled.

#### Side effects of this change:

We will likely want to remove the app name from the local nav in all our applications and use the new method provided by the theme gem instead. However, it is out of scope of this ticket (and project) to make that decision, so I've left it in for now.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
