### PR TITLE
Add turbo:load event listener to Matomo code

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -40,6 +40,25 @@
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
+
+  // Lightly modified from https://github.com/turbolinks/turbolinks/issues/436
+  // Send Matomo a new event when navigating to a new page using Turbolinks
+  // (see https://developer.matomo.org/guides/spa-tracking)
+  (function() {
+    var previousPageUrl = null;
+    addEventListener('turbo:load', function(event) {
+      if (previousPageUrl) {
+        _paq.push(['setReferrerUrl', previousPageUrl]);
+        _paq.push(['setCustomUrl', window.location.href]);
+        _paq.push(['setDocumentTitle', document.title]);
+        if (event.data && event.data.timing) {
+          _paq.push(['setGenerationTimeMs', event.data.timing.visitEnd - event.data.timing.visitStart]);
+        }
+        _paq.push(['trackPageView']);
+      }
+      previousPageUrl = window.location.href;
+    });
+  })();
 </script>
 <!-- End Matomo Code -->
 <% end %>


### PR DESCRIPTION
Why these changes are being introduced:

It’s a known issue that the out-of-the-box Matomo tracking code does not work with Turbo, but we want to continue using Turbo because it's great.

Relevant ticket(s):

* [GDT-289](https://mitlibraries.atlassian.net/browse/GDT-289)

How this addresses that need:

This adds a JS snippet to the tracking code, based on Matomo's instructions for tracking SPA's, that sends an event to Matomo when Turbo loads a page. See [this GitHub issue](https://github.com/turbolinks/turbolinks/issues/436) for details.

Side effects of this change:

We should add this change to the theme gem if it works for apps that are not using Turbo. (It should, but I haven't confirmed it.)

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

To confirm the changes, you can deploy this to GeoData staging and confirm that pageviews and search terms are logged in Matomo staging. (Note that only the `q` param is captured at present.)

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-289]: https://mitlibraries.atlassian.net/browse/GDT-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ