### PR TITLE
[EXPERIMENT] Prototypal numeric queryTuning parameter for quepid experimentation

### DIFF
--- a/app/models/enhancer.rb
+++ b/app/models/enhancer.rb
@@ -1,7 +1,7 @@
 class Enhancer
   attr_accessor :enhanced_query
 
-  QUERY_PARAMS = %i[q citation contentType contributors fundingInformation identifiers locations subjects title queryMode].freeze
+  QUERY_PARAMS = %i[q citation contentType contributors fundingInformation identifiers locations subjects title queryMode queryTuning].freeze
   FILTER_PARAMS = %i[accessToFilesFilter contentTypeFilter contributorsFilter formatFilter languagesFilter
                      literaryFormFilter placesFilter sourceFilter subjectsFilter].freeze
   GEO_PARAMS = %i[geoboxMinLongitude geoboxMinLatitude geoboxMaxLongitude geoboxMaxLatitude geodistanceLatitude

--- a/app/models/query_builder.rb
+++ b/app/models/query_builder.rb
@@ -72,6 +72,17 @@ class QueryBuilder
 
     # Validate against allow list
     mode = 'keyword' unless VALID_QUERY_MODES.include?(mode)
+
+    # Override mode based on numeric tuning parameter if specific values present
+    if enhanced_query[:queryTuning]
+      Rails.logger.debug 'Query Tuning parameter present - checking for override'
+      Rails.logger.debug "queryTuning is #{enhanced_query[:queryTuning]}"
+      mode = 'keyword' if enhanced_query[:queryTuning].to_f == 0.0
+      mode = 'hybrid' if (enhanced_query[:queryTuning].to_f - 0.5).abs < Float::EPSILON
+      mode = 'semantic' if (enhanced_query[:queryTuning].to_f - 1.0).abs < Float::EPSILON
+      Rails.logger.debug "Query mode set to #{mode}"
+    end
+
     @query['queryMode'] = mode
   end
 end


### PR DESCRIPTION
This is a brief prototype of what a numeric querystring parameter that is mapped to the new `queryMode` value within the application. This is meant to expose a tunable value to Quepid that allows "mixing" between the three query modes.

This may not see the light of day. If it does, this will be cleaned up with tests and associated PR message.