### PR TITLE
Update access type values

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -83,7 +83,7 @@ module RecordHelper
 
     # At this point, we don't show download links for non-MIT records. For MIT records, the download link is stored
     # consistently as a download link. We are confirming that the link text is 'Data' for added confirmation.
-    if access_type(metadata) == 'Not owned by MIT'
+    if access_type(metadata) == 'unknown: check with owning institution'
       links.select { |link| link['kind'] == 'Website' }.first['url']
     else
       links.select { |link| link['kind'] == 'Download' && link['text'] == 'Data' }.first['url']

--- a/app/views/record/_access_button.html.erb
+++ b/app/views/record/_access_button.html.erb
@@ -1,9 +1,9 @@
 <% return if @record.blank? %>
 
 <div class="access-button-container <%= display %>">
-  <% if access_type(@record) == 'Free/open to all' %>
+  <% if access_type(@record) == 'no authentication required' %>
     <a class="btn button-primary access-button" href="<%= gis_access_link(@record) %>">Download geodata files</a>
-  <% elsif access_type(@record) == 'MIT authentication' %>
+  <% elsif access_type(@record) == 'MIT authentication required' %>
     <a class="btn button-primary access-button" href="<%= gis_access_link(@record) %>">
       Download geodata files <span class="auth-notice">MIT authentication</span>
     </a>

--- a/app/views/record/_record_geo.html.erb
+++ b/app/views/record/_record_geo.html.erb
@@ -42,7 +42,7 @@
     <% end %>
 
     <div class="record-access-links">
-      <% if access_type(@record) != 'Not owned by MIT' && source_metadata_available?(@record['links']) %>
+      <% if access_type(@record) != 'unknown: check with owning institution' && source_metadata_available?(@record['links']) %>
         <a class="btn button-secondary metadata-link"
            href="<%= source_metadata_link(@record['links']) %>">Download full metadata</a>
       <% end %>

--- a/app/views/shared/_geo_data_info.html.erb
+++ b/app/views/shared/_geo_data_info.html.erb
@@ -3,12 +3,12 @@
   <% if parse_geo_dates(metadata['dates']) %>
     <li><%= parse_geo_dates(metadata['dates']) %></li>
   <% end %>
-  <% if access_type(metadata) == 'Not owned by MIT' %>
+  <% if access_type(metadata) == 'unknown: check with owning institution' %>
     <li>
-      <%= access_type(metadata) %>
+      Not owned by MIT
       <span class="other-provider">(<%= link_to "Owned by #{metadata['provider']}", gis_access_link(metadata) %>)</span>
     </li>
-  <% elsif access_type(metadata) == 'MIT authentication' %>
+  <% elsif access_type(metadata) == 'MIT authentication required' %>
     <li><span class="access-restricted"><%= access_type(metadata) %></span></li>
   <% end %>
 </ul>

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -122,12 +122,12 @@ class RecordHelperTest < ActionView::TestCase
                    'kind' => 'bar'
                  },
                  {
-                   'description' => 'Free/open to all',
+                   'description' => 'no authentication required',
                    'kind' => 'Access to files'
                  }
                ]
              }
-    assert_equal 'Free/open to all', access_type(rights)
+    assert_equal 'no authentication required', access_type(rights)
   end
 
   test 'gis_access_link returns nil if access type is blank' do
@@ -157,7 +157,7 @@ class RecordHelperTest < ActionView::TestCase
                             'kind' => 'bar'
                           },
                           {
-                            'description' => 'Free/open to all',
+                            'description' => 'no authentication required',
                             'kind' => 'Access to files'
                           }
                         ]
@@ -173,7 +173,7 @@ class RecordHelperTest < ActionView::TestCase
                              'kind' => 'bar'
                            },
                            {
-                             'description' => 'Not owned by MIT',
+                             'description' => 'unknown: check with owning institution',
                              'kind' => 'Access to files'
                            }
                          ],
@@ -202,7 +202,7 @@ class RecordHelperTest < ActionView::TestCase
                         'kind' => 'bar'
                       },
                       {
-                        'description' => 'Free/open to all',
+                        'description' => 'no authentication required',
                         'kind' => 'Access to files'
                       }
                     ],
@@ -226,7 +226,7 @@ class RecordHelperTest < ActionView::TestCase
                         'kind' => 'bar'
                       },
                       {
-                        'description' => 'MIT authenticated',
+                        'description' => 'MIT authentication required',
                         'kind' => 'Access to files'
                       }
                     ],


### PR DESCRIPTION
#### Why these changes are being introduced:

The "access to files" values have been changed in the data mapping
layer. We need to make a corresponding change in a few partials
where the value of that field is a rendering condition.

#### Relevant ticket(s):

* [GDT-252](https://mitlibraries.atlassian.net/browse/GDT-252)

#### How this addresses that need:

This updates the values as needed in the access_button, record_geo, and
geo_data_info partials, as well as the access_type helper method.

#### Side effects of this change:

It was a bit tricky to wrangle and update all of these hardcoded values.
Though they are unlikely to change again, this is something that
we may want to consider refactoring.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

To confirm the changes, check a full record for each of the three access types. The download buttons should contain the following text, based on the access type:
* `MIT authentication required`: "Download geodata files `fa-lock icon` MIT authentication"
*` no authentication required`: "Download geodata files"
*` unknown: check with owning institution`: "View `institution name` record"

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-252]: https://mitlibraries.atlassian.net/browse/GDT-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ