### PR TITLE
Remove skips from record controller tests

### DIFF
--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -55,7 +55,6 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'access button displays for freely accessible data' do
-      skip("DataEng has changed access type labels and is currently reloading dev1 as of 3/28 at 12:20pm.")
       gis_record_id = 'gismit:CAMBRIDGEMEMPOLES09'
       VCR.use_cassette('gis record mit free',
                  allow_playback_repeats: true,
@@ -67,7 +66,6 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'access button displays for data requiring MIT auth' do
-      skip("DataEng has changed access type labels and is currently reloading dev1 as of 3/28 at 12:20pm.")
       gis_record_id = 'gismit:us_ma_boston_g47parcels_2018'
       VCR.use_cassette('gis record mit auth',
                  allow_playback_repeats: true,
@@ -79,7 +77,6 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'access button displays for non-MIT GIS records' do
-      skip("DataEng has changed access type labels and is currently reloading dev1 as of 3/28 at 12:20pm.")
       gis_record_id = 'gisogm:edu.stanford.purl:be6ef8cd8ac5'
       VCR.use_cassette('gis record elsewhere',
                  allow_playback_repeats: true,


### PR DESCRIPTION
#### Why these changes are being introduced:

There were three record controller tests that had to be skipped due to a data reload that was in process. That reload, which was related to the access type values, is now complete, and the corresponding UI code has been updated, so these tests will pass again.

#### Relevant ticket(s):

* [GDT-252](https://mitlibraries.atlassian.net/browse/GDT-252)

#### How this addresses that need:

This removes the skip statements from the tests in question, so they will run again.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

N/A.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-252]: https://mitlibraries.atlassian.net/browse/GDT-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ