### PR TITLE
Improve page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,36 @@ module ApplicationHelper
     ['DSpace@MIT', 'Abdul Latif Jameel Poverty Action Lab Dataverse',
      'Woods Hole Open Access Server', 'Zenodo'].join(',')
   end
+
+  def index_page_title
+    ENV.fetch('PLATFORM_NAME', nil) ? "Search #{ENV.fetch('PLATFORM_NAME')} | MIT Libraries" : 'Search | MIT Libraries'
+  end
+
+  def results_page_title(query, character_limit = 50)
+    return index_page_title unless query.present?
+
+    ignored_terms = %i[page advanced geobox geodistance]
+    terms = query.reject { |term| ignored_terms.include? term }.values.join(' ')
+    terms = "#{terms.first(character_limit)}..." if terms.length > character_limit
+    "#{terms} | #{page_title_base}"
+  end
+
+  def record_page_title(record, character_limit = 25)
+    # Theoretically, every record should have a title, but just in case...
+    return index_page_title unless record.present? && record['title'].present?
+
+    title = if record['title'].length > character_limit
+              "#{record['title'].first(character_limit)}..."
+            else
+              record['title']
+            end
+
+    "#{title} | #{page_title_base}"
+  end
+
+  private
+
+  def page_title_base
+    ENV.fetch('PLATFORM_NAME', nil) ? "#{ENV.fetch('PLATFORM_NAME')} | MIT Libraries" : 'MIT Libraries'
+  end
 end

--- a/app/views/basic_search/index.html.erb
+++ b/app/views/basic_search/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, "Search | MIT Libraries") %>
+<%= content_for(:title, index_page_title) %>
 
 <div class="space-wrap">
   <%= render partial: "shared/site_title" %>

--- a/app/views/record/view.html.erb
+++ b/app/views/record/view.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, "Search Results | MIT Libraries") %>
+<%= content_for(:title, record_page_title(@record)) %>
 
 <%= render(partial: 'shared/error', collection: @errors) %>
 

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, "Search Results | MIT Libraries") %>
+<%= content_for(:title, results_page_title(@enhanced_query)) %>
 
 <div class="space-wrap">
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class FilterHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test 'index_page_title renders as expected' do
+    assert_equal 'Search | MIT Libraries', index_page_title
+  end
+
+  test 'results_page_title includes keyword search terms' do
+    query = { q: 'National Parks Service' }
+    assert_equal 'National Parks Service | MIT Libraries', results_page_title(query)
+  end
+
+  test 'results_page_title excludes irrelevant query params' do
+    query = { q: 'National Parks Service', page: 1, geobox: 'true', geodistance: 'true', advanced: 'true' }
+    assert_equal 'National Parks Service | MIT Libraries', results_page_title(query)
+  end
+
+  test 'results_page_title includes advanced search terms' do
+    query = { title: 'Sister Outsider', contributors: ['Lorde, Audre'] }
+    assert_equal 'Sister Outsider Lorde, Audre | MIT Libraries', results_page_title(query)
+  end
+
+  test 'results_page_title includes geospatial search terms' do
+    query = { geodistanceLatitude: '42.281389', geodistanceLongitude: '-83.748333', geodistanceDistance: '29.09mi' }
+    assert_equal '42.281389 -83.748333 29.09mi | MIT Libraries', results_page_title(query)
+  end
+
+  test 'results_page_title truncates terms above character limit' do
+    query = { q: 'National Park Service Land Resources Division tract and boundary data' }
+
+    # Default character limit (50)
+    assert_equal 'National Park Service Land Resources Division trac... | MIT Libraries',
+                 results_page_title(query)
+
+    # Custom character limit
+    assert_equal 'National Park S... | MIT Libraries', results_page_title(query, 15)
+  end
+
+  test 'results_page_title returns index_page_title if there is no enhanced query for some reason' do
+    no_query = nil
+    assert_equal 'Search | MIT Libraries', results_page_title(no_query)
+  end
+
+  test 'record_page_title includes record title' do
+    record = { 'title' => 'The Waves' }
+    assert_equal 'The Waves | MIT Libraries', record_page_title(record)
+  end
+
+  test 'record_page_title truncates titles above the character limit' do
+    record = { 'title' => 'Indigenous Continent: The Epic Contest for North America | GeoData | MIT Libraries' }
+
+    # Default character limit (25)
+    assert_equal 'Indigenous Continent: The... | MIT Libraries',
+                 record_page_title(record)
+
+    # Custom character limit
+    assert_equal 'Indigenous Continent... | MIT Libraries', record_page_title(record, 20)
+  end
+
+  test 'record_page_title returns index_page_title if there is no record or title for some reason' do
+    absence_of_record = nil
+    no_title = { 'recordId' => 'foo.bar' }
+    assert_equal 'Search | MIT Libraries', record_page_title(absence_of_record)
+    assert_equal 'Search | MIT Libraries', record_page_title(no_title)
+  end
+
+  test 'page titles can include platform name' do
+    ClimateControl.modify PLATFORM_NAME: 'GeoData' do
+      query = { q: 'foo' }
+      record = { 'title' => 'bar' }
+      assert_equal 'Search GeoData | MIT Libraries', index_page_title
+      assert_equal 'foo | GeoData | MIT Libraries', results_page_title(query)
+      assert_equal 'bar | GeoData | MIT Libraries', record_page_title(record)
+    end
+  end
+end


### PR DESCRIPTION
#### Why these changes are being introduced:

Every view currently has the same generic title content. It's common practice in discovery applications to include context about the current query in the page title, so users can see these pertinent details in a given tab or bookmark.

#### Relevant ticket(s):

* [GDT-234](https://mitlibraries.atlassian.net/browse/GDT-234)

#### How this addresses that need:

This adds helper methods to construct page titles for the following views:

* `basic_search/index`: "Search `PLATFORM_NAME` | MIT Libraries"
* `record/view`: "`record['title']` | `PLATFORM_NAME` | MIT Libraries"
* `results`: "`params from enhanced query` | `PLATFORM_NAME` | MIT Libraries"

If the query/title preview string exceeds a configurable character limit (defaults to 50 for results and 25 for record), the string is truncated with an ellipsis.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

I'm waiting to hear from Darcy if she wants to include geospatial field values. I think they're probably useful to folks who would be using those fields, so I've included them for now, but that might change if Darcy disagrees.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-234]: https://mitlibraries.atlassian.net/browse/GDT-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ