### PR TITLE
Fix iOS text wrap bug

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -44,16 +44,11 @@
   padding: 2rem;
   border-top: 1px solid $brand-primary;
   font-size: $fs-small;
+  line-height: 0; /* line height needs to be reset so iOS doesn't act weird */
 
   &::marker {
     font-size: 2.5rem;
-    line-height: 1.1;
     font-weight: $fw-bold;
-  }
-
-  .record-title {
-    font-size: 2.5rem;
-    line-height: 1.1;
   }
 
   &:hover,
@@ -61,29 +56,38 @@
     background-color: $gray-l4;
   }
 
-  a:visited {
-    color: $brand-secondary;
-  }
+  .result-content {
+    line-height: 1.2;
 
-  .pub-info {
-    font-size: $fs-base;
-    color:  $gray-d1;
-    span:first-child:after {
-      content: " | ";
+    .record-title {
+      font-size: 2.5rem;
+      line-height: 1.1;
     }
-    margin: 1em 0;
-  }
 
-  .result-summary {
-    margin-bottom: 2.4em;
-  }
+    a:visited {
+      color: $brand-secondary;
+    }
 
-  .result-highlights {
-    margin-top: 1.4em;
-    ul {
-      list-style: none;
-      li {
-        margin-left: 2rem;
+    .pub-info {
+      font-size: $fs-base;
+      color:  $gray-d1;
+      span:first-child:after {
+        content: " | ";
+      }
+      margin: 1em 0;
+    }
+
+    .result-summary {
+      margin-bottom: 2.4em;
+    }
+
+    .result-highlights {
+      margin-top: 1.4em;
+      ul {
+        list-style: none;
+        li {
+          margin-left: 2rem;
+        }
       }
     }
   }

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,27 +1,29 @@
 <li class="result">
-  <h3 class="record-title">
-    <span class="sr">Title: </span><%= link_to(result['title'], record_path(result['timdexRecordId'])) %>
-  </h3>
+  <div class="result-content">
+    <h3 class="record-title">
+      <span class="sr">Title: </span><%= link_to(result['title'], record_path(result['timdexRecordId'])) %>
+    </h3>
 
-  <p class="pub-info">
-    <span><%= result['contentType']&.each { |type| type['value'] }&.join(' ; ') %></span>
-    <span>
-      <% result['dates']&.each do |date| %>
-        <%= date['value'] if date['kind'] == 'Publication date' %>
-      <% end %>
-    </span>
-  </p>
+    <p class="pub-info">
+      <span><%= result['contentType']&.each { |type| type['value'] }&.join(' ; ') %></span>
+      <span>
+        <% result['dates']&.each do |date| %>
+          <%= date['value'] if date['kind'] == 'Publication date' %>
+        <% end %>
+      </span>
+    </p>
 
-  <span class="sr">Contributors: </span>
-  <ul class="list-inline truncate-list contributors">
-    <%= render partial: 'shared/contributors', locals: { contributors: result['contributors'] } %>
-  </ul>
+    <span class="sr">Contributors: </span>
+    <ul class="list-inline truncate-list contributors">
+      <%= render partial: 'shared/contributors', locals: { contributors: result['contributors'] } %>
+    </ul>
 
-  <div class="result-highlights">
-    <%= render partial: 'search/highlights', locals: { result: result } %>
-  </div>
+    <div class="result-highlights">
+      <%= render partial: 'search/highlights', locals: { result: result } %>
+    </div>
 
-  <div class="result-get">
-    <%= view_online(result) %>
+    <div class="result-get">
+      <%= view_online(result) %>
+    </div>
   </div>
 </li>

--- a/app/views/search/_result_geo.html.erb
+++ b/app/views/search/_result_geo.html.erb
@@ -1,32 +1,34 @@
 <li class="result">
-  <h3 class="record-title">
-    <span class="sr">Title: </span><%= link_to(result_geo['title'], record_path(result_geo['timdexRecordId'])) %>
-  </h3>
+  <div class="result-content">
+    <h3 class="record-title">
+      <span class="sr">Title: </span><%= link_to(result_geo['title'], record_path(result_geo['timdexRecordId'])) %>
+    </h3>
 
-  <div class="data-info">
-    <%= render partial: 'shared/geo_data_info', locals: { metadata: result_geo } %>
-  </div>
-
-  <% if result_geo['contributors'] %> 
-    <span class="sr">Contributors: </span>
-    <ul class="list-inline truncate-list contributors">
-      <%= render partial: 'shared/contributors', locals: { contributors: result_geo['contributors'] } %>
-    </ul>
-  <% end %>
-
-  <% if result_geo['summary'] %>
-    <p class="result-summary truncate-list">
-      <span class="sr">Summary: </span><%= result_geo['summary'].join(' ') %>
-    </p>
-  <% end %>
-
-  <% if result_geo['highlight'] %>
-    <div class="result-highlights">
-      <%= render partial: 'search/highlights', locals: { result: result_geo } %>
+    <div class="data-info">
+      <%= render partial: 'shared/geo_data_info', locals: { metadata: result_geo } %>
     </div>
-  <% end %>
 
-  <div class="result-record">
-    <%= view_record(result_geo['timdexRecordId']) %>
+    <% if result_geo['contributors'] %> 
+      <span class="sr">Contributors: </span>
+      <ul class="list-inline truncate-list contributors">
+        <%= render partial: 'shared/contributors', locals: { contributors: result_geo['contributors'] } %>
+      </ul>
+    <% end %>
+
+    <% if result_geo['summary'] %>
+      <p class="result-summary truncate-list">
+        <span class="sr">Summary: </span><%= result_geo['summary'].join(' ') %>
+      </p>
+    <% end %>
+
+    <% if result_geo['highlight'] %>
+      <div class="result-highlights">
+        <%= render partial: 'search/highlights', locals: { result: result_geo } %>
+      </div>
+    <% end %>
+
+    <div class="result-record">
+      <%= view_record(result_geo['timdexRecordId']) %>
+    </div>
   </div>
 </li>


### PR DESCRIPTION
#### Why these changes are being introduced:

SwiftUI/iOS has some unusual behavior for list markers. It adds line height to them, such that when we increase the font size for a marker, the line height is dramatically increased. This is particularly visible when the text next to the marker wraps, which is common for TIMDEX UI record titles.

#### Relevant ticket(s):

* [GDT-246](https://mitlibraries.atlassian.net/browse/GDT-246)

#### How this addresses that need:

This implements a CSS workaround. First, we reset the line height to 0 on `.result`, enforcing no line height for markers. Then, we add a div to wrap the rest of the result (`.result-content`), with a rule that sets the line height to 1.2.

#### Side effects of this change:

I don't forsee any, but it's a pretty ugly workaround to accommodate a minor bug in a weird OS.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

This will get UXWS review, but if the code reviewer would like to do QA as well, it would be useful to confirm the changes on a few browsers on desktop and on an iOS device. 

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[GDT-246]: https://mitlibraries.atlassian.net/browse/GDT-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ