### PR TITLE
Reduce size and overlap of result titles

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -25,15 +25,16 @@
   border-top: 1px solid $brand-primary;
   font-size: $fs-small;
 
-  /* Adding hd-2 styling for order markers to match result titles */
   &::marker {
-    font-size: $fs-xxlarge;
-    line-height: $lh-tight;
+    font-size: 2.5rem;
+    line-height: 1.1;
     font-weight: $fw-bold;
   }
 
   .record-title {
     display: inline;
+    font-size: 2.5rem;
+    line-height: 1.1;
   }
 
   &:hover,
@@ -83,5 +84,10 @@
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+  }
+
+  .inner-heading {
+    font-size: 1.8rem;
+    line-height: 1.1;
   }
 }

--- a/app/assets/stylesheets/partials/_shared.scss
+++ b/app/assets/stylesheets/partials/_shared.scss
@@ -1,7 +1,7 @@
 .result,
 .full-record {
   .authors {
-    font-size: $fs-large;
+    font-size: 1.8rem;
     font-weight: $fw-bold;
     margin-bottom: 0.6em;
   }

--- a/app/views/search/_highlights.html.erb
+++ b/app/views/search/_highlights.html.erb
@@ -1,7 +1,7 @@
 <% highlights = trim_highlights(result) %>
 <% return unless highlights&.any? %>
 
-<h3 class="hd-6">Other fields matching your search:</h3>
+<h3 class="inner-heading">Other fields matching your search:</h3>
 <ul class="list-unbulleted truncate-list">
   <% highlights.each do |h| %>
     <% h['matchedPhrases'].each do |phrase| %>


### PR DESCRIPTION
Why these changes are being introduced:

This was suggested by UXWS as a visual design improvement.

Relevant ticket(s):

* [GDT-238](https://mitlibraries.atlassian.net/browse/GDT-238)
* [GDT-215](https://mitlibraries.atlassian.net/browse/GDT-215)

How this addresses that need:

This changes the result titles, authors, and highlights heading to the suggested sizes.

Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

Though it's not a new issue, running WAVE this time reminded me that it gets confused by the authors list, thinking it should be a heading. Most likely, that section *should* have a heading; it should probably also be an unordered list rather than a series of `a` tags within a `p` tag. I'm not sure whether this is the sort of thing that should be ticketed at this point, or if it should just wait for a11y review.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

I was originally going to stick to style guide variables as much as possible, but TIMDEX UI overrides those [based on UX work done in RDI](https://github.com/MITLibraries/timdex-ui/commit/229ea477b91a399329044f0a7077cffabb808c9d), and the overridding typography is further from Darcy's suggestions than that of the style guide.

There may be a discussion to have about whether the local typography overrides are still relevant. At this point, I'm reluctant to remove them because they are based in research, but I also can't use them for this particular change. I would also be happy to acknowledge that this is an exception and continue as-is.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-238]: https://mitlibraries.atlassian.net/browse/GDT-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDT-215]: https://mitlibraries.atlassian.net/browse/GDT-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ