### PR TITLE
Adds additional tabs for timdex sources

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   end
 
   def timdex_tabs
-    %w[aspace timdex timdex_alma website]
+    %w[aspace databases dspace geodata timdex timdex_alma website]
   end
 
   def all_tabs

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -184,6 +184,9 @@ class SearchController < ApplicationController
     query[:sourceFilter] = ['MIT Libraries Website', 'LibGuides'] if @active_tab == 'website'
     query[:sourceFilter] = ['MIT ArchivesSpace'] if @active_tab == 'aspace'
     query[:sourceFilter] = ['MIT Alma'] if @active_tab == 'timdex_alma'
+    query[:sourceFilter] = ['DSpace@MIT'] if @active_tab == 'dspace'
+    query[:sourceFilter] = ['Research Databases'] if @active_tab == 'databases'
+    query[:sourceFilter] = ['OpenGeoMetadata GIS Resources', 'MIT GIS Resources'] if @active_tab == 'geodata'
 
     # We generate unique cache keys to avoid naming collisions.
     cache_key = CacheKeyGenerator.call(query)
@@ -391,7 +394,8 @@ class SearchController < ApplicationController
       'message' => 'Hmm, we seem to be having difficulties...',
       'description' => 'In the meantime, try searching these tools directly.',
       'links' => [
-        { 'label' => "MIT's WorldCat", 'description' => 'Books and media', 'url' => 'https://libraries.mit.edu/worldcat' },
+        { 'label' => "MIT's WorldCat", 'description' => 'Books and media',
+          'url' => 'https://libraries.mit.edu/worldcat' },
         { 'label' => 'Google Scholar', 'description' => 'Articles', 'url' => 'https://scholar.google.com/' },
         { 'label' => 'ArchivesSpace', 'description' => 'MIT archives', 'url' => 'https://archivesspace.mit.edu/' },
         { 'label' => 'DSpace@MIT', 'description' => 'MIT research', 'url' => 'https://dspace.mit.edu/' }

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,27 +1,39 @@
 module ResultsHelper
+  # Descriptions for each tab. HTML entries use raw anchor tags (all URLs are
+  # hardcoded external links, so no XSS risk) and must be marked html_safe.
+  TAB_DESCRIPTIONS = {
+    'all' => 'Search across all MIT Libraries systems',
+    'cdi' => 'Articles, reviews, book chapters, and more from ' \
+             '<a href="https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en">' \
+             'Articles, Books & More</a>'.html_safe,
+    'alma' => 'Books, e-books, journals, streaming and physical media, and more from ' \
+              '<a href="https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en">' \
+              'Articles, Books & More</a>'.html_safe,
+    'timdex_alma' => 'Books, e-books, journals, streaming and physical media, and more',
+    'primo' => 'Articles, books, chapters, streaming and physical media, and more',
+    'aspace' => 'Finding aids for archival and unique primary source materials at MIT from ' \
+                '<a href="https://archivesspace.mit.edu">Archives & Manuscripts</a>'.html_safe,
+    'timdex' => 'Digital collections, images, documents, and more from MIT Libraries',
+    'website' => 'Events, news, services, and research guides from the ' \
+                 '<a href="https://libraries.mit.edu">Library Website</a> and ' \
+                 '<a href="https://libraries.mit.edu/experts/">Research Guides</a>'.html_safe,
+    'dspace' => 'Peer-reviewed articles, theses and dissertations, technical reports, and more from ' \
+                '<a href="https://dspace.mit.edu">MIT Open Scholarship</a> '.html_safe,
+    'geodata' => 'Shape files, raster data, and more from ' \
+                 '<a href="https://geodata.libraries.mit.edu">MIT Geospatial Data</a>'.html_safe,
+    'databases' => 'Indexes, full-text archives, data sources, and other specialized search tools from ' \
+                   '<a href="https://libguides.mit.edu/az/databases">Research Databases</a>'.html_safe
+  }.freeze
+
   def results_summary(hits)
     hits.to_i >= 10_000 ? '10,000+ results' : "#{number_with_delimiter(hits)} results"
   end
 
   # Provides a description for the current tab in search results.
   def tab_description
-    case params[:tab]
-    when 'all'
-      'All MIT Libraries sources'
-    when 'cdi'
-      'Journal and newspaper articles, book reviews, book chapters, and more'
-    when 'alma', 'timdex_alma'
-      'Books, e-books, journals, streaming and physical media, and more'
-    when 'primo'
-      'Articles, books, chapters, streaming and physical media, and more'
-    when 'aspace'
-      'Archives, manuscripts, and other unique materials related to MIT'
-    when 'timdex'
-      'Digital collections, images, documents, and more from MIT Libraries'
-    when 'website'
-      'Information about the library: events, news, services, and more'
-    else
+    TAB_DESCRIPTIONS.fetch(params[:tab]) do
       Rails.logger.error "Unknown tab parameter in `tab_description` helper: #{params[:tab]}"
+      ''
     end
   end
 

--- a/app/javascript/source_tabs.js
+++ b/app/javascript/source_tabs.js
@@ -35,6 +35,9 @@ moreBtn.addEventListener('click', (e) => {
   moreBtn.setAttribute('aria-expanded', container.classList.contains('--show-secondary'))
 })
 
+// Maximum number of tabs to show in the primary tab bar at once
+const MAX_TABS = 10
+
 // adapt tabs
 const doAdapt = () => {
 
@@ -43,14 +46,17 @@ const doAdapt = () => {
     item.classList.remove('--hidden')
   })
 
-  // hide items that won't fit in the Primary tab bar
+  // hide items that won't fit in the Primary tab bar, or exceed MAX_TABS
+  // once a tab is hidden, all subsequent tabs are also hidden to preserve order
   let stopWidth = moreBtn.offsetWidth
   let hiddenItems = []
+  let shouldHide = false
   const primaryWidth = primary.offsetWidth
   primaryItems.forEach((item, i) => {
-    if(primaryWidth >= stopWidth + item.offsetWidth) {
+    if(!shouldHide && i < MAX_TABS && primaryWidth >= stopWidth + item.offsetWidth) {
       stopWidth += item.offsetWidth
     } else {
+      shouldHide = true
       item.classList.add('--hidden')
       hiddenItems.push(i)
     }

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -33,8 +33,9 @@
 #
 class Feature
   # List of all valid features in the application
-  VALID_FEATURES = %i[bot_detection geodata boolean_picker oa_always primo_nde_links simulate_search_latency tab_primo_all tab_timdex_all
-                      tab_timdex_alma record_link timdex_fulltext].freeze
+  VALID_FEATURES = %i[bot_detection geodata boolean_picker oa_always primo_nde_links simulate_search_latency
+                      tab_primo_all tab_timdex_all tab_timdex_alma record_link timdex_fulltext
+                      timdex_semantic_search].freeze
 
   # Check if a feature is enabled by name
   #

--- a/app/views/search/_source_tabs.html.erb
+++ b/app/views/search/_source_tabs.html.erb
@@ -1,23 +1,28 @@
   <!-- Tab Navigation -->
   <nav id="tabs" class="tab-navigation" aria-label="Result type navigation" data-matomo-click="Navigation, Tabs Engaged, Current Tab: {{getActiveTabName}}; Navigated to: {{getElementText}}">
     <ul class="primary">
+      <%# Core tabs %>
       <li><%= link_to_tab("All") %></li>
+      <li><%= link_to_tab("cdi", "Articles") %></li>
+      <li><%= link_to_tab("alma", "Books & media") %></li>
+      <li><%= link_to_tab("databases", "Databases") %></li>
+      <li><%= link_to_tab("aspace", "MIT archives") %></li>
+      <li><%= link_to_tab("dspace", "MIT scholarship") %></li>
+      <li><%= link_to_tab("geodata", "Geospatial data") %></li>
+      <li><%= link_to_tab("Website") %></li>
 
+      <%# Experimental tabs %>
       <% if Feature.enabled?(:tab_primo_all) %>
         <li><%= link_to_tab("Primo", "Articles and Catalog") %></li>
       <% end %>
 
-      <li><%= link_to_tab("cdi", "Articles") %></li>
-      <li><%= link_to_tab("alma", "Books and media") %></li>
-
       <% if Feature.enabled?(:tab_timdex_all) %>
         <li><%= link_to_tab("TIMDEX") %></li>
       <% end %>
+
       <% if Feature.enabled?(:tab_timdex_alma) %>
         <li><%= link_to_tab("timdex_alma", "Alma (TIMDEX)") %></li>
       <% end %>
-      <li><%= link_to_tab("aspace", "MIT archives") %></li>
-      <li><%= link_to_tab("Website") %></li>
     </ul>
   </nav>
 

--- a/test/controllers/application_controller_unit_test.rb
+++ b/test/controllers/application_controller_unit_test.rb
@@ -10,11 +10,11 @@ class ApplicationControllerUnitTest < ActionController::TestCase
   end
 
   test '#timdex_tabs returns expected tabs' do
-    assert_equal %w[aspace timdex timdex_alma website], @controller.timdex_tabs
+    assert_equal %w[aspace databases dspace geodata timdex timdex_alma website], @controller.timdex_tabs
   end
 
   test '#all_tabs includes both primo and timdex tabs as well as all tab' do
-    expected = %w[all alma cdi primo aspace timdex timdex_alma website]
+    expected = %w[all alma cdi primo aspace databases dspace geodata timdex timdex_alma website]
     assert_equal expected, @controller.all_tabs
   end
 

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -21,37 +21,25 @@ class ResultsHelperTest < ActionView::TestCase
   end
 
   test 'result helper handles tab descriptions for tabs based on params hash' do
-    params[:tab] = 'all'
-    description = 'All MIT Libraries sources'
-    assert_equal description, tab_description
+    ResultsHelper::TAB_DESCRIPTIONS.each do |tab, expected|
+      params[:tab] = tab
+      assert_equal expected, tab_description, "Expected description for tab '#{tab}' to match TAB_DESCRIPTIONS"
+    end
+  end
 
-    params[:tab] = 'cdi'
-    description = 'Journal and newspaper articles, book reviews, book chapters, and more'
-    assert_equal description, tab_description
+  test 'tab_description returns empty string for unknown tabs' do
+    params[:tab] = 'unknown_tab'
+    assert_equal '', tab_description
+  end
 
-    params[:tab] = 'alma'
-    description = 'Books, e-books, journals, streaming and physical media, and more'
-    assert_equal description, tab_description
+  test 'tab_description returns empty string for nil tab' do
+    params[:tab] = nil
+    assert_equal '', tab_description
+  end
 
-    params[:tab] = 'timdex_alma'
-    description = 'Books, e-books, journals, streaming and physical media, and more'
-    assert_equal description, tab_description
-
-    params[:tab] = 'primo'
-    description = 'Articles, books, chapters, streaming and physical media, and more'
-    assert_equal description, tab_description
-
-    params[:tab] = 'aspace'
-    description = 'Archives, manuscripts, and other unique materials related to MIT'
-    assert_equal description, tab_description
-
-    params[:tab] = 'timdex'
-    description = 'Digital collections, images, documents, and more from MIT Libraries'
-    assert_equal description, tab_description
-
-    params[:tab] = 'website'
-    description = 'Information about the library: events, news, services, and more'
-    assert_equal description, tab_description
+  test 'tab_description returns empty string for empty tab' do
+    params[:tab] = ''
+    assert_equal '', tab_description
   end
 
   test 'search_primo_link includes encoded search query and correct path' do


### PR DESCRIPTION
Why are these changes being introduced:

* All sources should exist in at least one tab

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/USE-517

How does this address that need:

* Adds additional tabs for timdex sources
* Adds additional blurbs for the new tabs

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
