### PR TITLE
Make result highlight field names more human-readable

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -9,6 +9,11 @@ module SearchHelper
     result['highlight'].reject { |h| displayed_fields.include? h['matchedField'] }
   end
 
+  def format_highlight_label(field_name)
+    field_name = field_name.split('.').first if field_name.include?('.')
+    field_name.underscore.humanize
+  end
+
   def view_online(result)
     return unless result['sourceLink'].present?
 

--- a/app/views/search/_highlights.html.erb
+++ b/app/views/search/_highlights.html.erb
@@ -5,7 +5,7 @@
 <ul class="list-unbulleted truncate-list">
   <% highlights.each do |h| %>
     <% h['matchedPhrases'].each do |phrase| %>
-      <li><strong><%= h['matchedField'] %>:</strong> <%= sanitize(phrase, tags: ['span']) %></li>
+      <li><strong><%= format_highlight_label(h['matchedField']) %>:</strong> <%= sanitize(phrase, tags: ['span']) %></li>
     <% end %>
   <% end %>
 </ul>

--- a/test/helpers/search_helper_test.rb
+++ b/test/helpers/search_helper_test.rb
@@ -98,4 +98,19 @@ class SearchHelperTest < ActionView::TestCase
     assert_nil parse_geo_dates(wtf)
     assert_nil parse_geo_dates(omg)
   end
+
+  # The goal here is not test every possible field name, but to confirm enough of a variety that we can infer that all
+  # of them will be parsed appropriately.
+  test 'highlight field names are humanized' do
+    subjects_value = 'subjects.value'
+    alternate_titles = 'alternateTitle.value'
+    funding_information_name = 'fundingInformation.funderName'
+    date_range = 'dates.range'
+    edition = 'edition'
+    assert_equal 'Subjects', format_highlight_label(subjects_value)
+    assert_equal 'Alternate title', format_highlight_label(alternate_titles)
+    assert_equal 'Funding information', format_highlight_label(funding_information_name)
+    assert_equal 'Dates', format_highlight_label(date_range)
+    assert_equal 'Edition', format_highlight_label(edition)
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

The OpenSearch highlight field collects matched field names as-is, so for nested fields we get names like `subjects.value`.

#### Relevant ticket(s):

* [GDT-248](https://mitlibraries.atlassian.net/browse/GDT-248)

#### How this addresses that need:

This adds a helper method to parse matched field names.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

The helper method first calls `underscore` then `humanize`, so field names with multiple words should appear like "Alternate title" and one-word field names should appear like "Format."

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-248]: https://mitlibraries.atlassian.net/browse/GDT-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ