### PR TITLE
Deduplicate subject values in GDT

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -124,6 +124,13 @@ module RecordHelper
     locations.any? { |location| location['geoshape'] }
   end
 
+  # It is possible for duplicate subject values to appear for the same record.
+  def deduplicate_subjects(subjects)
+    return if subjects.blank?
+
+    subjects.map { |subject| subject['value'].uniq(&:downcase) }.uniq { |values| values.map(&:downcase) }
+  end
+
   private
 
   def render_kind_value(list)

--- a/app/views/record/_record_geo.html.erb
+++ b/app/views/record/_record_geo.html.erb
@@ -62,8 +62,8 @@
     <% if @record['subjects'].present? %>
       <h3 class="section-title">Subjects</h3>
       <ul>
-      <% @record['subjects'].each do |subject| %>
-        <li><%= subject['value'].join('; ') %></li>
+      <% deduplicate_subjects(@record['subjects'])&.each do |subject| %>
+        <li><%= subject.join('; ') %></li>
       <% end %>
       </ul>
     <% end %>

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -301,4 +301,32 @@ class RecordHelperTest < ActionView::TestCase
     locations = []
     assert_not geospatial_coordinates?(locations)
   end
+
+  test 'deduplicate_subjects returns only unique subjects' do
+    # within the same subject
+    duplicative_subject = [{ 'kind' => 'foo', 'value' => ['bar', 'bar', 'baz']}]
+    assert_equal [['bar', 'baz']], deduplicate_subjects(duplicative_subject)
+
+    # across multiple subjects
+    multiple_duplicative_subjects = [{ 'kind' => 'foo', 'value' => ['bar'] },
+                                     { 'kind' => 'baz', 'value' => ['bar'] }]
+    assert_equal [['bar']], deduplicate_subjects(multiple_duplicative_subjects)
+  end
+
+  test 'deduplicate_subjects ignores case' do
+    # within the same subject
+    duplicative_subject = [{ 'kind' => 'foo', 'value' => ['Bar', 'BAR', 'bar']}]
+    assert_equal [['Bar']], deduplicate_subjects(duplicative_subject)
+
+    # across multiple subjects
+    multiple_duplicative_subjects = [{ 'kind' => 'foo', 'value' => ['Bar'] },
+                                     { 'kind' => 'foo', 'value' => ['BAR'] },
+                                     { 'kind' => 'foo', 'value' => ['bar'] }]
+    assert_equal [['Bar']], deduplicate_subjects(multiple_duplicative_subjects)
+  end
+
+  test 'deduplicate_subjects returns nothing if subjects are not present' do
+    subjects = []
+    assert_nil deduplicate_subjects(subjects)
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

The same subject value can appear twice in the full record view. In some cases, this is because the value appears in the record for different subject kinds. However, it's also entirely possible for the same kind/value pair to appear multiple times [in the same record](https://timdex-ui-prod.herokuapp.com/record/alma:990005961340106761), so merely including the subject kinds as we do in other TIMDEX UI apps does not solve this problem.

#### Relevant ticket(s):

* [GDT-297](https://mitlibraries.atlassian.net/browse/GDT-297)

#### How this addresses that need:

This adds a `deduplicate_subjects` method that calls `uniq` on a record's subject values (within a given term and across all term), then returns the deduplicated, two-dimensional array of values.

#### Side effects of this change:

Case is ignored to manage known instances of the same subject value appearing as capitalized and lower-case. However, passing the `downcase` to `uniq` causes it to select the first instance it finds, meaning it may select the lower-case value if it comes first in the record.

This feels like more of an annoyance than a bug, so I've chosen not to add complexity to the deduplication method to fix it. (Calling `humanize` on every subject value was tempting, but I suspect there may be subjects that are intentionally case-sensitive.)

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Example records:

* [Population Bands, Guatemala, 2014](https://geodata.libraries.mit.edu/record/gisogm:edu.stanford.purl:0eee84352f75): duplicate entries for 'Society' should be deduplicated in the [review app](https://timdex-ui-pi-gdt-297-de-exbh3m.herokuapp.com/record/gisogm:edu.stanford.purl:0eee84352f75).
* [Colorado Rivers](https://geodata.libraries.mit.edu/record/gisogm:edu.harvard:c227f00bf1cd): a case where additional string manipulation may be useful (see "inlandWaters" subject). However, as noted above, I wonder if enforced `titleize`/`lowercase`/`humanize`/etc would inadvertently mangle case-sensitive subjects (e.g., 'NPS data sets').
* [Colorado Block Groups](https://geodata.libraries.mit.edu/record/gisogm:edu.harvard:bcf67d2b61d0): 'society' appears twice, once titlecase and once lowercase. This should be deduplicated in the [review app](https://timdex-ui-pi-gdt-297-de-exbh3m.herokuapp.com/record/gisogm:edu.harvard:bcf67d2b61d0).

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-297]: https://mitlibraries.atlassian.net/browse/GDT-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ