### PR TITLE
Toward replicating fact architecture for searches

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,8 @@
 class SearchController < ApplicationController
   before_action :validate_q!, only: %i[results]
 
+  layout false
+
   def results
     # hand off to Enhancer chain
     @enhanced_query = Enhancer.new(params).enhanced_query

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,3 +1,19 @@
 class StaticController < ApplicationController
   def style_guide; end
+
+  def results
+    @internal = internal_params
+  end
+
+  private
+
+    # TODO: More rigorously handle the validation of parameters for this request. The @internal instance variable will
+    # then be routed through the to_query method for the request to the internal search handler.
+    #
+    # This is duplicative of the validation in the search controller, but there should be a way to abstract that
+    # validation to a shared method somewhere.
+    def internal_params
+      params.permit(:q, :advanced, :citation)
+        .to_h { |key, value| [:"#{key}", value] }
+    end
 end

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -1,55 +1,48 @@
-<%= content_for(:title, "Search Results | MIT Libraries") %>
+<%= render partial: "search_summary" %>
 
-<div class="space-wrap">
-
-  <%= render partial: "shared/site_title" %>
-  <%= render partial: "form" %>
-  <%= render partial: "search_summary" %>
-
-  <div id="hint" aria-live="polite">
-    <%= render(partial: 'search/issn') %>
-    <%= render(partial: 'search/isbn') %>
-    <%= render(partial: 'search/pmid') %>
-    <%= render(partial: 'search/doi') %>
-  </div>
-
-  <%= render(partial: 'shared/error', collection: @errors) %>
-
-  <div class="<%= @filters.present? ? 'layout-1q3q' : 'layout-3q1q' %> layout-band top-space">
-    <% if @filters.present? %>
-      <aside class="col1q filter-container">
-        <div id="filters">
-          <h2 class="hd-3">Filter your results</h2>
-          <h3 class="hd-4"><em><%= results_summary(@pagination[:hits]) %></em></h3>
-          <% @filters&.each_with_index do |(category, values), index| %>
-            <% if index == 0 %>
-              <%= render(partial: 'search/filter', locals: { category: category, values: values, first: true }) %>
-            <% else %>
-              <%= render(partial: 'search/filter', locals: { category: category, values: values, first: false }) %>
-            <% end %>
-          <% end %>
-        </div>
-        <%= render partial: 'shared/ask', locals: { display: 'view-lg' } %>
-      </aside>
-    <% end %>
-
-    <div class="col3q wrap-results">
-      <% if @results.present? %>
-        <ul id="results" class="list-unbulleted">
-          <%= render(partial: 'search/result', collection: @results) %>
-        </ul>
-      <% else %>
-        <div id="results" class="no-results">
-          <p class="hd-2">No results found for your search</p>
-        </div>
-      <% end %>
-    </div>
-    <%= render partial: 'shared/ask', locals: { display: 'aside' } if @results.blank? %>
-
-  <% if @results.present? %>
-    <div id="pagination">  
-      <%= render partial: "pagination" %>
-    </div>
-    <%= render partial: 'shared/ask', locals: { display: 'view-md' } %>
-  <% end %>
+<div id="hint" aria-live="polite">
+  <%= render(partial: 'search/issn') %>
+  <%= render(partial: 'search/isbn') %>
+  <%= render(partial: 'search/pmid') %>
+  <%= render(partial: 'search/doi') %>
 </div>
+
+<%= render(partial: 'shared/error', collection: @errors) %>
+
+<div class="<%= @filters.present? ? 'layout-1q3q' : 'layout-3q1q' %> layout-band top-space">
+  <% if @filters.present? %>
+    <aside class="col1q filter-container">
+      <div id="filters">
+        <h2 class="hd-3">Filter your results</h2>
+        <h3 class="hd-4"><em><%= results_summary(@pagination[:hits]) %></em></h3>
+        <% @filters&.each_with_index do |(category, values), index| %>
+          <% if index == 0 %>
+            <%= render(partial: 'search/filter', locals: { category: category, values: values, first: true }) %>
+          <% else %>
+            <%= render(partial: 'search/filter', locals: { category: category, values: values, first: false }) %>
+          <% end %>
+        <% end %>
+      </div>
+      <%= render partial: 'shared/ask', locals: { display: 'view-lg' } %>
+    </aside>
+  <% end %>
+
+  <div class="col3q wrap-results">
+    <% if @results.present? %>
+      <ul id="results" class="list-unbulleted">
+        <%= render(partial: 'search/result', collection: @results) %>
+      </ul>
+    <% else %>
+      <div id="results" class="no-results">
+        <p class="hd-2">No results found for your search</p>
+      </div>
+    <% end %>
+  </div>
+  <%= render partial: 'shared/ask', locals: { display: 'aside' } if @results.blank? %>
+
+<% if @results.present? %>
+  <div id="pagination">
+    <%= render partial: "pagination" %>
+  </div>
+  <%= render partial: 'shared/ask', locals: { display: 'view-md' } %>
+<% end %>

--- a/app/views/static/results.html.erb
+++ b/app/views/static/results.html.erb
@@ -1,0 +1,17 @@
+<%= content_for(:title, "Search Results | MIT Libraries") %>
+
+<% data_url = "/internal?#{@internal.to_query}" %>
+
+<div class="space-wrap">
+
+  <%= render partial: "shared/site_title" %>
+  <%= render partial: "search/form" %>
+
+  <div class="result-container top-space"
+    id="result-container"
+    data-controller="content-loader"
+    data-content-loader-url-value=<%= data_url %>>
+    <p>Your search is being completed...</p>
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,12 @@ Rails.application.routes.draw do
   get 'issn', to: 'fact#issn'
   get 'pmid', to: 'fact#pmid'
 
+  get 'internal', to: 'search#results', as: 'internal'
+
   get 'record/(:id)',
       to: 'record#view',
       as: 'record',
       :constraints => { :id => /[0-z\.\-\_~\(\)]+/ }
-  get 'results', to: 'search#results'
   get 'style-guide', to: 'static#style_guide'
+  get 'results', to: 'static#results'
 end


### PR DESCRIPTION
** Why are these changes being introduced:

* The TIMDEX API responses can be quite slow at times, and the response of the application can be frustrating to users when that happens. The browsers' page-loading indications can be subtle, and users now expect more prominent confirmation that their request has been received.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/gdt-143

** How does this address that need:

THIS IS A WORK IN PROGRESS, NOT A FINISHED COMMIT.

* This implements a loading-status message by replacing our search architecture (directly loading results and including them in the first meaningful response to the user) with the approach taken in our fact panels - using a data controller for the search results, while moving the search results to the static page controller.

* The tests are broken, because this is only a partial implementation.

** Document any side effects to this change:

* I am committing these changes and sharing now, because I want a point of comparison with an alternative approach - using turbo frames. The point I've reached here is to now need to replicate the request validation in the static page controller (or to abstract out the validation from the search controller to something called both by search and static controllers). This feels icky, so we are going to see if turbo feels better.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES | NO

#### Includes new or updated dependencies?

YES | NO
