### PR TITLE
Fix bug in filter sidebar SCSS

### DIFF
--- a/app/assets/stylesheets/partials/_filters.scss
+++ b/app/assets/stylesheets/partials/_filters.scss
@@ -88,10 +88,12 @@
           }
         }
         &.applied {
-          .name {
+          span {
             color: #000;
-            &:hover,
-            &:focus {
+          }
+          &:hover,
+          &:focus {
+            span {
               color: #fff;
             }
           }


### PR DESCRIPTION
##### Why these changes are being introduced:

The SCSS for the filter names in the sidebar doesn't work exactly the way we intend it to. When an applied filter is in focus, the font color is black; it should be white to contrast with the background.

##### Relevant ticket(s):

Discovered while working on [GDT-232](https://mitlibraries.atlassian.net/browse/GDT-232), but otherwise unrelated to that ticket.

##### How this addresses that need:

This updates the SCSS so that applied filters are white on focus and hover.

##### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Confirm that, while a filter is in focus, its color is white, not black.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-232]: https://mitlibraries.atlassian.net/browse/GDT-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ