### PR TITLE
Make default progress indicator more prominent

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,7 @@
 @import "partials/_local_nav";
 @import "partials/_pagination";
 @import "partials/_panels";
+@import "partials/_progress_bar";
 @import "partials/_search";
 @import "partials/_results";
 @import "partials/_typography";

--- a/app/assets/stylesheets/partials/_progress_bar.scss
+++ b/app/assets/stylesheets/partials/_progress_bar.scss
@@ -1,0 +1,4 @@
+.turbo-progress-bar {
+  background: linear-gradient(to right, #000, #fff);
+  height: 75px;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+// Show the progress bar after 200 milliseconds, not the default 500
+Turbolinks.setProgressBarDelay(200)


### PR DESCRIPTION
### Why are these changes being introduced:

* Our application may already be showing a progress indicator that comes with Rails, but the default rendering is very subtle (only three px high). We want to make this more prominent.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/gdt-143

### How does this address that need:

This makes two changes:

* Sets the threshold for showing the progress to bar to 200 milliseconds instead of the default 500. This will result in users seeing the progress bar more quickly while waiting for a slightly slow page load, which should give them greater assurance that the application is working on a response.

* Once shown, the progress bar is now 75 pixels tall, rather than 3. This is the height of the black navbar at the top of the page, which should make the progress bar much harder to miss when it appears.

### Document any side effects to this change:

This isn't a side effect, but an issue I've become aware of which I can't change at the moment: the default progress bar which Turbo uses is not particularly accessible to screen readers, which means that the "visual indicator of progress happening" is exactly that - purely visual. The screen reader experience while the indicator moves is completely silent.

This is not a new behavior with this change, so it isn't a regression - but it is an example an improvement for one audience not being extended to other audiences. I'm not sure whether this should be enough to block this PR from merging.

The level of effort to make this solution accessible for all audiences would be something like these options:

* Write some javascript to augment the default markup with more accessible markup (aria roles, etc)
* Contribute upstream to turbo-rails to replace the `div` being used by Turbo with more accessible markup
* Look for an existing gem that has already augmented the default markup (I've done some brief searching for such a gem, but nothing immediately jumped out at me)
 
### Developer

#### ENV
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] No ENV needs to change

#### A11y
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] The change does not introduce a new accessibility problem, but I
      recognize that it does not address an existing a11y problem. See commit and
      PR text for details.

#### Stakeholders
- [ ] Stakeholder approval has been confirmed (or is not needed)
- [x] Stakeholder approval will happen during QA

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO

### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

