### PR TITLE
Fix spacing for search summary panel

### DIFF
--- a/app/assets/stylesheets/partials/_panels.scss
+++ b/app/assets/stylesheets/partials/_panels.scss
@@ -127,15 +127,17 @@
     font-size: $fs-small;
     text-decoration: none;
     margin-right: 2rem;
+    margin-bottom: 0;
   }
-  .applied-term {
+  .terms-list {
     margin-top: .5rem;
+    margin-bottom: 0;
     &:first-child {
       margin-top: 0;
     }
   }
   .keyword {
-    margin-bottom: 1.2rem;
+    margin-bottom: .8rem;
   }
   .applied-filter {
     padding: .5rem;

--- a/app/views/search/_search_summary.html.erb
+++ b/app/views/search/_search_summary.html.erb
@@ -12,8 +12,8 @@
           <li class="applied-term keyword"><%= applied_keyword(@enhanced_query).first %></li>
         <% end %>
         <% if applied_geobox_terms(@enhanced_query).present? %>
-          <li class="applied-term">
-            <ul class="list-inline">
+          <li>
+            <ul class="list-inline terms-list">
               <% applied_geobox_terms(@enhanced_query).each do |term| %>
                 <li class="applied-term"><%= term %></li>
               <% end %>
@@ -21,8 +21,8 @@
           </li>
         <% end %>
         <% if applied_geodistance_terms(@enhanced_query).present? %>
-          <li class="applied-term">
-            <ul class="list-inline">
+          <li>
+            <ul class="list-inline terms-list">
               <% applied_geodistance_terms(@enhanced_query).each do |term| %>
                 <li class="applied-term"><%= term %></li>
               <% end %>
@@ -30,8 +30,8 @@
           </li>
         <% end %>
         <% if applied_advanced_terms(@enhanced_query).present? %>
-          <li class="applied-term">
-            <ul class="list-inline">
+          <li>
+            <ul class="list-inline terms-list">
               <% applied_advanced_terms(@enhanced_query).each do |term| %>
                 <li class="applied-term"><%= term %></li>
               <% end %>


### PR DESCRIPTION
#### Why these changes are being introduced:

The current CSS rules for the search summary panel results in an unintended top margin if geospatial/advanced search terms are entered without a keyword.

#### Relevant ticket(s):

N/A

#### How this addresses that need:

This puts the top margin for applied terms on the `ul` elements instead of the `li` elements. It also adjusts the margin to match the others.

#### Side effects of this change:

N/A

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

This is unticketed because I noticed it while working on an unrelated ticket.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.
