### PR TITLE
Configure dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
+ARG RUBY_VERSION=3.2.8
+FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,34 @@
+name: "timdex-ui"
+
+services:
+  rails-app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+  #   depends_on:
+  #     - selenium
+  #     - redis
+
+  # selenium:
+  #   image: selenium/standalone-chromium
+  #   restart: unless-stopped
+
+  # redis:
+  #   image: redis:7.2
+  #   restart: unless-stopped
+  #   volumes:
+  #     - redis-data:/data
+# volumes:
+#   redis-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+  "name": "timdex-ui",
+  "dockerComposeFile": "compose.yaml",
+  "service": "rails-app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    // "ghcr.io/rails/devcontainer/features/activestorage": {},
+    "ghcr.io/rails/devcontainer/features/sqlite3": {},
+    "ghcr.io/rails/devcontainer/features/postgres-client": {}
+  },
+  // "containerEnv": {
+  //   "CAPYBARA_SERVER_PORT": "45678",
+  //   "SELENIUM_HOST": "selenium",
+  //   "REDIS_URL": "redis://redis:6379/1"
+  // },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [
+    3000,
+    6379
+  ],
+  // Configure tool-specific properties.
+  // "customizations": {},
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "bin/setup"
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
     erb (2.2.3)
       cgi
     erubi (1.13.1)
+    ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
@@ -223,6 +224,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.8-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
@@ -356,6 +359,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (2.7.1-aarch64-linux-gnu)
     sqlite3 (2.7.1-arm64-darwin)
     sqlite3 (2.7.1-x86_64-darwin)
     sqlite3 (2.7.1-x86_64-linux-gnu)
@@ -396,6 +400,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24

--- a/README.md
+++ b/README.md
@@ -149,3 +149,26 @@ The schema for the GraphQL endpoint can be found at `/config/schema/schema.json`
 ```ruby
 GraphQL::Client.dump_schema(TimdexBase::HTTP, 'config/schema/schema.json')
 ```
+
+### Development containers (aka devcontainers)
+
+This repository provides [devcontainers](https://containers.dev). Rather than taking the time to configure your local
+environment, consider using the provided devcontainers. You can still use your prefered code editors as if you were
+working locally, but all execution of code will happen in containers in a way that will be consistent across all
+developers using these containers.
+
+#### VScode
+
+[VScode can detect and manage devcontainers](https://code.visualstudio.com/docs/devcontainers/containers)
+for you. It can build and reopen the code in the container and then the terminal within VScode will execute
+commands in the container.
+
+This requires a functional Docker environment and the [VScode Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+
+#### Non-VScode
+
+If you prefer an editor other than VSCode, you can manage [Dev Containers from the CLI](https://containers.dev/supporting#devcontainer-cli) or look to see if your chosen editor may have direct support for Dev Containers.
+
+[DevPod](https://github.com/loft-sh/devpod) is also something to consider. It provides a VScode-via-web-browser-in-a-box
+as well as allowing you to use whatever editor you want and only using DevPod to start/stop the containers and run your
+terminals. Local for editor, DevPod managed Dev Container for everything else.


### PR DESCRIPTION
#### Why these changes are being introduced:

Dev containers make it easier to develop apps
without maintaining a local Ruby/Rails
environment.

#### Relevant ticket(s):

* [TCO-89](https://mitlibraries.atlassian.net/browse/TCO-89)

#### How this addresses that need:

This adds dev container config files and
documentation.

#### Side effects of this change:

Gemfile.lock now includes aarch64-linux, probably
because I ran the dev container on my Macbook.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

To confirm the dev container works, open the repo in VS Code. You should see a prompt to open the dev container. From there, in a terminal, commands like `ruby -v` and `rails -v` should return the expected values, `rails s` should start a server, and `rails t` should run the test suite.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[TCO-89]: https://mitlibraries.atlassian.net/browse/TCO-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ