### PR TITLE
Remove affordance to clear search terms

### DIFF
--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -36,9 +36,9 @@
     margin-bottom: .8rem;
     padding: 6px 12px;
 
-    @media (min-width: $bp-screen-md) {
+    @media (min-width: $bp-screen-sm) {
       display: inline-block;
-      width: 65%;
+      width: 80%;
       margin-bottom: 0;
     }
   }
@@ -112,28 +112,13 @@
   }
 
   .basic-search-submit {
-    .button-secondary {
-      background-color: $white;
-      text-align: center;
-      &:hover,
-      &:focus {
-        background-color: $blue;
-      }
+    @media (min-width: $bp-screen-sm) {
+      display: inline-block;
+      width: 18%;
     }
     .btn {
       border-radius: 0;
       width: 100%;
-      &:last-child {
-        margin-top: 0.4rem;
-      }
-    }
-    @media (min-width: $bp-screen-md) {
-      display: inline-block;
-      width: 34%;
-      .btn {
-        width: 49%;
-        margin-top: 0;
-      }
     }
   }
 }

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -42,7 +42,6 @@ end
            value="<%= params[:q] %>" <%= 'required="required" aria-required="true"' if search_required %>>
     <div class="basic-search-submit">
       <button type="submit" class="btn button-primary">Search</button>
-      <a href="/" class="btn button-secondary">Clear</a>
     </div>
 
     <% if Flipflop.enabled?(:gdt) %>


### PR DESCRIPTION
#### Why these changes are being introduced:

UXWS changed their mind on this feature. They believe it's likely to be confusing.

#### Relevant ticket(s):

* [GDT-244](https://mitlibraries.atlassian.net/browse/GDT-244)

#### How this addresses that need:

This removes the 'clear' button from the search form and resets the CSS accordingly.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Form display should now be identical to GeoData prod.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-244]: https://mitlibraries.atlassian.net/browse/GDT-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ