### PR TITLE
USE-434: Add h4 for screen readers above summary in results

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -48,7 +48,7 @@
 
       <% if result[:summary].present? %>
         <div class="result-summary truncate-list">
-          <span class="sr">Summary: </span><%= sanitize result[:summary] %>
+          <h4 class="sr">Summary: </h4><%= sanitize result[:summary] %>
         </div>
       <% end %>
     </div>

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -63,7 +63,7 @@
 
         <% if result[:summary].present? %>
           <div class="result-summary truncate-list">
-            <span class="sr">Summary: </span><%= sanitize result[:summary] %>
+            <h4 class="sr">Summary: </h4><%= sanitize result[:summary] %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
#### Developer
In our accessibility review, Rich suggested using an h4 above the summary section to help screen reader users use the heading navigation functionality to jump between summaries.

This work replaces a span with an h4 that was already set up with a screen reader class.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
