### PR TITLE
Refactor search form JS

### DIFF
--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -48,14 +48,6 @@
         font-family: FontAwesome;
         margin-right: 1rem;
       }
-
-      &.closed:before {
-        content: '\f054';
-      }
-
-      &.open:before {
-        content: '\f078';
-      }
     }
 
     &::-webkit-details-marker {
@@ -69,6 +61,22 @@
     fieldset {
       legend {
         color: $black;
+      }
+    }
+    #advanced-search-label,
+    #geobox-search-label,
+    #geodistance-search-label {
+      &::before {
+        content: '\f054';
+      }
+    }
+    &[open] {
+      #advanced-search-label,
+      #geobox-search-label,
+      #geodistance-search-label {
+        &::before {
+          content: '\f078';
+        }
       }
     }
   }

--- a/app/javascript/search_form.js
+++ b/app/javascript/search_form.js
@@ -1,123 +1,80 @@
-function disableAdvanced() {
-  advanced_field.setAttribute('value', '');
-  if (geobox_label.classList.contains('closed') && geodistance_label.classList.contains('closed')) {
-    keyword_field.toggleAttribute('required');
-    keyword_field.classList.toggle('required');
-    keyword_field.setAttribute('placeholder', 'Enter your search');
-  }
-  [...details_panel.getElementsByClassName('field')].forEach(
-    field => field.value = ''
-  );
-  advanced_label.classList = 'closed';
-};
+var keywordField = document.getElementById('basic-search-main');
+var advancedPanel = document.getElementById('advanced-search-panel');
+var geoboxPanel = document.getElementById('geobox-search-panel');
+var geodistancePanel = document.getElementById('geodistance-search-panel');
+var allPanels = document.getElementsByClassName('form-panel');
 
-function enableAdvanced() {
-  advanced_field.setAttribute('value', 'true');
-  if (geobox_label.classList.contains('closed') && geodistance_label.classList.contains('closed')) {
-    keyword_field.toggleAttribute('required');
-    keyword_field.classList.toggle('required');
-    keyword_field.setAttribute('placeholder', 'Keyword anywhere');
+function togglePanelState(currentPanel) {
+  // Only the geoboxPanel and geodistancePanel inputs need to be required. Advanced search inputs do not.
+  if (currentPanel === geoboxPanel || currentPanel === geodistancePanel) {
+    toggleRequiredFieldset(currentPanel);
   }
-  advanced_label.classList = 'open';
-};
 
-function disableGeobox() {
-  if (advanced_label.classList.contains('closed') && geodistance_label.classList.contains('closed')) {
-    keyword_field.toggleAttribute('required');
-    keyword_field.classList.toggle('required');
-    keyword_field.setAttribute('placeholder', 'Enter your search');
-  }
-  geobox_field.setAttribute('value', '');
-  [...geobox_details_panel.getElementsByClassName('field')].forEach(function(field) {
+  // These two functions are delayed to ensure that events have propagated first. Otherwise, they will fire before
+  // the `open` attribute has toggled on the currentPanel, resulting in unexpected behavior.
+  setTimeout(toggleKeywordRequired, 0);
+  setTimeout(updateKeywordPlaceholder, 0);
+
+  // Finally, enable or disable the search type of the current panel, based on whether it is open or not.
+  toggleSearch(currentPanel);
+}
+
+function toggleRequiredFieldset(panel) {
+  [...panel.getElementsByClassName('field')].forEach((field) => {
     field.value = '';
     field.classList.toggle('required');
     field.toggleAttribute('required');
   });
-  geobox_label.classList = 'closed';
-};
+}
 
-function enableGeobox() {
-  if (advanced_label.classList.contains('closed') && geodistance_label.classList.contains('closed')) {
-    keyword_field.toggleAttribute('required');
-    keyword_field.classList.toggle('required');
-    keyword_field.setAttribute('placeholder', 'Keyword anywhere');
-  }
-  geobox_field.setAttribute('value', 'true');
-  [...geobox_details_panel.getElementsByClassName('field')].forEach(function(field) {
-    field.value = '';
-    field.classList.toggle('required');
-    field.toggleAttribute('required');
-  });
-  geobox_label.classList = 'open';
-};
-
-function disableGeodistance() {
-  if (advanced_label.classList.contains('closed') && geobox_label.classList.contains('closed')) {
-    keyword_field.toggleAttribute('required');
-    keyword_field.classList.toggle('required');
-    keyword_field.setAttribute('placeholder', 'Enter your search');
-  }
-  geodistance_field.setAttribute('value', '');
-  [...geodistance_details_panel.getElementsByClassName('field')].forEach(function(field) {
-    field.value = '';
-    field.classList.toggle('required');
-    field.toggleAttribute('required');
-  });
-  geodistance_label.classList = 'closed';
-};
-
-function enableGeodistance() {
-  if (advanced_label.classList.contains('closed') && geobox_label.classList.contains('closed')) {
-    keyword_field.toggleAttribute('required');
-    keyword_field.classList.toggle('required');
-    keyword_field.setAttribute('placeholder', 'Keyword anywhere');
-  }
-  geodistance_field.setAttribute('value', 'true');
-  [...geodistance_details_panel.getElementsByClassName('field')].forEach(function(field) {
-    field.value = '';
-    field.classList.toggle('required');
-    field.toggleAttribute('required');
-  });
-  geodistance_label.classList = 'open';
-};
-
-
-var advanced_field = document.getElementById('advanced-search-field');
-var advanced_label = document.getElementById('advanced-search-label');
-var advanced_toggle = document.getElementById('advanced-summary');
-var details_panel = document.getElementById('advanced-search-panel');
-var keyword_field = document.getElementById('basic-search-main');
-var geobox_field = document.getElementById('geobox-search-field');
-var geobox_label = document.getElementById('geobox-search-label');
-var geobox_toggle = document.getElementById('geobox-summary');
-var geobox_details_panel = document.getElementById('geobox-search-panel');
-var geodistance_field = document.getElementById('geodistance-search-field');
-var geodistance_label = document.getElementById('geodistance-search-label');
-var geodistance_toggle = document.getElementById('geodistance-summary');
-var geodistance_details_panel = document.getElementById('geodistance-search-panel');
-
-geobox_toggle.addEventListener('click', event => {
-  if (geobox_details_panel.attributes.hasOwnProperty('open')) {
-    disableGeobox();
+// Each panel has a hidden input that, when true, enables that type of search.
+function toggleSearch(panel) {
+  let input = panel.querySelector('.fieldset-toggle');
+  if (panel.open) {
+    input.setAttribute('value', '');
   } else {
-    enableGeobox();
+    input.setAttribute('value', 'true');
   }
-});
+}
 
-geodistance_toggle.addEventListener('click', event => {
-  if (geodistance_details_panel.attributes.hasOwnProperty('open')) {
-    disableGeodistance();
+// The keyword field is required only if all panels are closed.
+function toggleKeywordRequired() {
+  if (Array.from(allPanels).every((panel) => !panel.open)) {
+    keywordField.setAttribute('required', '');
+    keywordField.classList.add('required');
   } else {
-    enableGeodistance();
+    keywordField.removeAttribute('required');
+    keywordField.classList.remove('required');
   }
-});
+}
 
-advanced_toggle.addEventListener('click', event => {
-  if (details_panel.attributes.hasOwnProperty('open')) {
-    disableAdvanced();
+// Placeholder text should be 'Keyword anywhere' if any panels are open, and 'Enter your search' otherwise.
+function updateKeywordPlaceholder() {
+  if (Array.from(allPanels).some((panel) => panel.open)) {
+    keywordField.setAttribute('placeholder', 'Keyword anywhere');
   } else {
-    enableAdvanced();
+    keywordField.setAttribute('placeholder', 'Enter your search');
   }
-});
+}
+
+// Add event listeners for all panels in the DOM. For GDT, this is currently both geospatial panels and the advanced
+// panel. In all other TIMDEX UI apps, it's just the advanced panel.
+if (Array.from(allPanels).includes(geoboxPanel && geodistancePanel)) {
+  document.getElementById('geobox-summary').addEventListener('click', () => {
+    togglePanelState(geoboxPanel);
+  });
+
+  document.getElementById('geodistance-summary').addEventListener('click', () => {
+    togglePanelState(geodistancePanel);
+  });
+
+  document.getElementById('advanced-summary').addEventListener('click', () => {
+    togglePanelState(advancedPanel);
+  });
+} else {
+  document.getElementById('advanced-summary').addEventListener('click', () => {
+    togglePanelState(advancedPanel);
+  });
+}
 
 console.log('search_form.js loaded');

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -1,44 +1,42 @@
 <%
 # Initial form setup is determined by the advanced parameter. Thereafter it is altered by javascript.
 advanced_label = "Search by title, author, etc."
-advanced_label_class = "closed"
 search_required = true
 if params[:advanced] == "true"
-  advanced_label_class = "open"
   search_required = false
 end
 
 geobox_label = "Geospatial bounding box search"
-geobox_label_class = "closed"
 if params[:geobox] == "true"
-  geobox_label_class = "open"
   geobox_required = true
   search_required = false
 end
 
 geodistance_label = "Geospatial distance search"
-geodistance_label_class = "closed"
 if params[:geodistance] == "true"
-  geodistance_label_class = "open"
   geodistance_required = true
   search_required = false
 end
+
+# Placeholder text for the keyword input changes if any of the search panels are open.
+keyword_placeholder = search_required ? "Enter your search" : "Keyword anywhere"
 %>
 
 <form id="basic-search" class="form-horizontal basic-search" action="<%= results_path %>" method="get" role="search">
   <div class="form-group">
     <input id="basic-search-main" type="search"
            class="field field-text basic-search-input <%= "required" if search_required %>" name="q"
-           title="Keyword anywhere" placeholder="Enter your search"
+           title="Keyword anywhere" placeholder="<%= keyword_placeholder %>"
            value="<%= params[:q] %>" <%= 'required' if search_required %>
            <%= 'aria-describedby=site-desc' if Flipflop.enabled?(:gdt) %>>
 
     <% if Flipflop.enabled?(:gdt) %>
-      <details id="geobox-search-panel" <%= "open" if params[:geobox] == "true" %>>
+      <details id="geobox-search-panel" class="form-panel" <%= "open" if params[:geobox] == "true" %>>
         <summary class="btn button-secondary" id="geobox-summary">
-          <span id="geobox-search-label" class="<%= geobox_label_class %>"><%= geobox_label %></span>
+          <span id="geobox-search-label"><%= geobox_label %></span>
         </summary>
-        <input id="geobox-search-field" type="hidden" name="geobox" value="<%= params[:geobox] %>">
+        <input id="geobox-search-field" class="fieldset-toggle" type="hidden" name="geobox"
+               value="<%= params[:geobox] %>">
         <fieldset>
           <legend>Search within a geospatial bounding box</legend>
           <p>* All fields in this section are required</p>
@@ -94,11 +92,12 @@ end
           </div>
         </fieldset>
       </details>
-      <details id="geodistance-search-panel" <%= "open" if params[:geodistance] == "true" %>>
+      <details id="geodistance-search-panel" class="form-panel" <%= "open" if params[:geodistance] == "true" %>>
         <summary class="btn button-secondary" id="geodistance-summary">
-          <span id="geodistance-search-label" class="<%= geodistance_label_class %>"><%= geodistance_label %></span>
+          <span id="geodistance-search-label"><%= geodistance_label %></span>
         </summary>
-        <input id="geodistance-search-field" type="hidden" name="geodistance" value="<%= params[:geodistance] %>">
+        <input id="geodistance-search-field" class="fieldset-toggle" type="hidden" name="geodistance"
+               value="<%= params[:geodistance] %>">
         <fieldset>
           <legend>Search within a distance of a geographic point</legend>
           <p>* All fields in this section are required</p>
@@ -145,11 +144,12 @@ end
       </details>
     <% end %>
 
-    <details id="advanced-search-panel" <%= "open" if params[:advanced] == "true" %>>
+    <details id="advanced-search-panel" class="form-panel" <%= "open" if params[:advanced] == "true" %>>
       <summary class="btn button-secondary" id="advanced-summary">
-        <span id="advanced-search-label"class="<%= advanced_label_class %>"><%= advanced_label %></span>
+        <span id="advanced-search-label"><%= advanced_label %></span>
       </summary>
-      <input id="advanced-search-field" type="hidden" name="advanced" value="<%= params[:advanced] %>">
+      <input id="advanced-search-field" class="fieldset-toggle" type="hidden" name="advanced"
+             value="<%= params[:advanced] %>">
       <div class="field-container">
         <div class="field-wrap">
           <label for="advanced-title" class="field-label">Title</label>


### PR DESCRIPTION
Why these changes are being introduced:

During usability testing, stakeholders noted that the form can enter a state in which they keyword field is incorrectly required. (E.g., the geodistance panel is open, but the keyword input still has the `required` attribute.)

In our attempts to replicate this bug, we have intermittently gotten the form into a similar out-of-sync state. However, we have not been able to replicate it consistently. Part of the problem is the poor structure of the search form JS, which makes the script difficult to debug.

Relevant ticket(s):

* [GDT-302](https://mitlibraries.atlassian.net/browse/GDT-302)
* [TIMX-281](https://mitlibraries.atlassian.net/browse/TIMX-281)

How this addresses that need:

This refactors the search form JS to be more well structured, concise, and DRY, with the intention of resolving two tickets:

* GDT-302, the bug mentioned above. To resolve this, we delay the execution of the functions that trigger the keyword input state change, so as to avoid the syncing issues we found in testing.
* TIMX-281, a bug in non-GDT form state that prevents the visual changes to icon and placeholder when the advanced search panel is open.

Because we can't consistently replicate the bug that GDT-302 seeks to address, I can't say with certainty that this fixes the problem. I've tried click-testing it, and certain behavior that had previously gotten it out of sync no longer does. At minimum, the refactor should improve the maintainability of our codebase and make it easier to debug any future issues that may emerge.

Side effects of this change:

`var` is intentionally used instead of `const` or `let`. When form submission fails with a redirect, Rails seems not to trigger a full page reload. This causes the JS interpreter to throw an error for modifying variables that have already been declare, unless we declare them with `var`.

Since `var` is still valid JS, albeit not ideal, it's preferable at this point to overriding Rails (likely Turbo) behavior on form submit.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

In my experience, an out-of-sync form is most likely to happen either when opening and closing several panels (e.g., open geodistance and advanced search panel, close advanced search panel, keyword is incorrectly required); or, after a search has been executed (execute search, try to execute geodistance search, keyword is incorrectly required). However, as mentioned in the commit message, I haven't found a way to consistently replicate the behavior.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
