### PR TITLE
Update site title based on stakeholder feedback

### DIFF
--- a/app/views/shared/_site_title.html.erb
+++ b/app/views/shared/_site_title.html.erb
@@ -1,6 +1,6 @@
 <% if Flipflop.enabled?(:gdt) %>
-  <h1 class="hd-2">Search for Geographic/GIS data</h1>
-  <p>Find GIS data held at MIT and other universities</p>
+  <h1 class="hd-2">Search for Geospatial/GIS data</h1>
+  <p>Find GIS data held at MIT and other institutions</p>
 <% else %>
   <h1 class="hd-2">Search the MIT Libraries</h1>
 <% end %>


### PR DESCRIPTION
#### Why these changes are being introduced:

The current site title is not entirely accurate.

#### Relevant ticket(s):

* [GDT-291](https://mitlibraries.atlassian.net/browse/GDT-291)

#### How this addresses that need:

This updates the site title as requested.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

The new h1 and subtitle should read:

```
Search for Geospatial/GIS data
Find GIS data held at MIT and other institutions
```

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-291]: https://mitlibraries.atlassian.net/browse/GDT-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ