### PR TITLE
Adjust font size for authors element

### DIFF
--- a/app/assets/stylesheets/partials/_shared.scss
+++ b/app/assets/stylesheets/partials/_shared.scss
@@ -1,7 +1,7 @@
 .result,
 .full-record {
   .authors {
-    font-size: 1.8rem;
+    font-size: 1.6rem;
     font-weight: $fw-bold;
     margin-bottom: 0.6em;
   }


### PR DESCRIPTION
#### Why these changes are being introduced:

This is a follow-on request for GDT-238 that Darcy suggested and
I enthusiastically support.

#### Relevant ticket(s):

* [GDT-238](https://mitlibraries.atlassian.net/browse/GDT-238)

#### How this addresses that need:

This reduces the font size for authors to 1.6rem.

#### Side effects of this change:

While reviewing this, Darcy noticed a bug in iOS where the second
line of an ordered list element appears to have top padding. We
opened [GDT-246](https://mitlibraries.atlassian.net/browse/GDT-246)
to explore this further.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Ignore the many force-pushes and deploys on this PR. I was using the PR builds in draft mode to check potential solutions to the aforementioned iOS bug.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-238]: https://mitlibraries.atlassian.net/browse/GDT-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDT-246]: https://mitlibraries.atlassian.net/browse/GDT-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ