### PR TITLE
Add site title partial

### DIFF
--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -6,7 +6,7 @@
 .basic-search {
   background-color: #989898;
   margin-bottom: 0rem;
-  padding: 1.6rem 2rem;
+  padding: 2.4rem 2rem 1rem 2.4rem;
 
   details {
     margin-top: 1rem;

--- a/app/views/basic_search/index.html.erb
+++ b/app/views/basic_search/index.html.erb
@@ -1,6 +1,7 @@
 <%= content_for(:title, "Search | MIT Libraries") %>
 
 <div class="space-wrap">
+  <%= render partial: "shared/site_title" %>
   <%= render partial: "search/form" %>
   <%= render partial: "static/about" if ENV.fetch('ABOUT_APP', nil) %>
 </div>

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -1,10 +1,5 @@
 <div class="wrap-outer-header-local layout-band">
   <div class="wrap-header-local">
-    <% unless ENV['PLATFORM_NAME'] %>
-      <div class="local-identity">
-        <h2 class="title title-site"><a href="/">TIMDEX UI</a></h2>
-      </div>
-    <% end %>
     <div class="wrap-local-nav">
       <nav class="local-nav" aria-label="Main menu">
         <%= nav_link_to("Home", root_path) %>

--- a/app/views/record/view.html.erb
+++ b/app/views/record/view.html.erb
@@ -2,6 +2,7 @@
 
 <%= render(partial: 'shared/error', collection: @errors) %>
 
+<%= render(partial: 'shared/site_title') %>
 <%= render(partial: 'search/form')%>
 
 <% if @record.nil? %>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -19,7 +19,7 @@ end
 
 <form id="basic-search" class="form-horizontal basic-search" action="<%= results_path %>" method="get">
   <div class="form-group">
-    <label for="basic-search-main" class="field-label"><%= label %></label>
+    <label for="basic-search-main" class="field-label" title="<%= label %>" />
     <input id="basic-search-main" type="search" class="field field-text basic-search-input <%= "required" if search_required %>" name="q" placeholder="Enter your search" value="<%= params[:q] %>" <%= 'required="required" aria-required="true"' if search_required %>>
     <div class="basic-search-submit">
       <button type="submit" class="btn button-primary">Search</button>

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -1,6 +1,8 @@
 <%= content_for(:title, "Search Results | MIT Libraries") %>
 
 <div class="space-wrap">
+
+  <%= render partial: "shared/site_title" %>
   <%= render partial: "form" %>
   <%= render partial: "search_summary" %>
 

--- a/app/views/shared/_site_title.html.erb
+++ b/app/views/shared/_site_title.html.erb
@@ -1,0 +1,6 @@
+<% if Flipflop.enabled?(:gdt) %>
+  <h1 class="hd-2">Search for Geographic/GIS data</h1>
+  <p>Find GIS data held at MIT and other universities</p>
+<% else %>
+  <h1 class="hd-2">Search the MIT Libraries</h1>
+<% end %>

--- a/app/views/static/_forms.html.erb
+++ b/app/views/static/_forms.html.erb
@@ -1,5 +1,5 @@
 <%
-  label = "Search the MIT Libraries"
+  label = "Enter your search"
   button = "Search"
 %>
 <form id="basic-search" class="form-horizontal basic-search" action="/results" method="get">


### PR DESCRIPTION
#### Why these changes are being introduced:

The GeoData visual design includes a heading at the top of each
page, along with some descriptive text.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/GDT-182

#### How this addresses that need:

This adds the requested element as a partial, with conditional
copy for GDT versus non-GDT applications. It also moves the label text
to the `title` attribute, as the label is is now visually redundant but
may still be useful to screen reader users.

#### Side effects of this change:

* The input label before form submit is now the same as the placeholder
text. This feels fine since screen readers might not read placeholder
text, but they do consistently rely on labels.
* The copy for non-GDT titles did not come from UXWS and is subject
to change.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
