### PR TITLE
USE-518: No Results page responsive views now have search suggestions

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -476,7 +476,7 @@
 // SIDEBAR COLLAPSES BELOW RESULTS
 @media (max-width: $bp-screen-lg) {
   // Hide the bordered callouts
-  #results > .callout-wrapper {
+  #results:not(.no-results-container) > .callout-wrapper {
     display: none;
   }
 }


### PR DESCRIPTION
#### Developer
We observed that the desktop version of the "No Results" state had search suggestions, but they were lost on tablet and smaller devices.

This was caused by a CSS media query with a selector that was a little too broad.

This work tightens the selector to exclude the No Results container, ensuring this appears correctly on smaller devices.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
