### PR TITLE
Render filter value names in non-GDT contexts

### DIFF
--- a/app/views/search/_filter.html.erb
+++ b/app/views/search/_filter.html.erb
@@ -15,9 +15,11 @@
           <a href="<%= results_path(add_filter(@enhanced_query, category, term['key'])) %>">
           <span class="sr">Apply filter:</span>
         <% end %>
-          <% if Flipflop.enabled?(:gdt) %>
-            <span class="name"><%= gdt_sources(term['key'], category) %></span>
-          <% end %>
+        <% if Flipflop.enabled?(:gdt) %>
+          <span class="name"><%= gdt_sources(term['key'], category) %></span>
+        <% else %>
+          <span class="name"><%= term['key'] %></span>
+        <% end %>
           <span class="count"><%= term['docCount'] %> <span class="sr">records</span></span>
         </a>
       </li>

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -139,6 +139,17 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'a filter category lists available filters with names and values' do
+    VCR.use_cassette('data basic controller',
+                     allow_playback_repeats: true,
+                     match_requests_on: %i[method uri body]) do
+      get '/results?q=data'
+      assert_response :success
+      assert_select '.filter-options .category-terms .name', { minimum: 1 }
+      assert_select '.filter-options .category-terms .count', { minimum: 1 }
+    end
+  end
+
   test 'results with valid query has div for pagination' do
     VCR.use_cassette('data basic controller',
                      allow_playback_repeats: true,


### PR DESCRIPTION
#### Why these changes are being introduced:

When introducing the helper method to rename GDT source filter values, we inadvertently removed all filter values for non-GDT apps. This is hilarious, but not very usable.

#### Relevant ticket(s):

N/A

#### How this addresses that need:

This adds to the filter partial an `else` clause that renders the term key if GDT is not enabled.

#### Side effects of this change:

Users will know what filters they are applying.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Successful application and removal (and visibility) of filters should be confirmed with and without the GDT feature flag.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
