### PR TITLE
Switch from Turbolinks to Turbo for progress bar

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,4 +3,4 @@ import "@hotwired/turbo-rails"
 import "controllers"
 
 // Show the progress bar after 200 milliseconds, not the default 500
-Turbolinks.setProgressBarDelay(200)
+window.Turbo.setProgressBarDelay(200);

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -13,7 +13,7 @@
 <![endif]-->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic&subset=latin,latin-ext" type="text/css">
-<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+<%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
 
 <!-- For all other devices -->
 <!-- Size should be 32 x 32 pixels -->


### PR DESCRIPTION
#### Why these changes are being introduced:

[Turbolinks is no longer actively developed](https://www.honeybadger.io/blog/hb-turbolinks-to-turbo/). We should switch to Turbo for our progress bar customization.

#### Relevant ticket(s):

* [GDT-289](https://mitlibraries.atlassian.net/browse/GDT-289)

#### How this addresses that need:

This migrates our use of Turbolinks to (currently limited to the progress bar) to Turbo.

#### Side effects of this change:

A small change, recommended in the blog post linked above, has been made to the `stylesheet_link_tag` element in our custom head (adding `media: all`).

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Confirm in the PR build (or locally):
* No errors related to Turbolinks appear in the console; and
* Links are still preloaded (the easiest way to test this is by hovering over filter links and checking in the Rails logger if requests were made).

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-289]: https://mitlibraries.atlassian.net/browse/GDT-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ