### PR TITLE
Consolidate full record access links in sidebar

### DIFF
--- a/app/assets/stylesheets/partials/_record.scss
+++ b/app/assets/stylesheets/partials/_record.scss
@@ -5,12 +5,15 @@
   }
 
   .access-button-container {
-    margin-top: 2.6rem;
-    .access-button {
+    .access-button,
+    .metadata-link {
+      display: block;
       font-weight: $fw-bold;
       text-align: center;
       padding-top: 1rem;
       padding-bottom: 1rem;
+    }
+    .access-button {
       .auth-notice {
         &::before {
           font-family: FontAwesome;
@@ -21,6 +24,9 @@
         margin-top: 1rem;
         display: block;
       }
+    }
+    .metadata-link {
+      margin-top: 1rem;
     }
   }
   .hidden-md {
@@ -36,8 +42,7 @@
        display: none;
     }
   }
-  .section-title,
-  .metadata-link {
+  .section-title {
     margin-top: 1.4em;
   }
 }
@@ -60,4 +65,8 @@
       margin-right: 1rem;
     }
   }
+}
+
+.access-sidebar {
+  padding-top: 3%;
 }

--- a/app/views/record/_access_buttons.html.erb
+++ b/app/views/record/_access_buttons.html.erb
@@ -1,6 +1,6 @@
 <% return if @record.blank? %>
 
-<div class="access-button-container <%= display %>">
+<div class="access-button-container">
   <% if access_type(@record) == 'no authentication required' %>
     <a class="btn button-primary access-button" href="<%= gis_access_link(@record) %>">Download geodata files</a>
   <% elsif access_type(@record) == 'MIT authentication required' %>
@@ -11,6 +11,12 @@
     <p>This content is owned by: <strong><%= @record['provider'] %></strong></p>
     <a class="btn button-primary access-button" href="<%= gis_access_link(@record) %>">
       View <%= @record['provider'] %> record
+    </a>
+  <% end %>
+  <% if access_type(@record) != 'unknown: check with owning institution' &&
+        source_metadata_available?(@record['links']) %>
+    <a class="btn button-secondary metadata-link" href="<%= source_metadata_link(@record['links']) %>">
+      Download full metadata
     </a>
   <% end %>
 </div>

--- a/app/views/record/_record_geo.html.erb
+++ b/app/views/record/_record_geo.html.erb
@@ -124,14 +124,6 @@
       <% end %>
       </ul>
     <% end %>
-
-    <div class="record-access-links">
-      <% if access_type(@record) != 'unknown: check with owning institution' && source_metadata_available?(@record['links']) %>
-        <a class="btn button-secondary metadata-link"
-           href="<%= source_metadata_link(@record['links']) %>">Download full metadata</a>
-      <% end %>
-      <%= render partial: 'access_button', locals: { display: 'view-md' } %> 
-    </div>
   </main>
 
   <%= render('sidebar') %>

--- a/app/views/record/_sidebar.html.erb
+++ b/app/views/record/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% if Flipflop.enabled?(:gdt) %>
-  <div role="region" aria-label="Access link and additional information" class="col1q-r sidebar">
+  <div role="region" aria-label="Access links and additional information" class="col1q-r sidebar access-sidebar">
 <% else %>
   <aside class="col1q-r sidebar">
 <% end %>
@@ -13,7 +13,8 @@
   <% end %>
 
   <% if Flipflop.enabled?(:gdt) && access_type(@record) && gis_access_link(@record) %>
-    <%= render partial: 'access_button', locals: { display: 'hidden-md' } %>
+    <h2 class="title hd-4">Access links</h2>
+    <%= render partial: 'access_buttons' %>
   <% end %>
 
    <%= render partial: 'shared/ask', locals: { display: '' } %>


### PR DESCRIPTION
#### Why these changes are being introduced:

The metadata download link appears at the end of the full record with no heading. This makes it look like part of the last full record heading (usually 'Languages').

A related issue is that the access link in the sidebar has no heading. We have an `aria-label` that describes this section for screen reader users, but for sighted users, this section lacks context.

As part of their accessibility review, DAS has recommended moving the metadata download link to the same section as the access link.

#### Relevant ticket(s):

* [GDT-319](https://mitlibraries.atlassian.net/browse/GDT-319)

#### How this addresses that need:

This moves the download link below the access link in the sidebar, and adds a heading to that section.

#### Side effects of this change:

While working on this, I noticed that the fact panel markup needs some work to be semantically meaningful. I haven't touched that in this commit, but it will be worth revisiting when we return to search intent detection.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-319]: https://mitlibraries.atlassian.net/browse/GDT-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ