### PR TITLE
Address UX feedback on GDT result view

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -7,16 +7,15 @@
   background-color: $white-t;
   padding: 15px;
 
+  @media (max-width: $bp-screen-md) {
+    padding: 0px;
+  }
   .no-results {
     margin-left: -15px;
   }
 
   .no-results + .ask-us {
     margin-top: 0rem;
-  }
-
-  #results {
-    list-style-position: inside;
   }
 }
 
@@ -32,7 +31,6 @@
   }
 
   .record-title {
-    display: inline;
     font-size: 2.5rem;
     line-height: 1.1;
   }
@@ -69,11 +67,17 @@
     }
   }
 
-  .result-get {
+  .result-get,
+  .result-record {
     padding-top: 5px;
     a:visited {
       color: $white;
-      background-color:  green;
+    }
+  }
+
+  .result-get {
+    a:visited {
+      background-color: $brand-secondary;
     }
   }
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -12,11 +12,11 @@ module SearchHelper
   def view_online(result)
     return unless result['sourceLink'].present?
 
-    link_to 'View online', result['sourceLink'], class: 'button button-primary green'
+    link_to 'View online', result['sourceLink'], class: 'button button-primary'
   end
 
   def view_record(record_id)
-    link_to 'View full record', record_path(id: record_id), class: 'button button-primary green'
+    link_to 'View full record', record_path(id: record_id), class: 'button button-primary'
   end
 
   # 'Coverage' and 'issued' seem to be the most prevalent types; 'coverage' is typically formatted as

--- a/app/views/search/_result_geo.html.erb
+++ b/app/views/search/_result_geo.html.erb
@@ -25,7 +25,7 @@
     </div>
   <% end %>
 
-  <div class="result-get">
+  <div class="result-record">
     <%= view_record(result_geo['timdexRecordId']) %>
   </div>
 </li>

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1048,7 +1048,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
 
         record_id = controller.view_assigns['results'].first['timdexRecordId']
-        assert_select '.result-get a', href: '/record/#{record_id}', text: 'View full record'
+        assert_select '.result-record a', href: '/record/#{record_id}', text: 'View full record'
       end
     end
   end

--- a/test/helpers/search_helper_test.rb
+++ b/test/helpers/search_helper_test.rb
@@ -28,7 +28,7 @@ class SearchHelperTest < ActionView::TestCase
 
   test 'renders view_online link if sourceLink is present' do
     result = { 'title' => 'A record', 'sourceLink' => 'https://example.org' }
-    assert_equal '<a class="button button-primary green" href="https://example.org">View online</a>',
+    assert_equal '<a class="button button-primary" href="https://example.org">View online</a>',
                  view_online(result)
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

This responds to UX feedback on GDT-130 (result view for GDT).

#### Relevant ticket(s):

* [GDT-130](https://mitlibraries.atlassian.net/browse/GDT-130)

#### How this addresses that need:

This removes result padding in smaller viewports, moves result markers outside of the titles, changes full record link hover/focus color to blue, and removes the visited styling for full record links.

The visited styling remains for 'View online' links in other TIMDEX UI apps, as these are outlinks to the source record. The GDT links go to the full record, which is already indicated as visited in the title link, so it doesn't feel critical to add visited styling to the button as well.

#### Side effects of this change:

[GDT-248](https://mitlibraries.atlassian.net/browse/GDT-248) has been opened to address some feedback on the result highlight labels.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

N/A

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-130]: https://mitlibraries.atlassian.net/browse/GDT-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GDT-248]: https://mitlibraries.atlassian.net/browse/GDT-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ