### PR TITLE
Relabel source values for GDT

### DIFF
--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -33,6 +33,16 @@ module FilterHelper
     }
   end
 
+  def gdt_sources(value, category)
+    return value if category != :sourceFilter
+
+    return 'Non-MIT institutions' if value == 'opengeometadata gis resources'
+
+    return 'MIT' if value == 'mit gis resources'
+
+    value
+  end
+
   def remove_filter(query, filter, term)
     new_query = query.deep_dup
     new_query[:page] = 1

--- a/app/views/search/_filter.html.erb
+++ b/app/views/search/_filter.html.erb
@@ -8,14 +8,16 @@
     <ul class="category-terms list-unbulleted">
     <% values.each do |term| %>
       <li class="term">
-        <% if filter_applied?(@enhanced_query[category.to_sym], term['key']) %>
+        <% if filter_applied?(@enhanced_query[category], term['key']) %>
           <a href="<%= results_path(remove_filter(@enhanced_query, category, term['key'])) %>" class="applied">
           <span class="sr">Remove applied filter:</span>
         <% else %>
           <a href="<%= results_path(add_filter(@enhanced_query, category, term['key'])) %>">
           <span class="sr">Apply filter:</span>
         <% end %>
-          <span class="name"><%= term['key'] %></span>
+          <% if Flipflop.enabled?(:gdt) %>
+            <span class="name"><%= gdt_sources(term['key'], category) %></span>
+          <% end %>
           <span class="count"><%= term['docCount'] %> <span class="sr">records</span></span>
         </a>
       </li>

--- a/app/views/search/_search_summary.html.erb
+++ b/app/views/search/_search_summary.html.erb
@@ -6,7 +6,12 @@
   <% applied_filters.each do |filter| %>
     <li>
       <a href="<%= results_path(remove_filter(@enhanced_query, filter.keys[0], filter.values[0])) %>">
-        <%= "#{nice_labels[filter.keys[0]] || filter.keys[0]}: #{filter.values[0]}" %>
+        <%= "#{nice_labels[filter.keys[0]] || filter.keys[0]}:" %>
+        <% if Flipflop.enabled?(:gdt) %>
+          <%= "#{gdt_sources(filter.values[0], filter.keys[0])}" %>
+        <% else %>
+          <%= "#{filter.values[0]}" %>
+        <% end %>
         <span class="sr">Remove applied filter?</span>
       </a>
     </li>

--- a/test/helpers/filter_helper_test.rb
+++ b/test/helpers/filter_helper_test.rb
@@ -182,4 +182,21 @@ class FilterHelperTest < ActionView::TestCase
     }
     assert_equal [{ contentTypeFilter: 'dataset' }], applied_filters
   end
+
+  test 'gdt_sources returns the source label we want for MIT stuff' do
+    assert_equal 'MIT', gdt_sources('mit gis resources', :sourceFilter)
+  end
+
+  test 'gdt_sources returns the source label we want for non-MIT stuff' do
+    assert_equal 'Non-MIT institutions', gdt_sources('opengeometadata gis resources', :sourceFilter)
+  end
+
+  test 'gdt_sources returns the source label as-is if we have no translation for it' do
+    assert_equal 'geodude', gdt_sources('geodude', :sourceFilter)
+  end
+
+  test 'gdt_sources returns the label as-is for non-source filters' do
+    assert_equal 'me', gdt_sources('me', :contributorsFilter)
+    assert_equal 'GIS', gdt_sources('GIS', :subjectsFilter)
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

GDT needs to provide users the option to toggle between MIT and non-MIT results. The source filter is reasonable solution for MVP, but the current values are not intuitively named.

#### Relevant ticket(s):

* [GDT-245](https://mitlibraries.atlassian.net/browse/GDT-245)

#### How this addresses that need:

This adds a `gdt_sources` method in the filter helper that is a lookup hash that translates the two GDT sources. If the GDT feature is enabled, then source values are translated to the desired labels in the filter panel and sidebar.

#### Side effects of this change:

* There was a lingering `to_sym` coercion in the filter partial. I removed it, as it is no longer need after last month's filter redesign. Its removal is unrelated to this change.
* This was a bit tricky to test. Because geo search is currently siloed, I can't confirm that non-GDT sources remain unaffected when the GDT feature is enabled. For now, the filter helper and single search controller test will have to suffice, but it makes me a bit nervous to leave untested conditional logic in the view layer.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

See 'side effects' in commit message and above.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-245]: https://mitlibraries.atlassian.net/browse/GDT-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ