### PR TITLE
Reorder geo bounding box fields

### DIFF
--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -55,6 +55,18 @@ end
           <p>* All fields in this section are required</p>
           <div class="gridband layout-2c">
             <div class="field-wrap grid-item">
+              <label class="geo-label" for="geobox-minLatitude">Minimum latitude</label>
+              <input type="number" step="0.000001" min="-90.0" max="90.0"
+                     class="field field-text <%= "required" if geobox_required %>" 
+                     id="geobox-minLatitude" name="geoboxMinLatitude" value="<%= params[:geoboxMinLatitude] %>"
+                     <%= 'required="required" aria-required="true"' if geobox_required %>
+                     aria-describedby="minLat-desc">
+              <span class="geo-desc" id="minLat-desc">
+                A decimal between -90.0 and 90.0 (Ex: 41.239083)
+                <span class="hint">Southern Hemisphere is negative</span>
+              </span>
+            </div>
+            <div class="field-wrap grid-item">
               <label class="geo-label" for="geobox-minLongitude">Minimum longitude</label>
               <input type="number" step="0.000001" min="-180.0" max="180.0"
                      class="field field-text <%= "required" if geobox_required %>" 
@@ -67,14 +79,14 @@ end
               </span>
             </div>
             <div class="field-wrap grid-item">
-              <label class="geo-label" for="geobox-minLatitude">Minimum latitude</label>
+              <label class="geo-label" for="geobox-maxLatitude">Maximum latitude</label>
               <input type="number" step="0.000001" min="-90.0" max="90.0"
                      class="field field-text <%= "required" if geobox_required %>" 
-                     id="geobox-minLatitude" name="geoboxMinLatitude" value="<%= params[:geoboxMinLatitude] %>"
+                     id="geobox-maxLatitude" name="geoboxMaxLatitude" value="<%= params[:geoboxMaxLatitude] %>"
                      <%= 'required="required" aria-required="true"' if geobox_required %>
-                     aria-describedby="minLat-desc">
-              <span class="geo-desc" id="minLat-desc">
-                A decimal between -90.0 and 90.0 (Ex: 41.239083)
+                     aria-describedby="maxLat-desc">
+               <span class="geo-desc" id="maxLat-desc">
+                A decimal between -90.0 and 90.0 (Ex: 42.886759)
                 <span class="hint">Southern Hemisphere is negative</span>
               </span>
             </div>
@@ -89,18 +101,6 @@ end
                  A decimal between -180.0 and 180.0 (Ex: -69.928713)
                  <span class="hint">Western Hemisphere is negative</span>
                </span>
-            </div>
-            <div class="field-wrap grid-item">
-              <label class="geo-label" for="geobox-maxLatitude">Maximum latitude</label>
-              <input type="number" step="0.000001" min="-90.0" max="90.0"
-                     class="field field-text <%= "required" if geobox_required %>" 
-                     id="geobox-maxLatitude" name="geoboxMaxLatitude" value="<%= params[:geoboxMaxLatitude] %>"
-                     <%= 'required="required" aria-required="true"' if geobox_required %>
-                     aria-describedby="maxLat-desc">
-               <span class="geo-desc" id="maxLat-desc">
-                A decimal between -90.0 and 90.0 (Ex: 42.886759)
-                <span class="hint">Southern Hemisphere is negative</span>
-              </span>
             </div>
           </div>
         </fieldset>


### PR DESCRIPTION
#### Why these changes are being introduced:

Longitude appears before latitude in the bounding box fieldset, but it is more conventional to list latitude first. This also matches the order of the geodistance fieldset.

#### Relevant ticket(s):

* [GDT-256](https://mitlibraries.atlassian.net/browse/GDT-256)

#### How this addresses that need:

This reorders the bounding box fieldset to display in the following order (from top to bottom, then left to right):
* Minimum latitude
* Maximum latitude
* Minimum longitude
* Maximum longtidue

#### Side effects of this change:

In mobile, the fields will render in the order they are listed in the markup; i.e., min lat, min long, max lat, max long. We should confirm that this is acceptable.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

This should be a quick review, as it's just moving markup around. I'm hoping to get Darcy's approval/confirmation of side effects (see above) before merging.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-256]: https://mitlibraries.atlassian.net/browse/GDT-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ