### PR TITLE
Display search terms in summary panel

### DIFF
--- a/app/assets/stylesheets/partials/_panels.scss
+++ b/app/assets/stylesheets/partials/_panels.scss
@@ -98,34 +98,56 @@
   }
 }
 
-.filter-summary {
+.search-summary {
   color: $black;
   background-color: $gray-l3;
   margin-top: 0;
   border: 0;
-  padding: 2rem;
-  padding-top: 1.5rem;
-  .list-filter-summary {
-    display: flex;
-    .hd-filter-summary {
-      margin-right: 2rem;
-      padding-top: 0.3rem;
+  padding: 2rem 2rem 1rem 2rem;
+  .list-filter-summary,
+  .list-terms-summary {
+    @media (min-width: $bp-screen-md) {
+      display: flex;
     }
-    .applied-filter {
-      font-size: $fs-small;
-      text-decoration: none;
-      padding: .5rem;
-      &::before {
-        font-family: FontAwesome;
-        content: '\f00d';
-        padding-right: .25rem;
-      }
-      &:hover,
-      &:focus {
-        color: $white;
-        background-color: $black;
-      }
-      margin-right: 2rem;
+  }
+  .list-filter-summary {
+    padding-top: 1rem;
+    border-top: 1px solid $black;
+  }
+  .hd-search-summary {
+    margin-right: 2rem;
+    padding-top: 0.2rem;
+    white-space: nowrap;
+  }
+  .list-unbulleted {
+    margin-bottom: 0;
+  }
+  .applied-filter,
+  .applied-term {
+    font-size: $fs-small;
+    text-decoration: none;
+    margin-right: 2rem;
+  }
+  .applied-term {
+    margin-top: .5rem;
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+  .keyword {
+    margin-bottom: 1.2rem;
+  }
+  .applied-filter {
+    padding: .5rem;
+    &::before {
+      font-family: FontAwesome;
+      content: '\f00d';
+      padding-right: .25rem;
+    }
+    &:hover,
+    &:focus {
+      color: $white;
+      background-color: $black;
     }
   }
   .clear-filters {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
   def results_page_title(query, character_limit = 50)
     return index_page_title unless query.present?
 
-    ignored_terms = %i[page advanced geobox geodistance]
+    ignored_terms = %i[page advanced geobox geodistance booleanType]
     terms = query.reject { |term| ignored_terms.include? term }.values.join(' ')
     terms = "#{terms.first(character_limit)}..." if terms.length > character_limit
     "#{terms} | #{page_title_base}"

--- a/app/views/search/_search_summary.html.erb
+++ b/app/views/search/_search_summary.html.erb
@@ -1,29 +1,71 @@
-<% return unless applied_filters(@enhanced_query).any? %>
+<% return unless (applied_filters(@enhanced_query).present? ||
+                  applied_keyword(@enhanced_query).present? ||
+                  applied_geobox_terms(@enhanced_query).present? ||
+                  applied_geodistance_terms(@enhanced_query).present? ||
+                  applied_advanced_terms(@enhanced_query).present?) %>
 
-<aside class="filter-summary">
-  <div class="list-filter-summary">
-    <h2 class="hd-filter-summary hd-5">Applied filters: </h2>
-    <ul class="list-inline">
-    <% applied_filters(@enhanced_query).each do |filter| %>
-      <li>
-        <a class="applied-filter"
-           href="<%= results_path(remove_filter(@enhanced_query, filter.keys[0], filter.values[0])) %>">
-          <%= "#{nice_labels[filter.keys[0]] || filter.keys[0]}:" %>
-          <% if Flipflop.enabled?(:gdt) %>
-            <%= "#{gdt_sources(filter.values[0], filter.keys[0])}" %>
-          <% else %>
-            <%= "#{filter.values[0]}" %>
-          <% end %>
-          <span class="sr">Remove applied filter?</span>
-        </a>
-      </li>
-    <% end %>
-    </ul>
+<aside class="search-summary">
+  <div class="list-terms-summary">
+    <h2 class="hd-search-summary hd-5">Applied search terms: </h2>
+      <ul class="list-unbulleted">
+        <% if applied_keyword(@enhanced_query).present? %>
+          <li class="applied-term keyword"><%= applied_keyword(@enhanced_query).first %></li>
+        <% end %>
+        <% if applied_geobox_terms(@enhanced_query).present? %>
+          <li class="applied-term">
+            <ul class="list-inline">
+              <% applied_geobox_terms(@enhanced_query).each do |term| %>
+                <li class="applied-term"><%= term %></li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
+        <% if applied_geodistance_terms(@enhanced_query).present? %>
+          <li class="applied-term">
+            <ul class="list-inline">
+              <% applied_geodistance_terms(@enhanced_query).each do |term| %>
+                <li class="applied-term"><%= term %></li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
+        <% if applied_advanced_terms(@enhanced_query).present? %>
+          <li class="applied-term">
+            <ul class="list-inline">
+              <% applied_advanced_terms(@enhanced_query).each do |term| %>
+                <li class="applied-term"><%= term %></li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
+      </ul>
   </div>
-  <% if applied_filters(@enhanced_query).length > 1 %>
-    <div class="clear-filters">
-      <a class="btn button-primary"
-       href="<%= results_path(remove_all_filters(@enhanced_query)) %>">Clear all filters</a>
+
+  <% if applied_filters(@enhanced_query).any? %>
+    <div class="list-filter-summary">
+      <h2 class="hd-search-summary hd-5">Applied filters: </h2>
+      <ul class="list-inline">
+      <% applied_filters(@enhanced_query).each do |filter| %>
+        <li>
+          <a class="applied-filter"
+             href="<%= results_path(remove_filter(@enhanced_query, filter.keys[0], filter.values[0])) %>">
+            <%= "#{nice_labels[filter.keys[0]] || filter.keys[0]}:" %>
+            <% if Flipflop.enabled?(:gdt) %>
+              <%= "#{gdt_sources(filter.values[0], filter.keys[0])}" %>
+            <% else %>
+              <%= "#{filter.values[0]}" %>
+            <% end %>
+            <span class="sr">Remove applied filter?</span>
+          </a>
+        </li>
+      <% end %>
+      </ul>
     </div>
+    <% if applied_filters(@enhanced_query).length > 1 %>
+      <div class="clear-filters">
+        <a class="btn button-primary"
+         href="<%= results_path(remove_all_filters(@enhanced_query)) %>">Clear all filters</a>
+      </div>
+    <% end %>
   <% end %>
 </aside>

--- a/test/controllers/search_controller_geo_test.rb
+++ b/test/controllers/search_controller_geo_test.rb
@@ -82,6 +82,35 @@ class SearchControllerGeoTest < ActionDispatch::IntegrationTest
     assert_select '#geodistance-search-panel', count: 0
   end
 
+  test 'GDT lists applied geospatial search terms' do
+    VCR.use_cassette('geobox and geodistance',
+                      allow_playback_repeats: true,
+                      match_requests_on: %i[method uri body]) do
+      query = {
+        geobox: 'true',
+        geodistance: 'true',
+        geoboxMinLongitude: 40.5,
+        geoboxMinLatitude: 60.0,
+        geoboxMaxLongitude: 78.2,
+        geoboxMaxLatitude: 80.0,
+        geodistanceLatitude: 36.1,
+        geodistanceLongitude: 62.6,
+        geodistanceDistance: '50mi'
+      }.to_query
+      get "/results?#{query}"
+      assert_response :success
+      assert_nil flash[:error]
+
+      assert_select 'li', 'Min longitude: 40.5'
+      assert_select 'li', 'Min latitude: 60.0'
+      assert_select 'li', 'Max longitude: 78.2'
+      assert_select 'li', 'Max latitude: 80.0'
+      assert_select 'li', 'Latitude: 36.1'
+      assert_select 'li', 'Longitude: 62.6'
+      assert_select 'li', 'Distance: 50mi'
+    end
+  end
+
   test 'can query geobox' do
     VCR.use_cassette('geobox',
                       allow_playback_repeats: true,

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -288,8 +288,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
   # Advanced search behavior
   test 'advanced search by keyword' do
-    skip("We no longer display a list of search terms in the UI; leaving this in in case we decide to reintroduce" \
-         "that feature soon.")
     VCR.use_cassette('advanced keyword asdf',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
@@ -313,8 +311,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'advanced search can accept values from all fields' do
-    skip("We no longer display a list of search terms in the UI; leaving this in in case we decide to reintroduce" \
-         "that feature soon.")
     VCR.use_cassette('advanced all',
                      allow_playback_repeats: true,
                      match_requests_on: %i[method uri body]) do
@@ -337,12 +333,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_select 'li', 'Keyword anywhere: data'
       assert_select 'li', 'Citation: citation'
       assert_select 'li', 'Contributors: contribs'
-      assert_select 'li', 'Funders: fund'
+      assert_select 'li', 'Funding information: fund'
       assert_select 'li', 'Identifiers: ids'
       assert_select 'li', 'Locations: locs'
       assert_select 'li', 'Subjects: subs'
       assert_select 'li', 'Title: title'
-      assert_select 'li', 'Source: sauce'
     end
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -13,7 +13,8 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test 'results_page_title excludes irrelevant query params' do
-    query = { q: 'National Parks Service', page: 1, geobox: 'true', geodistance: 'true', advanced: 'true' }
+    query = { q: 'National Parks Service', page: 1, geobox: 'true', geodistance: 'true', advanced: 'true',
+              booleanType: 'AND' }
     assert_equal 'National Parks Service | MIT Libraries', results_page_title(query)
   end
 

--- a/test/vcr_cassettes/advanced_all.yml
+++ b/test/vcr_cassettes/advanced_all.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://FAKE_TIMDEX_HOST/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query TimdexSearch__BaseQuery($q: String, $citation: String,
+        $contributors: String, $fundingInformation: String, $identifiers: String,
+        $locations: String, $subjects: String, $title: String, $index: String, $from:
+        String, $booleanType: String, $accessToFilesFilter: [String!], $contentTypeFilter:
+        [String!], $contributorsFilter: [String!], $formatFilter: [String!], $languagesFilter:
+        [String!], $literaryFormFilter: String, $placesFilter: [String!], $sourceFilter:
+        [String!], $subjectsFilter: [String!]) {\n  search(searchterm: $q, citation:
+        $citation, contributors: $contributors, fundingInformation: $fundingInformation,
+        identifiers: $identifiers, locations: $locations, subjects: $subjects, title:
+        $title, index: $index, from: $from, booleanType: $booleanType, accessToFilesFilter:
+        $accessToFilesFilter, contentTypeFilter: $contentTypeFilter, contributorsFilter:
+        $contributorsFilter, formatFilter: $formatFilter, languagesFilter: $languagesFilter,
+        literaryFormFilter: $literaryFormFilter, placesFilter: $placesFilter, sourceFilter:
+        $sourceFilter, subjectsFilter: $subjectsFilter) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
+        {\n        kind\n        value\n      }\n      publicationInformation\n      dates
+        {\n        kind\n        value\n      }\n      links {\n        kind\n        restrictions\n        text\n        url\n      }\n      notes
+        {\n        kind\n        value\n      }\n      highlight {\n        matchedField\n        matchedPhrases\n      }\n      provider\n      rights
+        {\n        kind\n        description\n        uri\n      }\n      sourceLink\n      summary\n    }\n    aggregations
+        {\n      accessToFiles {\n        key\n        docCount\n      }\n      contentType
+        {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      format
+        {\n        key\n        docCount\n      }\n      languages {\n        key\n        docCount\n      }\n      literaryForm
+        {\n        key\n        docCount\n      }\n      places {\n        key\n        docCount\n      }\n      source
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"from":"0","q":"data","citation":"citation","contributors":"contribs","fundingInformation":"fund","identifiers":"ids","locations":"locs","subjects":"subs","title":"title","booleanType":"AND","index":"FAKE_TIMDEX_INDEX"},"operationName":"TimdexSearch__BaseQuery"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - MIT Libraries Client
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Mon, 29 Apr 2024 20:26:42 GMT
+      Report-To:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1714422402&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=KqQRyemQQ1HwVHjJpBB28MzZaPMzbF7x5aMW8XV72DU%3D"}]}'
+      Reporting-Endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1714422402&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=KqQRyemQQ1HwVHjJpBB28MzZaPMzbF7x5aMW8XV72DU%3D
+      Nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"739d1361856b08c7d7dcf051784b4019"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 036e8a2c-434c-4f1e-a9ce-8786f930e340
+      X-Runtime:
+      - '0.178386'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '197'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"search":{"hits":0,"records":[],"aggregations":{"accessToFiles":[],"contentType":[],"contributors":[],"format":[],"languages":[],"literaryForm":[],"places":[],"source":[],"subjects":[]}}}}'
+  recorded_at: Mon, 29 Apr 2024 20:26:43 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/advanced_keyword_asdf.yml
+++ b/test/vcr_cassettes/advanced_keyword_asdf.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://FAKE_TIMDEX_HOST/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query TimdexSearch__BaseQuery($q: String, $citation: String,
+        $contributors: String, $fundingInformation: String, $identifiers: String,
+        $locations: String, $subjects: String, $title: String, $index: String, $from:
+        String, $booleanType: String, $accessToFilesFilter: [String!], $contentTypeFilter:
+        [String!], $contributorsFilter: [String!], $formatFilter: [String!], $languagesFilter:
+        [String!], $literaryFormFilter: String, $placesFilter: [String!], $sourceFilter:
+        [String!], $subjectsFilter: [String!]) {\n  search(searchterm: $q, citation:
+        $citation, contributors: $contributors, fundingInformation: $fundingInformation,
+        identifiers: $identifiers, locations: $locations, subjects: $subjects, title:
+        $title, index: $index, from: $from, booleanType: $booleanType, accessToFilesFilter:
+        $accessToFilesFilter, contentTypeFilter: $contentTypeFilter, contributorsFilter:
+        $contributorsFilter, formatFilter: $formatFilter, languagesFilter: $languagesFilter,
+        literaryFormFilter: $literaryFormFilter, placesFilter: $placesFilter, sourceFilter:
+        $sourceFilter, subjectsFilter: $subjectsFilter) {\n    hits\n    records {\n      timdexRecordId\n      title\n      contentType\n      contributors
+        {\n        kind\n        value\n      }\n      publicationInformation\n      dates
+        {\n        kind\n        value\n      }\n      links {\n        kind\n        restrictions\n        text\n        url\n      }\n      notes
+        {\n        kind\n        value\n      }\n      highlight {\n        matchedField\n        matchedPhrases\n      }\n      provider\n      rights
+        {\n        kind\n        description\n        uri\n      }\n      sourceLink\n      summary\n    }\n    aggregations
+        {\n      accessToFiles {\n        key\n        docCount\n      }\n      contentType
+        {\n        key\n        docCount\n      }\n      contributors {\n        key\n        docCount\n      }\n      format
+        {\n        key\n        docCount\n      }\n      languages {\n        key\n        docCount\n      }\n      literaryForm
+        {\n        key\n        docCount\n      }\n      places {\n        key\n        docCount\n      }\n      source
+        {\n        key\n        docCount\n      }\n      subjects {\n        key\n        docCount\n      }\n    }\n  }\n}","variables":{"from":"0","q":"asdf","booleanType":"AND","index":"FAKE_TIMDEX_INDEX"},"operationName":"TimdexSearch__BaseQuery"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - MIT Libraries Client
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Mon, 29 Apr 2024 20:26:42 GMT
+      Report-To:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1714422402&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=KqQRyemQQ1HwVHjJpBB28MzZaPMzbF7x5aMW8XV72DU%3D"}]}'
+      Reporting-Endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1714422402&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=KqQRyemQQ1HwVHjJpBB28MzZaPMzbF7x5aMW8XV72DU%3D
+      Nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"f38a0881ab435e9ed9321d2e97e39d4c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d6a48cab-4521-4ff2-9a53-f2096f276f4e
+      X-Runtime:
+      - '0.408223'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '3225'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJkYXRhIjp7InNlYXJjaCI6eyJoaXRzIjoxLCJyZWNvcmRzIjpbeyJ0aW1kZXhSZWNvcmRJZCI6ImFsbWE6OTkzNTAyMDYwMzIwNjc2MSIsInRpdGxlIjoiQXJjaGl0ZWN0aW5nIERlcGVuZGFibGUgU3lzdGVtcyBWSUkiLCJjb250ZW50VHlwZSI6WyJMYW5ndWFnZSBtYXRlcmlhbCJdLCJjb250cmlidXRvcnMiOlt7ImtpbmQiOiJlZGl0b3IiLCJ2YWx1ZSI6IkNhc2ltaXJvLCBBbnRvbmlvIn0seyJraW5kIjoiZWRpdG9yIiwidmFsdWUiOiJkZSBMZW1vcywgUm9nw6lyaW8ifSx7ImtpbmQiOiJlZGl0b3IiLCJ2YWx1ZSI6IkdhY2VrLCBDcmlzdGluYSJ9XSwicHVibGljYXRpb25JbmZvcm1hdGlvbiI6bnVsbCwiZGF0ZXMiOlt7ImtpbmQiOiJQdWJsaWNhdGlvbiBkYXRlIiwidmFsdWUiOiIyMDEwIn1dLCJsaW5rcyI6W3sia2luZCI6IkRpZ2l0YWwgb2JqZWN0IFVSTCIsInJlc3RyaWN0aW9ucyI6bnVsbCwidGV4dCI6IlNwcmluZ2VyIExlY3R1cmUgTm90ZXMgaW4gQ29tcHV0ZXIgU2NpZW5jZSBlQm9va3MiLCJ1cmwiOiJodHRwczovL25hMDYuYWxtYS5leGxpYnJpc2dyb3VwLmNvbS92aWV3L3VyZXNvbHZlci8wMU1JVF9JTlNUL29wZW51cmw/dS5pZ25vcmVfZGF0ZV9jb3ZlcmFnZT10cnVlXHUwMDI2cG9ydGZvbGlvX3BpZD01MzUzNTM2NTE5MDAwNjc2MVx1MDAyNkZvcmNlX2RpcmVjdD10cnVlIn1dLCJub3RlcyI6W3sia2luZCI6IlRpdGxlIFN0YXRlbWVudCBvZiBSZXNwb25zaWJpbGl0eSIsInZhbHVlIjpbImVkaXRlZCBieSBBbnRvbmlvIENhc2ltaXJvLCBSb2fDqXJpbyBkZSBMZW1vcywgQ3Jpc3RpbmEgR2FjZWsiXX0seyJraW5kIjoiR2VuZXJhbCBOb3RlIiwidmFsdWUiOlsiQmlibGlvZ3JhcGhpYyBMZXZlbCBNb2RlIG9mIElzc3VhbmNlOiBNb25vZ3JhcGgiXX0seyJraW5kIjoiQmlibGlvZ3JhcGh5IE5vdGUiLCJ2YWx1ZSI6WyJJbmNsdWRlcyBiaWJsaW9ncmFwaGljYWwgcmVmZXJlbmNlcyBhbmQgYXV0aG9yIGluZGV4Il19XSwiaGlnaGxpZ2h0IjpbeyJtYXRjaGVkRmllbGQiOiJjb250ZW50cyIsIm1hdGNoZWRQaHJhc2VzIjpbIlx1MDAzY3NwYW4gY2xhc3M9XCJoaWdobGlnaHRcIlx1MDAzZUFTREZcdTAwM2Mvc3Bhblx1MDAzZTogQW4gQXV0b21hdGVkLCBPbmxpbmUgRnJhbWV3b3JrIGZvciBEaWFnbm9zaW5nIFBlcmZvcm1hbmNlIFByb2JsZW1zIl19XSwicHJvdmlkZXIiOm51bGwsInJpZ2h0cyI6bnVsbCwic291cmNlTGluayI6Imh0dHBzOi8vbWl0LnByaW1vLmV4bGlicmlzZ3JvdXAuY29tL2Rpc2NvdmVyeS9mdWxsZGlzcGxheT92aWQ9MDFNSVRfSU5TVDpNSVRcdTAwMjZkb2NpZD1hbG1hOTkzNTAyMDYwMzIwNjc2MSIsInN1bW1hcnkiOlsiQXMgc29mdHdhcmUgc3lzdGVtcyBiZWNvbWUgaW5jcmVhc2luZ2x5IHViaXF1aXRvdXMsIGlzc3VlcyBvZiBkZXBlbmRhYmlsaXR5IGJlY29tZSBldmVyIG1vcmUgY3J1Y2lhbC4gR2l2ZW4gdGhhdCBzb2x1dGlvbnMgdG8gdGhlc2UgaXNzdWVzIG11c3QgYmUgY29uc2lkZXJlZCBmcm9tIHRoZSB2ZXJ5IGJlZ2lubmluZyBvZiB0aGUgZGVzaWduIHByb2Nlc3MsIGl0IGlzIGNsZWFyIHRoYXQgZGVwZW5kYWJpbGl0eSBhbmQgc2VjdXJpdHkgaGF2ZSB0byBiZSBhZGRyZXNzZWQgYXQgdGhlIGFyY2hpdGVjdHVyYWwgbGV2ZWwuIFRoaXMgYm9vaywgYXMgd2VsbCBhcyBpdHMgc2l4IHByZWRlY2Vzc29ycywgd2FzIGJvcm4gb2YgYW4gZWZmb3J0IHRvIGJyaW5nIHRvZ2V0aGVyIHRoZSByZXNlYXJjaCBjb21tdW5pdGllcyBvZiBzb2Z0d2FyZSBhcmNoaXRlY3R1cmVzLCBkZXBlbmRhYmlsaXR5LCBhbmQgc2VjdXJpdHkuIFRoaXMgc3RhdGUtb2YtdGhlLWFydCBzdXJ2ZXkgY29udGFpbnMgZXhwYW5kZWQsIHBlZXItcmV2aWV3ZWQgcGFwZXJzIGJhc2VkIG9uIHNlbGVjdGVkIGNvbnRyaWJ1dGlvbnMgZnJvbSB0aGUgV29ya3Nob3Agb24gQXJjaGl0ZWN0aW5nIERlcGVuZGFibGUgU3lzdGVtcyAoV0FEUyAyMDA5KSwgaGVsZCBhdCB0aGUgSW50ZXJuYXRpb25hbCBDb25mZXJlbmNlIG9uIERlcGVuZGFibGUgU3lzdGVtcyBhbmQgTmV0d29ya3MgKERTTiAyMDA5KSwgYXMgd2VsbCBhcyBhIG51bWJlciBvZiBpbnZpdGVkIHBhcGVycyB3cml0dGVuIGJ5IHJlbm93bmVkIGV4cGVydHMgaW4gdGhlIGFyZWEuIFRoZSAxMyBwYXBlcnMgYXJlIG9yZ2FuaXplZCBpbiB0b3BpY2FsIHNlY3Rpb25zIG9uOiBtb2JpbGUgYW5kIHViaXF1aXRvdXMgc3lzdGVtcywgYXJjaGl0ZWN0aW5nIHN5c3RlbXMsIGZhdWx0IG1hbmFnZW1lbnQsIGFuZCBleHBlcmllbmNlIGFuZCB2aXNpb24uIl19XSwiYWdncmVnYXRpb25zIjp7ImFjY2Vzc1RvRmlsZXMiOltdLCJjb250ZW50VHlwZSI6W3sia2V5IjoibGFuZ3VhZ2UgbWF0ZXJpYWwiLCJkb2NDb3VudCI6MX1dLCJjb250cmlidXRvcnMiOlt7ImtleSI6ImNhc2ltaXJvLCBhbnRvbmlvIiwiZG9jQ291bnQiOjF9LHsia2V5IjoiZGUgbGVtb3MsIHJvZ8OpcmlvIiwiZG9jQ291bnQiOjF9LHsia2V5IjoiZ2FjZWssIGNyaXN0aW5hIiwiZG9jQ291bnQiOjF9XSwiZm9ybWF0IjpbXSwibGFuZ3VhZ2VzIjpbeyJrZXkiOiJlbmdsaXNoIiwiZG9jQ291bnQiOjF9XSwibGl0ZXJhcnlGb3JtIjpbeyJrZXkiOiJub25maWN0aW9uIiwiZG9jQ291bnQiOjF9XSwicGxhY2VzIjpbXSwic291cmNlIjpbeyJrZXkiOiJtaXQgYWxtYSIsImRvY0NvdW50IjoxfV0sInN1YmplY3RzIjpbeyJrZXkiOiJzb2Z0d2FyZSBlbmdpbmVlcmluZyIsImRvY0NvdW50IjoyfSx7ImtleSI6ImNvbXB1dGVyIGxvZ2ljIiwiZG9jQ291bnQiOjF9LHsia2V5IjoiY29tcHV0ZXIgcHJvZ3JhbW1pbmciLCJkb2NDb3VudCI6MX0seyJrZXkiOiJjb21wdXRlcnMiLCJkb2NDb3VudCI6MX0seyJrZXkiOiJsb2dpY3MgYW5kIG1lYW5pbmdzIG9mIHByb2dyYW1zIiwiZG9jQ291bnQiOjF9LHsia2V5IjoibW9kZWxzIGFuZCBwcmluY2lwbGVzIiwiZG9jQ291bnQiOjF9LHsia2V5IjoicHJvZ3JhbW1pbmcgbGFuZ3VhZ2VzIChlbGVjdHJvbmljIGNvbXB1dGVycykiLCJkb2NDb3VudCI6MX0seyJrZXkiOiJwcm9ncmFtbWluZyBsYW5ndWFnZXMsIGNvbXBpbGVycywgaW50ZXJwcmV0ZXJzIiwiZG9jQ291bnQiOjF9LHsia2V5IjoicHJvZ3JhbW1pbmcgdGVjaG5pcXVlcyIsImRvY0NvdW50IjoxfSx7ImtleSI6InNvZnR3YXJlIGVuZ2luZWVyaW5nL3Byb2dyYW1taW5nIGFuZCBvcGVyYXRpbmcgc3lzdGVtcyIsImRvY0NvdW50IjoxfV19fX19
+  recorded_at: Mon, 29 Apr 2024 20:26:42 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
#### Why these changes are being introduced:

We had been leaning on the search form to remind users of the current search params, but this is not always reliable (e.g., if a input is cleared without executing a new search).

#### Relevant ticket(s):

* [GDT-285](https://mitlibraries.atlassian.net/browse/GDT-285)

#### How this addresses that need:

This displays applied search terms in the summary panel where we show applied filters.

#### Side effects of this change:

Two skipped tests, which confirmed an earlier iteration of this feature, have been reintroduced.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

It may be useful to apply some filters to see what that looks like alongside the applied search terms. (I separated them with a border, which I don't love aesthetically, but it probably adds visual clarity.)

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-285]: https://mitlibraries.atlassian.net/browse/GDT-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ