### PR TITLE
Pass JSON requests through Turnstile challenge

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -391,7 +391,7 @@ class SearchController < ApplicationController
 
   # authorized_request? handles the verification that a request is valid. This validity is enforced in different ways
   # based on the requested format. Requests for results in JSON format need to be accompanied with a valid token.
-  # Requests for results in HTML format are subject to review by BotDetector and Turnstile.
+  # Requests for results in other formats (HTML, primarily) are subject to review by BotDetector and Turnstile.
   #
   # If the request if authorized, it returns true (allowing the application to generate a response)
   # If the request is not authorized, it either renders an unauthorized error, or redirects the user to Turnstile

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -409,7 +409,6 @@ class SearchController < ApplicationController
 
       redirect_to turnstile_path(return_to: request.fullpath)
     end
-
   end
 
   # format_tokens_defined? confirms whether a format token is defined in both the environment and query params.

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -276,6 +276,7 @@ class SearchController < ApplicationController
   def challenge_bots!
     return unless Feature.enabled?(:bot_detection)
     return if session[:passed_turnstile]
+    return if request.format.json? # Requests for the JSON format are protected by a token, so BotDetector isn't needed.
     return unless BotDetector.should_challenge?(request)
 
     redirect_to turnstile_path(return_to: request.fullpath)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,6 @@
 class SearchController < ApplicationController
-  before_action :authorized_request?, only: %i[results]
   before_action :validate_q!, only: %i[results]
+  before_action :authorized_request?, only: %i[results]
   before_action :set_active_tab, only: %i[results]
   around_action :sleep_if_too_fast, only: %i[results]
 
@@ -390,13 +390,14 @@ class SearchController < ApplicationController
   end
 
   # authorized_request? handles the verification that a request is valid. This validity is enforced in different ways
-  # based on the requested format.
+  # based on the requested format. Requests for results in JSON format need to be accompanied with a valid token.
+  # Requests for results in HTML format are subject to review by BotDetector and Turnstile.
   #
   # Returns true if the request is valid and worth responding to
   # Returns false if the request is invalid
   def authorized_request?
     if request.format.json?
-      return true if format_token_defined? && valid_token?
+      return true if format_tokens_defined? && valid_token?
 
       render json: { error: 'Unauthorized request' }, status: :unauthorized
     else
@@ -407,11 +408,13 @@ class SearchController < ApplicationController
 
       redirect_to turnstile_path(return_to: request.fullpath)
     end
+
   end
 
-  # format_token_defined? confirms whether a format token is defined in the environment. Returns a boolean.
-  def format_token_defined?
-    return true if ENV.fetch('FORMAT_TOKEN', '').present?
+  # format_tokens_defined? confirms whether a format token is defined in both the environment and query params.
+  # Returns a boolean.
+  def format_tokens_defined?
+    return true if ENV.fetch('FORMAT_TOKEN', '').present? && params.key?(:format_token)
 
     false
   end
@@ -419,7 +422,7 @@ class SearchController < ApplicationController
   # valid_token? confirms whether the token received from the user matches the one defined in the environment. Returns
   # a boolean.
   def valid_token?
-    return true if params[:format_token] == ENV.fetch('FORMAT_TOKEN', '')
+    return true if ActiveSupport::SecurityUtils.secure_compare(params[:format_token], ENV.fetch('FORMAT_TOKEN', ''))
 
     false
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -393,8 +393,9 @@ class SearchController < ApplicationController
   # based on the requested format. Requests for results in JSON format need to be accompanied with a valid token.
   # Requests for results in HTML format are subject to review by BotDetector and Turnstile.
   #
-  # Returns true if the request is valid and worth responding to
-  # Returns false if the request is invalid
+  # If the request if authorized, it returns true (allowing the application to generate a response)
+  # If the request is not authorized, it either renders an unauthorized error, or redirects the user to Turnstile
+  # (depending on the requested format)
   def authorized_request?
     if request.format.json?
       return true if format_tokens_defined? && valid_token?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,8 +1,7 @@
 class SearchController < ApplicationController
+  before_action :authorized_request?, only: %i[results]
   before_action :validate_q!, only: %i[results]
-  before_action :validate_format_token, only: %i[results]
   before_action :set_active_tab, only: %i[results]
-  before_action :challenge_bots!, only: %i[results]
   around_action :sleep_if_too_fast, only: %i[results]
 
   before_action :validate_geobox_presence!, only: %i[results]
@@ -272,16 +271,6 @@ class SearchController < ApplicationController
     redirect_to root_url
   end
 
-  # Redirect suspected crawlers to Turnstile when the bot_detection feature is enabled.
-  def challenge_bots!
-    return unless Feature.enabled?(:bot_detection)
-    return if session[:passed_turnstile]
-    return if request.format.json? # Requests for the JSON format are protected by a token, so BotDetector isn't needed.
-    return unless BotDetector.should_challenge?(request)
-
-    redirect_to turnstile_path(return_to: request.fullpath)
-  end
-
   def validate_geodistance_presence!
     return unless Feature.enabled?(:geodata)
 
@@ -400,30 +389,38 @@ class SearchController < ApplicationController
     end
   end
 
-  # validate_format_token is only applicable to requests for JSON-format results. It takes no action so long as the
-  # valid_request_for_json? method returns true - otherwise it renders an error message with a 401 Unauthorized status.
-  def validate_format_token
-    return unless request.format.json?
+  # authorized_request? handles the verification that a request is valid. This validity is enforced in different ways
+  # based on the requested format.
+  #
+  # Returns true if the request is valid and worth responding to
+  # Returns false if the request is invalid
+  def authorized_request?
+    if request.format.json?
+      return true if format_token_defined? && valid_token?
 
-    return if valid_request_for_json?
+      render json: { error: 'Unauthorized request' }, status: :unauthorized
+    else
+      return true unless Feature.enabled?(:bot_detection) # always pass if feature not enabled
+      return true if session[:passed_turnstile]
 
-    render json: { error: 'Unauthorized request' }, status: :unauthorized
+      return true unless BotDetector.should_challenge?(request)
+
+      redirect_to turnstile_path(return_to: request.fullpath)
+    end
   end
 
-  # valid_request_for_json? is responsible for validating whether a request for JSON format results is accompanied by
-  # a token which matches the value defined in env.
-  # 1. If the ENV is undefined, then the feature is not enabled - the check fails, which will prompt an Unauthorized
-  #    error.
-  # 2. If the ENV is defined, and the provided token matches, then the check fails, and the request will be honored.
-  # 3. In all other cases, the check fails, which will prompt the Unauthorized error.
-  def valid_request_for_json?
-    # Always fail unless the token is defined in ENV
-    return false unless ENV.fetch('FORMAT_TOKEN', '').present?
+  # format_token_defined? confirms whether a format token is defined in the environment. Returns a boolean.
+  def format_token_defined?
+    return true if ENV.fetch('FORMAT_TOKEN', '').present?
 
-    # Success if tokens match
+    false
+  end
+
+  # valid_token? confirms whether the token received from the user matches the one defined in the environment. Returns
+  # a boolean.
+  def valid_token?
     return true if params[:format_token] == ENV.fetch('FORMAT_TOKEN', '')
 
-    # Otherwise fail
     false
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1116,9 +1116,22 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
   test 'results can be returned in JSON format when env is set and valid token is provided' do
     secret_value = 'sooper_sekret'
+    quepid_ua = 'Quepid/1.0 (Web Scraper)'
     ClimateControl.modify FORMAT_TOKEN: secret_value do
       mock_timdex_search_with_hits(10)
-      get "/results?q=test&format=json&format_token=#{secret_value}"
+      get "/results?q=test&format=json&format_token=#{secret_value}", headers: { 'HTTP_USER_AGENT' => quepid_ua }
+      assert_response :success
+      assert_equal 'application/json; charset=utf-8', response.content_type
+    end
+  end
+
+  test 'results can be returned in JSON format when env is set and valid token is provided even with bot challenge' do
+    secret_value = 'sooper_sekret'
+    quepid_ua = 'Quepid/1.0 (Web Scraper)'
+
+    ClimateControl.modify(FORMAT_TOKEN: secret_value, FEATURE_BOT_DETECTION: 'true') do
+      mock_timdex_search_with_hits(10)
+      get "/results?q=test&format=json&format_token=#{secret_value}", headers: { 'HTTP_USER_AGENT' => quepid_ua }
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
     end


### PR DESCRIPTION
When we recently deployed the BotDetector feature using Cloudflare Turnstile, our Quepid instance lost the ability to connect with Unified Search (which it previously had been able to do).

In order to restore Quepid's ability to connect with this tool, we update the guard clauses around the BotDetector gem - forcing BotDetector to stand down if the incoming request is for a JSON-formatted set of results. There is a separate enforcement mechanism for these requests, implemented via the `validate_format_token` method on the Search Controller - so skipping the Bot Detector in favor of the stricter token validation feels appropriate.

Ticket: https://mitlibraries.atlassian.net/browse/USE-465

Decision log: [Validation of requests for search results](https://mitlibraries.atlassian.net/wiki/spaces/D/pages/5268176898/Validation+of+requests+for+search+results+automation+bots+and+humans)

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
