### PR TITLE
USE-457: Swapping material type and source locations

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -280,7 +280,7 @@
   ul.contributors {
     line-clamp: 1;
     -webkit-line-clamp: 1;
-    margin-bottom: 12px;
+    margin-bottom: 4px;
 
     li {
       font-weight: $fw-normal;
@@ -293,6 +293,10 @@
         }
       }
     }
+  }
+
+  .result-source {
+    font-size: $fs-base;
   }
 
   .inner-heading {

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -186,12 +186,6 @@ module RecordHelper
     "<strong>#{loc[:name]}</strong> #{loc[:collection]} (#{loc[:call_number]})"
   end
 
-  # Returns true if the active tab includes multiple sources.
-  # As our tabs adjust over time, we will need to revisit this logic.
-  def multi_source_tab?
-    %w[all primo timdex website].include?(@active_tab)
-  end
-
   private
 
   def render_kind_value(list)

--- a/app/models/normalize_primo_record.rb
+++ b/app/models/normalize_primo_record.rb
@@ -13,6 +13,7 @@ class NormalizePrimoRecord
       creators:,
       eyebrow:,
       source:,
+      source_url:,
       year:,
       format:,
       links:,
@@ -72,10 +73,13 @@ class NormalizePrimoRecord
     format || 'Unknown format'
   end
 
-  # Provides user friendly string based and link into Primo UI
+  # Provides user friendly label and link into Primo UI
   def source
-    url = 'https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en'
-    "<a href=\"#{url}\">Articles, Books & More</a>".html_safe
+    'Articles, Books & More'
+  end
+
+  def source_url
+    "#{ENV.fetch('MIT_PRIMO_URL')}/discovery/search?vid=#{ENV.fetch('PRIMO_VID')}&lang=en"
   end
 
   def year

--- a/app/models/normalize_primo_record.rb
+++ b/app/models/normalize_primo_record.rb
@@ -68,17 +68,14 @@ class NormalizePrimoRecord
     author_list.uniq
   end
 
-  # Provides user friendly string based on whether the record is Alma or not-Alma (CDI)
   def eyebrow
-    if alma_record?
-      'MIT Libraries Catalog'
-    else
-      'MIT Libraries Catalog: Articles'
-    end
+    format || 'Unknown format'
   end
 
+  # Provides user friendly string based and link into Primo UI
   def source
-    'Primo'
+    url = 'https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en'
+    "<a href=\"#{url}\">Articles, Books & More</a>".html_safe
   end
 
   def year

--- a/app/models/normalize_timdex_record.rb
+++ b/app/models/normalize_timdex_record.rb
@@ -1,5 +1,19 @@
 # Transforms a TIMDEX result into a normalized record.
 class NormalizeTimdexRecord
+  # Maps raw TIMDEX source names to [display_name, url] pairs.
+  # Add new sources here — both fields stay in sync automatically.
+  SOURCES = {
+    'DSpace@MIT' => ['MIT Open Scholarship (DSpace@MIT)', 'https://dspace.mit.edu/'],
+    'LibGuides' => ['Research Guides', 'https://libguides.mit.edu/'],
+    'MIT ArchivesSpace' => ['Archives & Manuscripts', 'https://archivesspace.mit.edu'],
+    'OpenGeoMetadata GIS Resources' => ['Open Geospatial Consortium', 'https://opengeometadata.org/'],
+    'MIT GIS Resources' => ['MIT Geospatial Data', 'https://geodata.libraries.mit.edu/'],
+    'Research Databases' => ['Research Databases', 'https://libguides.mit.edu/az/databases'],
+    'MIT Libraries Website' => ['Library Website', 'https://libraries.mit.edu/'],
+    'MIT Alma' => ['MIT Libraries Catalog',
+                   "#{ENV.fetch('MIT_PRIMO_URL')}/discovery/search?vid=#{ENV.fetch('PRIMO_VID')}&lang=en"]
+  }.freeze
+
   def initialize(record, query)
     @record = record
     @query = query
@@ -13,6 +27,7 @@ class NormalizeTimdexRecord
       creators:,
       eyebrow:,
       source:,
+      source_url:,
       year:,
       format:,
       links:,
@@ -38,7 +53,7 @@ class NormalizeTimdexRecord
     title = @record['title'] || 'Unknown title'
 
     # The collection identifier is important for ASpace records so we append it to the title
-    return title unless source == 'MIT ArchivesSpace'
+    return title unless @record['source'] == 'MIT ArchivesSpace'
 
     title += " (#{aspace_collection(@record['identifiers'])})"
   end
@@ -70,26 +85,16 @@ class NormalizeTimdexRecord
     format
   end
 
-  # Maps sources to user friendly strings with links to source systems
+  # Maps sources to user friendly display names
   def source
     return 'Unknown source' unless @record['source']
 
-    case @record['source']
-    when 'DSpace@MIT'
-      '<a href="https://dspace.mit.edu/">MIT Open Scholarship (DSpace@MIT)</a>'.html_safe
-    when 'LibGuides'
-      '<a href="https://libguides.mit.edu/">Research Guides</a>'.html_safe
-    when 'OpenGeoMetadata GIS Resources'
-      '<a href="https://opengeometadata.org/">Open Geospatial Consortium</a>'.html_safe
-    when 'MIT GIS Resources'
-      '<a href="https://geodata.libraries.mit.edu/">MIT Geospatial Data</a>'.html_safe
-    when 'Research Databases'
-      '<a href="https://libguides.mit.edu/az/databases">Research Databases</a>'.html_safe
-    when 'MIT Libraries Website'
-      '<a href="https://libraries.mit.edu/">Library Website</a>'.html_safe
-    else
-      @record['source']
-    end
+    SOURCES.fetch(@record['source'], [@record['source']]).first
+  end
+
+  # Returns the URL for the source system, or nil if not mapped
+  def source_url
+    SOURCES[@record['source']]&.last
   end
 
   def year
@@ -106,7 +111,8 @@ class NormalizeTimdexRecord
     end
   end
 
-  # This is the same as the content_type field below.
+  # This is used in eyebrows and is similar to content_type but returns a default string if contentType is missing.
+  # This difference allows us to always have an eyebrow.
   def format
     return 'Unknown format' unless @record['contentType']
 
@@ -164,7 +170,7 @@ class NormalizeTimdexRecord
 
   # TIMDEX-specific methods
 
-  # This is the same as the format field above.
+  # This is similar to the format field above, but does not return a default string if contentType is missing.
   def content_type
     @record['contentType']&.map { |term| Vocabularies::Format.lookup(term) }&.join(' ; ')
   end

--- a/app/models/normalize_timdex_record.rb
+++ b/app/models/normalize_timdex_record.rb
@@ -66,26 +66,30 @@ class NormalizeTimdexRecord
       .map { |creator| { 'value' => creator['value'], 'link' => nil } }
   end
 
-  # Maps sources to user friendly strings
   def eyebrow
-    case source
-    when 'DSpace@MIT'
-      'DSpace@MIT (MIT Research)'
-    when 'LibGuides'
-      'MIT Libraries Website: Guides'
-    when 'OpenGeoMetadata GIS Resources'
-      'Non-MIT GeoSpatial Data'
-    when 'MIT GIS Resources'
-      'MIT GeoSpatial Data'
-    else
-      source
-    end
+    format
   end
 
+  # Maps sources to user friendly strings with links to source systems
   def source
     return 'Unknown source' unless @record['source']
 
-    @record['source']
+    case @record['source']
+    when 'DSpace@MIT'
+      '<a href="https://dspace.mit.edu/">MIT Open Scholarship (DSpace@MIT)</a>'.html_safe
+    when 'LibGuides'
+      '<a href="https://libguides.mit.edu/">Research Guides</a>'.html_safe
+    when 'OpenGeoMetadata GIS Resources'
+      '<a href="https://opengeometadata.org/">Open Geospatial Consortium</a>'.html_safe
+    when 'MIT GIS Resources'
+      '<a href="https://geodata.libraries.mit.edu/">MIT Geospatial Data</a>'.html_safe
+    when 'Research Databases'
+      '<a href="https://libguides.mit.edu/az/databases">Research Databases</a>'.html_safe
+    when 'MIT Libraries Website'
+      '<a href="https://libraries.mit.edu/">Library Website</a>'.html_safe
+    else
+      @record['source']
+    end
   end
 
   def year
@@ -104,7 +108,7 @@ class NormalizeTimdexRecord
 
   # This is the same as the content_type field below.
   def format
-    return '' unless @record['contentType']
+    return 'Unknown format' unless @record['contentType']
 
     @record['contentType']&.map { |term| Vocabularies::Format.lookup(term) }&.join(' ; ')
   end

--- a/app/models/vocabularies/format.rb
+++ b/app/models/vocabularies/format.rb
@@ -7,6 +7,7 @@ module Vocabularies
       'bkse' => 'eBook',
       'book_chapter' => 'Book Chapter',
       'conference_proceeding' => 'Conference Proceeding',
+      'libguide' => 'Research Guide',
       'magazinearticle' => 'Magazine Article',
       'newsletterarticle' => 'Newsletter Article',
       'reference_entry' => 'Reference Entry',

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -31,7 +31,13 @@
         </ul>
       <% end %>
 
-      <p class="result-source">Source: <%= result[:source] %></p>
+      <p class="result-source">Source:
+        <% if result[:source_url].present? %>
+          <%= link_to result[:source], result[:source_url] %>
+        <% else %>
+          <%= result[:source] %>
+        <% end %>
+      </p>
 
       <%# Primo displays citation here. TIMDEX citations probably need work to be useful here %>
 

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,7 +1,7 @@
 <li class="result use" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if result[:content_type].present? %>
-      <p class="eyebrow"><%= result[:content_type] %></p>
+    <% if result[:eyebrow].present? %>
+      <p class="eyebrow"><%= result[:eyebrow] %></p>
     <% end %>
     <h3 class="record-title">
       <%= link_to_result(result) %>
@@ -31,7 +31,7 @@
         </ul>
       <% end %>
 
-      <p class="result-source"><strong>Source: </strong><%= result[:eyebrow] %></p>
+      <p class="result-source">Source: <%= result[:source] %></p>
 
       <%# Primo displays citation here. TIMDEX citations probably need work to be useful here %>
 

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,7 +1,7 @@
 <li class="result use" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if multi_source_tab? && result[:eyebrow].present? %>
-      <p class="eyebrow"><%= result[:eyebrow] %></p>
+    <% if multi_source_tab? && result[:content_type].present? %>
+      <p class="eyebrow"><%= result[:content_type] %></p>
     <% end %>
     <h3 class="record-title">
       <%= link_to_result(result) %>
@@ -10,8 +10,6 @@
     <div class="result-metadata">
 
       <p class="pub-info">
-        <span><%= result[:content_type] %></span>
-
         <span>
           <% if result[:date_range].present? %>
             <%= result[:date_range] %>
@@ -32,6 +30,8 @@
           <%= render partial: 'shared/contributors', locals: { contributors: result[:contributors] } %>
         </ul>
       <% end %>
+
+      <p class="result-source"><strong>Source: </strong><%= result[:eyebrow] %></p>
 
       <%# Primo displays citation here. TIMDEX citations probably need work to be useful here %>
 

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,6 +1,6 @@
 <li class="result use" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if multi_source_tab? && result[:content_type].present? %>
+    <% if result[:content_type].present? %>
       <p class="eyebrow"><%= result[:content_type] %></p>
     <% end %>
     <h3 class="record-title">

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -43,7 +43,13 @@
           </ul>
         <% end %>
 
-        <p class="result-source">Source: <%= result[:source] %></p>
+        <p class="result-source">Source:
+          <% if result[:source_url].present? %>
+            <%= link_to result[:source], result[:source_url] %>
+          <% else %>
+            <%= result[:source] %>
+          <% end %>
+        </p>
 
         <% if result[:citation].present? %>
           <div class="result-container">

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -1,6 +1,6 @@
 <li class="result primo" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if multi_source_tab? && result[:format].present? %>
+    <% if result[:format].present? %>
       <p class="eyebrow"><%= result[:format] %></p>
     <% end %>
     <h3 class="record-title">

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -1,7 +1,7 @@
 <li class="result primo" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if result[:format].present? %>
-      <p class="eyebrow"><%= result[:format] %></p>
+    <% if result[:eyebrow].present? %>
+      <p class="eyebrow"><%= result[:eyebrow] %></p>
     <% end %>
     <h3 class="record-title">
       <% if result[:links]&.find { |link| link['kind'] == 'full record' } %>
@@ -43,7 +43,7 @@
           </ul>
         <% end %>
 
-        <p class="result-source"><strong>Source: </strong><%= result[:eyebrow] %></p>
+        <p class="result-source">Source: <%= result[:source] %></p>
 
         <% if result[:citation].present? %>
           <div class="result-container">

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -1,7 +1,7 @@
 <li class="result primo" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if multi_source_tab? && result[:eyebrow].present? %>
-      <p class="eyebrow"><%= result[:eyebrow] %></p>
+    <% if multi_source_tab? && result[:format].present? %>
+      <p class="eyebrow"><%= result[:format] %></p>
     <% end %>
     <h3 class="record-title">
       <% if result[:links]&.find { |link| link['kind'] == 'full record' } %>
@@ -24,7 +24,6 @@
 
       <div class="result-metadata">
         <p class="pub-info">
-          <span><%= result[:format] %></span>
           <span><%= result[:year] %></span>
         </p>
 
@@ -43,6 +42,8 @@
             <% end %>
           </ul>
         <% end %>
+
+        <p class="result-source"><strong>Source: </strong><%= result[:eyebrow] %></p>
 
         <% if result[:citation].present? %>
           <div class="result-container">

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -387,18 +387,4 @@ class RecordHelperTest < ActionView::TestCase
     expected = "<i class='fa-sharp fa-solid fa-question' aria-hidden='true''></i>"
     assert_equal expected, icon('question')
   end
-
-  test 'multi_source_tab? returns true for tabs that combine sources' do
-    %w[all primo timdex website].each do |tab|
-      @active_tab = tab
-      assert multi_source_tab?
-    end
-  end
-
-  test 'multi_source_tab? returns false for other tabs' do
-    %w[alma cdi aspace timdex_alma fake_tab].each do |tab|
-      @active_tab = tab
-      assert_not multi_source_tab?
-    end
-  end
 end

--- a/test/models/normalize_primo_record_test.rb
+++ b/test/models/normalize_primo_record_test.rb
@@ -43,9 +43,9 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
 
   test 'normalizes source' do
     normalized = NormalizePrimoRecord.new(full_record, 'test').normalize
-    url = 'https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en'
-    expected = "<a href=\"#{url}\">Articles, Books & More</a>"
-    assert_equal expected, normalized[:source]
+    assert_equal 'Articles, Books & More', normalized[:source]
+    expected_url = "#{ENV.fetch('MIT_PRIMO_URL')}/discovery/search?vid=#{ENV.fetch('PRIMO_VID')}&lang=en"
+    assert_equal expected_url, normalized[:source_url]
   end
 
   test 'normalizes year' do
@@ -515,9 +515,8 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
   end
 
   # This really should never happen, but this test confirms things don't break if it does
-  test 'sets eyebrow to MIT Libraries Catalog: Articles when identifier is missing' do
+  test 'missing pnx.display.type results in Unknown format' do
     record = minimal_record.dup
-    record.delete('recordid')
     normalized = NormalizePrimoRecord.new(record, 'test').normalize
     assert_equal 'Unknown format', normalized[:eyebrow]
     assert_includes normalized.keys, :eyebrow

--- a/test/models/normalize_primo_record_test.rb
+++ b/test/models/normalize_primo_record_test.rb
@@ -43,7 +43,9 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
 
   test 'normalizes source' do
     normalized = NormalizePrimoRecord.new(full_record, 'test').normalize
-    assert_equal 'Primo', normalized[:source]
+    url = 'https://mit.primo.exlibrisgroup.com/discovery/search?vid=01MIT_INST:MIT&lang=en'
+    expected = "<a href=\"#{url}\">Articles, Books & More</a>"
+    assert_equal expected, normalized[:source]
   end
 
   test 'normalizes year' do
@@ -500,15 +502,15 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
   end
 
   # Test eyebrow mapping
-  test 'sets eyebrow to MIT Libraries Catalog for Alma records' do
+  test 'sets eyebrow to book for books' do
     normalized = NormalizePrimoRecord.new(alma_record, 'test').normalize
-    assert_equal 'MIT Libraries Catalog', normalized[:eyebrow]
+    assert_equal 'Book', normalized[:eyebrow]
     assert_includes normalized.keys, :eyebrow
   end
 
-  test 'sets eyebrow to MIT Libraries Catalog: Articles for CDI records' do
+  test 'sets eyebrow to article for articles' do
     normalized = NormalizePrimoRecord.new(cdi_record, 'test').normalize
-    assert_equal 'MIT Libraries Catalog: Articles', normalized[:eyebrow]
+    assert_equal 'Article', normalized[:eyebrow]
     assert_includes normalized.keys, :eyebrow
   end
 
@@ -517,7 +519,7 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
     record = minimal_record.dup
     record.delete('recordid')
     normalized = NormalizePrimoRecord.new(record, 'test').normalize
-    assert_equal 'MIT Libraries Catalog: Articles', normalized[:eyebrow]
+    assert_equal 'Unknown format', normalized[:eyebrow]
     assert_includes normalized.keys, :eyebrow
   end
 end

--- a/test/models/normalize_timdex_record_test.rb
+++ b/test/models/normalize_timdex_record_test.rb
@@ -46,6 +46,7 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
   test 'normalizes source' do
     normalized = NormalizeTimdexRecord.new(full_record, 'test').normalize
     assert_equal 'Test Repository', normalized[:source]
+    assert_nil normalized[:source_url]
   end
 
   test 'handles missing source' do
@@ -53,6 +54,7 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
     record_without_source.delete('source')
     normalized = NormalizeTimdexRecord.new(record_without_source, 'test').normalize
     assert_equal 'Unknown source', normalized[:source]
+    assert_nil normalized[:source_url]
   end
 
   test 'extracts year from publication date' do
@@ -240,11 +242,22 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
   end
 
   # Test eyebrow mapping
+  test 'maps MIT ArchivesSpace source to source' do
+    record = full_record.dup
+    record['source'] = 'MIT ArchivesSpace'
+    record['identifiers'] = [{ 'value' => 'MC-0001', 'kind' => 'Collection Identifier' }]
+    normalized = NormalizeTimdexRecord.new(record, 'test').normalize
+    assert_equal 'Archives & Manuscripts', normalized[:source]
+    assert_equal 'https://archivesspace.mit.edu', normalized[:source_url]
+    assert_includes normalized.keys, :eyebrow
+  end
+
   test 'maps DSpace@MIT source to source' do
     record = full_record.dup
     record['source'] = 'DSpace@MIT'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal '<a href="https://dspace.mit.edu/">MIT Open Scholarship (DSpace@MIT)</a>', normalized[:source]
+    assert_equal 'MIT Open Scholarship (DSpace@MIT)', normalized[:source]
+    assert_equal 'https://dspace.mit.edu/', normalized[:source_url]
     assert_includes normalized.keys, :eyebrow
   end
 
@@ -252,7 +265,8 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
     record = full_record.dup
     record['source'] = 'LibGuides'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal '<a href="https://libguides.mit.edu/">Research Guides</a>', normalized[:source]
+    assert_equal 'Research Guides', normalized[:source]
+    assert_equal 'https://libguides.mit.edu/', normalized[:source_url]
     assert_includes normalized.keys, :eyebrow
   end
 
@@ -260,7 +274,8 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
     record = full_record.dup
     record['source'] = 'Research Databases'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal '<a href="https://libguides.mit.edu/az/databases">Research Databases</a>', normalized[:source]
+    assert_equal 'Research Databases', normalized[:source]
+    assert_equal 'https://libguides.mit.edu/az/databases', normalized[:source_url]
     assert_includes normalized.keys, :eyebrow
   end
 
@@ -268,7 +283,8 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
     record = full_record.dup
     record['source'] = 'MIT Libraries Website'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal '<a href="https://libraries.mit.edu/">Library Website</a>', normalized[:source]
+    assert_equal 'Library Website', normalized[:source]
+    assert_equal 'https://libraries.mit.edu/', normalized[:source_url]
     assert_includes normalized.keys, :eyebrow
   end
 
@@ -284,12 +300,21 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
     record = full_record.dup
     record['source'] = 'MIT GIS Resources'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal '<a href="https://geodata.libraries.mit.edu/">MIT Geospatial Data</a>',
-                 normalized[:source]
+    assert_equal 'MIT Geospatial Data', normalized[:source]
+    assert_equal 'https://geodata.libraries.mit.edu/', normalized[:source_url]
     assert_includes normalized.keys, :eyebrow
   end
 
-  test 'uses Unknown format as eyebrow for empty contentType' do
+  test 'maps OpenGeoMetadata GIS Resources source to source' do
+    record = full_record.dup
+    record['source'] = 'OpenGeoMetadata GIS Resources'
+    normalized = NormalizeTimdexRecord.new(record, 'test').normalize
+    assert_equal 'Open Geospatial Consortium', normalized[:source]
+    assert_equal 'https://opengeometadata.org/', normalized[:source_url]
+    assert_includes normalized.keys, :eyebrow
+  end
+
+  test 'uses Unknown format as eyebrow for nil contentType' do
     record = full_record.dup
     record['contentType'] = nil
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize

--- a/test/models/normalize_timdex_record_test.rb
+++ b/test/models/normalize_timdex_record_test.rb
@@ -94,7 +94,7 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
     record_without_format = minimal_record.dup
     record_without_format.delete('contentType')
     normalized = NormalizeTimdexRecord.new(record_without_format, 'test').normalize
-    assert_empty normalized[:format]
+    assert_equal 'Unknown format', normalized[:format]
   end
 
   test 'normalizes links from source link' do
@@ -240,43 +240,60 @@ class NormalizeTimdexRecordTest < ActiveSupport::TestCase
   end
 
   # Test eyebrow mapping
-  test 'maps DSpace@MIT source to eyebrow label' do
+  test 'maps DSpace@MIT source to source' do
     record = full_record.dup
     record['source'] = 'DSpace@MIT'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal 'DSpace@MIT (MIT Research)', normalized[:eyebrow]
+    assert_equal '<a href="https://dspace.mit.edu/">MIT Open Scholarship (DSpace@MIT)</a>', normalized[:source]
     assert_includes normalized.keys, :eyebrow
   end
 
-  test 'maps LibGuides source to eyebrow label' do
+  test 'maps LibGuides source to source' do
     record = full_record.dup
     record['source'] = 'LibGuides'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal 'MIT Libraries Website: Guides', normalized[:eyebrow]
+    assert_equal '<a href="https://libguides.mit.edu/">Research Guides</a>', normalized[:source]
     assert_includes normalized.keys, :eyebrow
   end
 
-  test 'maps OpenGeoMetadata GIS Resources source to eyebrow label' do
+  test 'maps research databases source to source' do
     record = full_record.dup
-    record['source'] = 'OpenGeoMetadata GIS Resources'
+    record['source'] = 'Research Databases'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal 'Non-MIT GeoSpatial Data', normalized[:eyebrow]
+    assert_equal '<a href="https://libguides.mit.edu/az/databases">Research Databases</a>', normalized[:source]
     assert_includes normalized.keys, :eyebrow
   end
 
-  test 'maps MIT GIS Resources source to eyebrow label' do
+  test 'maps website source to source' do
+    record = full_record.dup
+    record['source'] = 'MIT Libraries Website'
+    normalized = NormalizeTimdexRecord.new(record, 'test').normalize
+    assert_equal '<a href="https://libraries.mit.edu/">Library Website</a>', normalized[:source]
+    assert_includes normalized.keys, :eyebrow
+  end
+
+  test 'maps content_type to eyebrow label' do
+    record = full_record.dup
+    record['contentType'] = ['Lines, Polygons, and Points']
+    normalized = NormalizeTimdexRecord.new(record, 'test').normalize
+    assert_equal 'Lines, polygons, and points', normalized[:eyebrow]
+    assert_includes normalized.keys, :eyebrow
+  end
+
+  test 'maps MIT GIS Resources source to source' do
     record = full_record.dup
     record['source'] = 'MIT GIS Resources'
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal 'MIT GeoSpatial Data', normalized[:eyebrow]
+    assert_equal '<a href="https://geodata.libraries.mit.edu/">MIT Geospatial Data</a>',
+                 normalized[:source]
     assert_includes normalized.keys, :eyebrow
   end
 
-  test 'uses source value as eyebrow for unmapped sources' do
+  test 'uses Unknown format as eyebrow for empty contentType' do
     record = full_record.dup
-    record['source'] = 'Custom Repository'
+    record['contentType'] = nil
     normalized = NormalizeTimdexRecord.new(record, 'test').normalize
-    assert_equal 'Custom Repository', normalized[:eyebrow]
+    assert_equal 'Unknown format', normalized[:eyebrow]
     assert_includes normalized.keys, :eyebrow
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* stakeholders wanted eyebrows to be based on format/content_type instead
  of source
* stakeholders wanted source to be mapped to user friendly strings with
  links to source systems

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/USE-587
* https://mitlibraries.atlassian.net/browse/USE-457

How does this address that need:

* Updates eyebrow mappings to be based on format/content_type instead of source
* Adds source mappings to user friendly strings with links to source systems

Document any side effects to this change:

* Visited link to source may need a UI pass to make it look better

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
