### PR TITLE
USE-504: Adding tab tracking to event names

### DIFF
--- a/app/javascript/matomo_tracking.js
+++ b/app/javascript/matomo_tracking.js
@@ -5,8 +5,8 @@
 //
 // CLICK TRACKING
 // Add `data-matomo-click="Category, Action, Name"` to any element to track
-// clicks as Matomo events. The Name segment is optional. We have a convention 
-// of using semicolons inside Name to divide multiple values.
+// clicks as Matomo events. We have a convention of using semicolons inside Name 
+// to divide multiple values. This is purely for consistency.
 //
 // This tracking can be placed directly on an interactive element.
 // Tracking also works if placed on a container. The script will look
@@ -16,22 +16,22 @@
 //
 // Examples:
 //   <a href="/file.pdf" data-matomo-click="Downloads, PDF Click, My Paper">Download</a>
-//   <button data-matomo-click="Search, Boolean Toggle">AND/OR</button>
+//   <button data-matomo-click="Search, Boolean Toggle, Off">AND/OR</button>
 //
 // Event delegation on `document` means this works for elements loaded
 // asynchronously (Turbo frames, content-loader, etc.) without re-binding.
 //
 // SEEN TRACKING
 // Add `data-matomo-seen="Category, Action, Name"` to any element to fire a
-// Matomo event when that element becomes visible in the viewport. The Name
-// segment is optional. We have a convention of using semicolons inside Name 
-// to divide multiple values. Each element fires at most once per page load.
+// Matomo event when that element becomes visible in the viewport. We have  
+// a convention of using semicolons inside Name to divide multiple values. 
+// Each element fires at most once per page load.
 // Works for elements present on initial page load and for elements injected
 // later by Turbo frames or async content loaders.
 //
 // Examples:
 //   <div data-matomo-seen="Impressions, Result Card, Alma">...</div>
-//   <a data-matomo-seen="Promotions, Banner Shown">...</a>
+//   <a data-matomo-seen="Promotions, Banner Shown, Banner Type">...</a>
 //
 // DYNAMIC VALUES
 // Wrap a helper name in double curly braces anywhere inside a segment to have

--- a/app/views/layouts/_site_header.html.erb
+++ b/app/views/layouts/_site_header.html.erb
@@ -1,4 +1,4 @@
-<div class="institute-bar" data-matomo-seen="Navigation, Header Links Seen" data-matomo-click="Navigation, Header Links Engaged, Link: {{getElementText}}">
+<div class="institute-bar" data-matomo-seen="Navigation, Header Links Seen, Tab: {{getActiveTabName}}" data-matomo-click="Navigation, Header Links Engaged, Link: {{getElementText}}">
   <div class="wrapper">
     <a class="link-logo-mit" href="https://www.mit.edu" ><span class="sr">MIT Logo</span>
       <img src="https://cdn.libraries.mit.edu/files/branding/local/mit_logo_std_rgb_white.svg" height="24" alt="MIT logo" >
@@ -26,5 +26,5 @@
       <% end %>
     </header>
     <%= render partial: 'search/form' unless Feature.enabled?(:geodata) %>
-  </div>  
+  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
       <%= render partial: "layouts/global_alert" %>
 
       <%= render partial: "layouts/site_header" %>
-      
+
       <div class="wrap-outer-content layout-band">
         <div class="wrap-content">
           <%= render partial: "layouts/flash" %>
@@ -22,7 +22,7 @@
         </div>
       </div>
 
-      <footer data-matomo-seen="Navigation, Footer Links Seen" data-matomo-click="Navigation, Footer Links Engaged, Link: {{getElementText}}">
+      <footer data-matomo-seen="Navigation, Footer Links Seen, Tab: {{getActiveTabName}}" data-matomo-click="Navigation, Footer Links Engaged, Link: {{getElementText}}">
         <%= render partial: "layouts/libraries_footer" %>
         <%= render partial: "layouts/institute_footer" %>
       </footer>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -8,7 +8,7 @@
     <input id="tab-to-target" type="hidden" name="tab" value="<%= @active_tab %>">
     <button type="submit" class="btn button-primary">Search</button>
   </div>
-  <div class="search-actions"  data-matomo-click="Search, Advanced Search Engaged">
+  <div class="search-actions"  data-matomo-click="Search, Advanced Search Engaged, Tab: {{getActiveTabName}}">
     <a href="https://libraries.mit.edu/search-advanced">Advanced search</a>
   </div>
 </form>
@@ -16,22 +16,24 @@
 <% if Feature.enabled?(:boolean_picker) %>
   <aside class="panel panel-info">
     <div class="panel-heading">
-  <% if cookies[:boolean_type].present? %>
-    <p>Your boolean preference for this session is: <%= cookies[:boolean_type] %></p>
-  <% else %>
-    <p>No preference is set. Default boolean preference (`AND`) is enabled.</p>
-  <% end %>
+      <p>
+        <% if cookies[:boolean_type].present? %>
+          Your boolean preference for this session is: <%= cookies[:boolean_type] %>
+        <% else %>
+          No preference is set. Default boolean preference (`AND`) is enabled.
+        <% end %>
+      </p>
     </div>
     <div class="panel-body">
       <p>Change to:</p>
       <ul>
-      <% ENV.fetch('BOOLEAN_OPTIONS', 'AND,OR').split(',').each do |opt| %>
-        <li><%= link_to(opt, boolpref_path(boolean_type: opt)) %></li>
-      <% end %>
+        <% ENV.fetch('BOOLEAN_OPTIONS', 'AND,OR').split(',').each do |opt| %>
+          <li><%= link_to(opt, boolpref_path(boolean_type: opt)) %></li>
+        <% end %>
         <li><%= link_to('Clear preference', boolpref_path()) %></li>
       </ul>
     </div>
-    </aside>
+  </aside>
 <% end %>
 
 <%= render partial: 'search/source_tabs' if params[:q].present? %>

--- a/app/views/search/_results_callouts.html.erb
+++ b/app/views/search/_results_callouts.html.erb
@@ -1,4 +1,4 @@
-<div class="callout-wrapper" data-track-content data-content-name="Search Suggestions" data-matomo-seen="Search Suggestions, Search Suggestions Seen" data-matomo-click="Search Suggestions, Search Suggestions Engaged, Link: {{getElementText}}">
+<div class="callout-wrapper" data-track-content data-content-name="Search Suggestions" data-matomo-seen="Search Suggestions, Search Suggestions Seen, Tab: {{getActiveTabName}}" data-matomo-click="Search Suggestions, Search Suggestions Engaged, Link: {{getElementText}}">
   <% if ['cdi', 'alma', 'all'].include?(@active_tab) %>
     <%= render partial: "results_callout_component", locals: {
       fa_name: 'magnifying-glass',

--- a/app/views/search/_results_sidebar.html.erb
+++ b/app/views/search/_results_sidebar.html.erb
@@ -1,6 +1,6 @@
 <aside id="results-sidebar">
   <%= render partial: "results_callouts" %>
-  <div class="core-sidebar-items" data-track-content data-content-name="Sidebar Links" data-matomo-seen="Sidebar Links, Sidebar Links Seen" data-matomo-click="Sidebar Links, Sidebar Links Engaged, Link: {{getElementText}}">
+  <div class="core-sidebar-items" data-track-content data-content-name="Sidebar Links" data-matomo-seen="Sidebar Links, Sidebar Links Seen, Tab: {{getActiveTabName}}" data-matomo-click="Sidebar Links, Sidebar Links Engaged, Link: {{getElementText}}">
     <div>
       <i class="fa-light fa-message"></i>
       <div>

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -10,7 +10,7 @@
   <%= render(partial: 'trigger_tacos') if tacos_enabled? %>
 
   <%= turbo_frame_tag "search-results", data: { turbo_action: "advance" } do %>
-    <div id="results-section" data-matomo-seen="Search, Search Performed">
+    <div id="results-section" data-matomo-seen="Search, Search Performed, Tab: {{getActiveTabName}}">
 
       <% if @show_primo_continuation %>
 

--- a/app/views/tacos/analyze.html.erb
+++ b/app/views/tacos/analyze.html.erb
@@ -1,5 +1,5 @@
 <% if @suggestions.present? && !Feature.enabled?(:geodata) %>
-  <div id="hint" aria-live="polite" data-matomo-seen="Interventions, Intervention Shown" data-track-content data-content-name="Intervention">
+  <div id="hint" aria-live="polite" data-matomo-seen="Interventions, Intervention Shown, Tab: {{getActiveTabName}}" data-track-content data-content-name="Intervention">
     <aside class="mitlib-suggestion-panel">
       <div class="panel-content">
         <h2 class="panel-type">Suggested resource</h2>

--- a/app/views/thirdiron/browzine.html.erb
+++ b/app/views/thirdiron/browzine.html.erb
@@ -1,7 +1,7 @@
 <% if ThirdIron.enabled? && @browzine.present? %>
   <% if @browzine[:browzine_link].present? %>
     <div class="libkey-actions">
-      <%= link_to @browzine[:browzine_link][:text], @browzine[:browzine_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, Browzine Link Seen", matomo_click: "Results, Browzine Link Engaged, Link: {{getElementText}}", content_piece: @browzine[:browzine_link][:text] } %>
+      <%= link_to @browzine[:browzine_link][:text], @browzine[:browzine_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, Browzine Link Seen, Tab: {{getActiveTabName}}", matomo_click: "Results, Browzine Link Engaged, Link: {{getElementText}}", content_piece: @browzine[:browzine_link][:text] } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/thirdiron/libkey.html.erb
+++ b/app/views/thirdiron/libkey.html.erb
@@ -1,22 +1,22 @@
 <% if ThirdIron.enabled? && @libkey.present? %>
   <% if @libkey[:pdf_link].present? || @libkey[:html_link].present? %>
     <% if @libkey[:pdf_link].present? %>
-      <%= link_to( @libkey[:pdf_link][:text], @libkey[:pdf_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, LibKey Link Seen", matomo_click: "Results, LibKey Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:pdf_link][:text] } ) %>
+      <%= link_to( @libkey[:pdf_link][:text], @libkey[:pdf_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, LibKey Link Seen, Tab: {{getActiveTabName}}", matomo_click: "Results, LibKey Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:pdf_link][:text] } ) %>
     <% end %>
 
     <% if @libkey[:html_link].present? %>
-      <%= link_to( @libkey[:html_link][:text], @libkey[:html_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, LibKey Link Seen", matomo_click: "Results, LibKey Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:html_link][:text] } ) %>
+      <%= link_to( @libkey[:html_link][:text], @libkey[:html_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, LibKey Link Seen, Tab: {{getActiveTabName}}", matomo_click: "Results, LibKey Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:html_link][:text] } ) %>
     <% end %>
 
   <%# If we don't have direct links, fall back to best_integrator_link. This allows for things like Article Galaxy links %>
   <% elsif @libkey[:best_integrator_link].present? %>
-    <%= link_to( @libkey[:best_integrator_link][:text], @libkey[:best_integrator_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, LibKey Link Seen", matomo_click: "Results, LibKey Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:best_integrator_link][:text] } ) %>
+    <%= link_to( @libkey[:best_integrator_link][:text], @libkey[:best_integrator_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, LibKey Link Seen, Tab: {{getActiveTabName}}", matomo_click: "Results, LibKey Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:best_integrator_link][:text] } ) %>
   <% end %>
 
   <%# Display browzine link if available. This should always display if we have it regardless of other links. %>
   <% if @libkey[:browzine_link].present? %>
     <div class="libkey-actions">
-      <%= link_to @libkey[:browzine_link][:text], @libkey[:browzine_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, Browzine Link Seen", matomo_click: "Results, Browzine Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:browzine_link][:text] } %>
+      <%= link_to @libkey[:browzine_link][:text], @libkey[:browzine_link][:link], class: 'button libkey-link', data: { matomo_seen: "Results, Browzine Link Seen, Tab: {{getActiveTabName}}", matomo_click: "Results, Browzine Link Engaged, Link: {{getElementText}}", content_piece: @libkey[:browzine_link][:text] } %>
     </div>
   <% end %>
 


### PR DESCRIPTION
#### Developer
We noticed that our Matomo tracking dashboard had some name attributes that were never defined (because this is optional). This appears as "Event Name not defined" in the dashboard, which appears like something is broken.

As a quick fix to this, and to get slightly more robust data, we added the tab name to all instances where the name was empty. This provides slightly more robust data and avoids a dashboard that appears to be broken.

We'll revisit what should be here in the future.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
