### PR TITLE
Move results context from filter sidebar to results container

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -17,6 +17,14 @@
   .no-results + .ask-us {
     margin-top: 0rem;
   }
+  
+  .results-context {
+    margin-top: -15px;
+    padding-left: 2.5rem;
+    @media (max-width: $bp-screen-md) {
+      margin-top: 0;
+    }
+  }
 }
 
 .result {

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,5 +1,5 @@
 module ResultsHelper
   def results_summary(hits)
-    hits.to_i >= 10_000 ? '10,000+ items' : "#{number_with_delimiter(hits)} items"
+    hits.to_i >= 10_000 ? '10,000+ results' : "#{number_with_delimiter(hits)} results"
   end
 end

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -19,11 +19,10 @@
   <div class="<%= @filters.present? ? 'layout-1q3q' : 'layout-3q1q' %> layout-band top-space">
     <% if @filters.present? %>
       <aside id="filters" class="col1q">
-        <button id="filter-toggle"><span class="filter-toggle-name">Filter your results: <%= results_summary(@pagination[:hits]) %></span><span class="filter-toggle-hide">Hide filters</span></button>
+        <button id="filter-toggle"><span class="filter-toggle-name">Filter your results</span><span class="filter-toggle-hide">Hide filters</span></button>
         <div id="filter-container" class="hidden-md">
           <div class="hidden-md">
             <h2 class="hd-3">Filter your results</h2>
-            <h3 class="hd-4"><em><%= results_summary(@pagination[:hits]) %></em></h3>
           </div>
           <% @filters&.each_with_index do |(category, values), index| %>
             <% if index == 0 %>
@@ -37,9 +36,10 @@
       </aside>
     <% end %>
 
-    <div class="col3q wrap-results">
+    <div id="results" class="col3q wrap-results">
       <% if @results.present? %>
-        <ol id="results" start="<%= @pagination[:start] %>">
+        <h2 class="hd-3 results-context"><%= results_summary(@pagination[:hits]) %> returned</h2>
+        <ol class="results-list" start="<%= @pagination[:start] %>">
           <% if Flipflop.enabled?(:gdt) %>
             <%= render(partial: 'search/result_geo', collection: @results) %>
           <% else %>
@@ -47,7 +47,7 @@
           <% end %>
         </ol>
       <% else %>
-        <div id="results" class="no-results">
+        <div class="no-results">
           <p class="hd-2">No results found for your search</p>
         </div>
       <% end %>

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -5,16 +5,16 @@ class ResultsHelperTest < ActionView::TestCase
 
   test 'if number of hits is equal to 10,000, results summary returns "10,000+"' do
     hits = 10000
-    assert_equal '10,000+ items', results_summary(hits)
+    assert_equal '10,000+ results', results_summary(hits)
   end
 
   test 'if number of hits is above 10,000, results summary returns "10,000+"' do
     hits = 10500
-    assert_equal '10,000+ items', results_summary(hits)
+    assert_equal '10,000+ results', results_summary(hits)
   end
 
   test 'if number of hits is below 10,000, results summary returns actual number of results' do
     hits = 9000
-    assert_equal '9,000 items', results_summary(hits)
+    assert_equal '9,000 results', results_summary(hits)
   end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

We will be moving the filter sidebar further down the tab order, so screen reader users would not reach the number of search results until they reach the end of the results. This foregrounds that context, both for blind/low-vision and sighted users.

#### Relevant ticket(s):

* [GDT-235](https://mitlibraries.atlassian.net/browse/GDT-235)

#### How this addresses that need:

This moves the number of results returned to the top of the results container, making it the first focusable element when a screen reader user skips to results.

#### Side effects of this change:

The results ID moves up one level in the DOM to account for the new heading.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

N/A

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-235]: https://mitlibraries.atlassian.net/browse/GDT-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ