### PR TITLE
Relabel geospatial and advanced search accordion menus

### DIFF
--- a/app/javascript/search_form.js
+++ b/app/javascript/search_form.js
@@ -10,7 +10,6 @@ function disableAdvanced() {
     field => field.value = ''
   );
   advanced_label.classList = 'closed';
-  advanced_label.innerText = 'Advanced search';
 };
 
 function enableAdvanced() {
@@ -22,7 +21,6 @@ function enableAdvanced() {
     keyword_field.setAttribute('placeholder', 'Keyword anywhere');
   }
   advanced_label.classList = 'open';
-  advanced_label.innerText = 'Close advanced search';
 };
 
 function disableGeobox() {
@@ -40,7 +38,6 @@ function disableGeobox() {
     field.setAttribute('aria-required', false);
   });
   geobox_label.classList = 'closed';
-  geobox_label.innerText = 'Geospatial bounding box search';
 };
 
 function enableGeobox() {
@@ -58,7 +55,6 @@ function enableGeobox() {
     field.setAttribute('aria-required', true);
   });
   geobox_label.classList = 'open';
-  geobox_label.innerText = 'Close bounding box search';
 };
 
 function disableGeodistance() {
@@ -76,7 +72,6 @@ function disableGeodistance() {
     field.setAttribute('aria-required', false);
   });
   geodistance_label.classList = 'closed';
-  geodistance_label.innerText = 'Geospatial distance search';
 };
 
 function enableGeodistance() {
@@ -94,7 +89,6 @@ function enableGeodistance() {
     field.setAttribute('aria-required', true);
   });
   geodistance_label.classList = 'open';
-  geodistance_label.innerText = 'Close distance search';
 };
 
 

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -6,11 +6,10 @@ if params[:q]
 end
 
 # Initial form setup is determined by the advanced parameter. Thereafter it is altered by javascript.
-advanced_label = "Advanced search"
+advanced_label = "Search by title, author, etc."
 advanced_label_class = "closed"
 search_required = true
 if params[:advanced] == "true"
-  advanced_label = "Close advanced search"
   advanced_label_class = "open"
   search_required = false
 end
@@ -18,7 +17,6 @@ end
 geobox_label = "Geospatial bounding box search"
 geobox_label_class = "closed"
 if params[:geobox] == "true"
-  geobox_label = "Close bounding box search"
   geobox_label_class = "open"
   geobox_required = true
   search_required = false
@@ -27,7 +25,6 @@ end
 geodistance_label = "Geospatial distance search"
 geodistance_label_class = "closed"
 if params[:geodistance] == "true"
-  geodistance_label = "Close distance search"
   geodistance_label_class = "open"
   geodistance_required = true
   search_required = false


### PR DESCRIPTION
#### Why these changes are being introduced:

The change in label for these accordions when open (e.g., 'Advanced search' to 'Close advanced search') is unnecessary and confused some usability test participants.

The 'Advanced search' menu was also unused without prompting in usuability testing. UXWS has suggested relabeling it for clarity.

#### Relevant ticket(s):

* [GDT-301](https://mitlibraries.atlassian.net/browse/GDT-301)

#### How this addresses that need:

This relabels the accordion menus as suggested by UXWS.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

N/A.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-301]: https://mitlibraries.atlassian.net/browse/GDT-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ