### PR TITLE
Accommodate multi-digit list markers

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -28,6 +28,16 @@
       margin-top: 0;
     }
   }
+
+  .results-list {
+    @media (max-width: $bp-screen-md) {
+      .result {
+        padding-left: 0;
+        padding-right: 0;
+        margin-left: 3rem;
+      }
+    }
+  }
 }
 
 .result {


### PR DESCRIPTION
#### Why these changes are being introduced:

The result list does not have a sufficient left margin to
accommodate list markers that are more than one digit. Because
of this, markers for results further down in the list are
truncated.

This issue exists on smaller viewports only. Larger viewports
have enough space for markers up to five digits. (This is the
maximum, in our case.)

#### Relevant ticket(s):

* [GDT-314](https://mitlibraries.atlassian.net/browse/GDT-314)

#### How this addresses that need:

This adds a left margin on smaller viewports to accommodate
4-digit result markers, and removes the result padding to provide
more room for text flow.

#### Side effects of this change:

* The margin is somewhat excessive for 1- or 2-digit numbers, but
it seems like a reasonable tradeoff for now.
* The leading digit of 5-digit numbers is still truncated. This only
affects one possible result, and it's unlikely that a user would get
to result 10,000.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Try a broad search (I use 'data') and confirm that you can see all five digits of result marker 10000 on page 500.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-314]: https://mitlibraries.atlassian.net/browse/GDT-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ