### PR TITLE
Remove additional skip links

### DIFF
--- a/app/views/layouts/_skip_links.html.erb
+++ b/app/views/layouts/_skip_links.html.erb
@@ -1,11 +1,9 @@
-<a class="skip-link sr sr-focusable" href="#main-menu">Skip to main menu</a>
-<a class="skip-link sr sr-focusable" href="#basic-search">Skip to search form</a>
-<% if current_page?(results_path) %>
-  <a class="skip-link sr sr-focusable" href="#results">Skip to results</a>
-  <% if @filters.present? %>
-    <a class="skip-link sr sr-focusable" href="#filters">Skip to search filters</a>
-  <% end %>
-<% end %>
 <% if controller.controller_name == 'record' && controller.action_name == 'view' %>
-  <a class="skip-link sr sr-focusable" href="#full-record">Skip to content</a>
+  <a class='skip-link sr sr-focusable' href='#full-record'>
+<% elsif controller.controller_name == 'search' %>
+  <a class='skip-link sr sr-focusable' href='#results'>
+<% else %>
+  <a class='skip-link sr sr-focusable' href='#basic-search-main'>
 <% end %>
+    Skip to main content
+  </a>


### PR DESCRIPTION
#### Why these changes are being introduced:

Kate and Rich from DAS advised us that skip links are primarily for sighted users navigating with a keyboard, and it's very unusual to find more than one skip link. To that end, we've decided to simplify the skip links.

#### Relevant ticket(s):

* [GDT-280](https://mitlibraries.atlassian.net/browse/GDT-280)

#### How this addresses that need:

* All skip links now have the same conventional text: 'skip to main content'.
* On the results view, there is one skip link that goes to the results list.
* On the full record view, there is one skip link that goes to the top of the record.
* On all other views (i.e., the landing page), there is one skip link that goes to the first input in the search form (keyword search).

#### Side effects of this change:

We may need to revisit this after a11y testing to confirm that the skip links are useful.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Based on the new info we got from DAS, I think this should be tested with keyboard nav, not Voiceover.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-280]: https://mitlibraries.atlassian.net/browse/GDT-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ