### PR TITLE
Improve markup for contributors

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -107,6 +107,7 @@
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
   }
 
   .inner-heading {

--- a/app/assets/stylesheets/partials/_shared.scss
+++ b/app/assets/stylesheets/partials/_shared.scss
@@ -1,9 +1,18 @@
 .result,
 .full-record {
-  .authors {
+  .contributors {
     font-size: 1.6rem;
     font-weight: $fw-bold;
     margin-bottom: 0.6em;
+    li {
+      display: inline;
+    }
+    li::after {
+      content: " ; ";
+    }
+    li:last-child:after {
+      content: "";
+    }
   }
 
   .data-info {

--- a/app/views/record/_record_geo.html.erb
+++ b/app/views/record/_record_geo.html.erb
@@ -14,9 +14,10 @@
     </div>
 
     <% if @record['contributors'].present? %>
-      <p class="authors">
-        <%= render partial: 'shared/authors', locals: { contributors: @record['contributors'] } %>
-      </p>
+      <span class="sr">Contributors: </span>
+      <ul class="list-inline contributors">
+        <%= render partial: 'shared/contributors', locals: { contributors: @record['contributors'] } %>
+      </ul>
     <% end %>
 
     <% if @record['alternateTitles'].present? %>

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -12,9 +12,10 @@
     </span>
   </p>
 
-  <p class="authors">
-    <%= render partial: 'shared/authors', locals: { contributors: result['contributors'] } %>
-  </p>
+  <span class="sr">Contributors: </span>
+  <ul class="list-inline truncate-list contributors">
+    <%= render partial: 'shared/contributors', locals: { contributors: result['contributors'] } %>
+  </ul>
 
   <div class="result-highlights">
     <%= render partial: 'search/highlights', locals: { result: result } %>

--- a/app/views/search/_result_geo.html.erb
+++ b/app/views/search/_result_geo.html.erb
@@ -8,9 +8,10 @@
   </div>
 
   <% if result_geo['contributors'] %> 
-    <p class="authors truncate-list">
-      <%= render partial: 'shared/authors', locals: { contributors: result_geo['contributors'] } %>
-    </p>
+    <span class="sr">Contributors: </span>
+    <ul class="list-inline truncate-list contributors">
+      <%= render partial: 'shared/contributors', locals: { contributors: result_geo['contributors'] } %>
+    </ul>
   <% end %>
 
   <% if result_geo['summary'] %>

--- a/app/views/shared/_contributors.html.erb
+++ b/app/views/shared/_contributors.html.erb
@@ -1,0 +1,5 @@
+<%= return if contributors.blank? %>
+
+<% contributors.uniq do |contributor| %>
+  <li><%= link_to contributor['value'], results_path({ advanced: true, contributors: contributor['value'] }) %></li>
+<% end %>


### PR DESCRIPTION
#### Why these changes are being introduced:

Authors are currently rendered within a `p` tag. This is not very semantically meaningful.

#### Relevant ticket(s):

* [GDT-284](https://mitlibraries.atlassian.net/browse/GDT-284)

#### How this addresses that need:

This refactors the contributors section to a partial and renders contributors as an unordered list. It is the same changeset that was introduced in #191, but without displaying the contributor type, which UXWS has deemed unnecessary at this time.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

N/A

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[GDT-284]: https://mitlibraries.atlassian.net/browse/GDT-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ