### PR TITLE
Fact panels controlled via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ feature flag enabled, and do not when it is disabled.
 - `BOOLEAN_OPTIONS`: comma separated list of values to present to testers on instances where `BOOLEAN_PICKER` feature is enabled.
 - `BOOLEAN_PICKER`: feature to allow users to select their preferred boolean type. If set, feature is enabled. This feature is only intended for internal team
   testing and should never be enabled in production (mostly because the UI is a mess more than it would cause harm).
+- `FACT_PANELS_ENABLED`: Comma separated list of enabled fact panels. See `/views/results.html.erb` for implemented panels/valid options. Leave unset to disable all.
 - `FILTER_ACCESS_TO_FILES`: The name to use instead of "Access to files" for that filter / aggregation.
 - `FILTER_CONTENT_TYPE`: The name to use instead of "Content type" for that filter / aggregation.
 - `FILTER_CONTRIBUTOR`: The name to use instead of "Contributor" for that filter / aggregation.

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,4 +1,8 @@
 module ResultsHelper
+  def fact_enabled?(fact_type)
+    ENV.fetch('FACT_PANELS_ENABLED', false).split(',').include?(fact_type)
+  end
+
   def results_summary(hits)
     hits.to_i >= 10_000 ? '10,000+ results' : "#{number_with_delimiter(hits)} results"
   end

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -7,12 +7,14 @@
   <%= render partial: "form" %>
   <%= render partial: "search_summary" %>
 
-  <div id="hint" aria-live="polite">
-    <%= render(partial: 'search/issn') %>
-    <%= render(partial: 'search/isbn') %>
-    <%= render(partial: 'search/pmid') %>
-    <%= render(partial: 'search/doi') %>
-  </div>
+  <% if ENV.fetch('FACT_PANELS_ENABLED', false).present? %>
+    <div id="hint" aria-live="polite">
+      <%= render(partial: 'search/issn') if fact_enabled?('issn') %>
+      <%= render(partial: 'search/isbn') if fact_enabled?('isbn') %>
+      <%= render(partial: 'search/pmid') if fact_enabled?('pmid') %>
+      <%= render(partial: 'search/doi') if fact_enabled?('doi') %>
+    </div>
+  <% end %>
 
   <%= render(partial: 'shared/error', collection: @errors) %>
 


### PR DESCRIPTION
Why are these changes being introduced:

* Our experimental fact panels need to be disabled by default now that a version of this UI is moving to production

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-313

How does this address that need:

* Adds a configuration option that takes a comma separated list of fact panels that should be enabled.
* If a fact panel is enabled and there is a a detected fact of that type a fact panel will display as it did previously. If a fact is detected of a type in which no fact panel has been enabled, we do not display a fact panel.
* If no fact panels are enabled, we don't check for specific fact panels to determine if they should be enabled.

Document any side effects to this change:

After discussion with the team, we chose not to use FlipFlop for this work. We'll be considering over time whether the approach taken here is a good option instead of reaching for FlipFlop at least in situations where the feature does not extend into many places in the codebase.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [x] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
