### PR TITLE
Trigger OpenAlex lookups on articles only

### DIFF
--- a/app/controllers/thirdiron_controller.rb
+++ b/app/controllers/thirdiron_controller.rb
@@ -7,6 +7,7 @@ class ThirdironController < ApplicationController
     @libkey = Libkey.lookup(type: params[:type], identifier: params[:identifier])
     @doi = params[:type] == 'doi' ? params[:identifier] : nil
     @pmid = params[:type] == 'pmid' ? params[:identifier] : nil
+    @format = params[:format]
   end
 
   def browzine

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -58,4 +58,14 @@ module ResultsHelper
 
     'https://mit.on.worldcat.org/search?' + worldcat_params
   end
+
+  # Determines if a format value represents an article type
+  #
+  # @param format [String] The format value to check (e.g., 'Article', 'Magazine Article')
+  # @return [Boolean] True if format contains 'article' as a whole word (case-insensitive), false otherwise
+  def article?(format)
+    return false if format.blank?
+
+    format.match?(/\barticle\b/i)
+  end
 end

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -86,13 +86,14 @@
 
         <%# LibKey links are our preferred links so we call the API when possible to get these preferred links %>
         <% if ThirdIron.enabled? && result[:doi].present? %>
-          <%= render(partial: 'trigger_libkey', locals: { kind: 'doi', identifier: result[:doi] }) %>
+          <%= render(partial: 'trigger_libkey', locals: { kind: 'doi', identifier: result[:doi], format: result[:format] }) %>
         <% elsif ThirdIron.enabled? && result[:pmid].present? %>
-          <%= render(partial: 'trigger_libkey', locals: { kind: 'pmid', identifier: result[:pmid] }) %>
+          <%= render(partial: 'trigger_libkey', locals: { kind: 'pmid', identifier: result[:pmid], format: result[:format] }) %>
         <% end %>
 
         <%# OpenAccess Links: If OA_ALWAYS is enabled, include them when available. If not we'll trigger when we have a DOI/PMID but LibKey does not return data. See app/views/thirdiron/libkey.html.erb %>
-        <% if Feature.enabled?(:oa_always) %>
+        <%# Only show OpenAccess links for articles %>
+        <% if Feature.enabled?(:oa_always) && article?(result[:format]) %>
           <%= render(partial: 'trigger_openalex_setup', locals: { doi: result[:doi], pmid: result[:pmid] }) %>
         <% end %>
 

--- a/app/views/search/_trigger_libkey.html.erb
+++ b/app/views/search/_trigger_libkey.html.erb
@@ -1,6 +1,8 @@
 <% return unless ThirdIron.enabled? %>
 
-<% data_url = "/libkey?type=#{kind}&identifier=#{identifier}" %>
+<% query_params = { type: kind, identifier: identifier } %>
+<% query_params[:format] = format if format.present? %>
+<% data_url = "/libkey?#{query_params.to_query}" %>
 
 <span class="libkey-container"
      data-controller="content-loader"

--- a/app/views/thirdiron/libkey.html.erb
+++ b/app/views/thirdiron/libkey.html.erb
@@ -21,6 +21,7 @@
   <% end %>
 
 <%# If we didn't get data back from LibKey, we try OpenAlex unless OA_ALWAYS is enabled at which point we would have already requested data from OpenAlex in parallel to LibKey %>
-<% elsif @libkey.blank? && !Feature.enabled?(:oa_always) %>
+<%# Only show OpenAlex links for articles %>
+<% elsif @libkey.blank? && !Feature.enabled?(:oa_always) && article?(@format) %>
   <%= render(partial: 'search/trigger_openalex_setup', locals: { doi: @doi, pmid: @pmid }) %>
 <% end %>

--- a/test/controllers/thirdiron_controller_test.rb
+++ b/test/controllers/thirdiron_controller_test.rb
@@ -41,7 +41,7 @@ class ThirdironControllerTest < ActionDispatch::IntegrationTest
   test 'libkey for non-existent identifier inserts openalex setup when oa_always is false' do
     # Libkey responds here, so we have a cassette - but the response is empty
     VCR.use_cassette('libkey nonexistent') do
-      get '/libkey?type=doi&identifier=foobar'
+      get '/libkey?type=doi&identifier=foobar&format=Article'
 
       assert_response :success
       assert_select '.openalex-container', { count: 1 }
@@ -52,11 +52,21 @@ class ThirdironControllerTest < ActionDispatch::IntegrationTest
     ClimateControl.modify(FEATURE_OA_ALWAYS: 'true') do
       # Libkey responds here, so we have a cassette - but the response is empty
       VCR.use_cassette('libkey nonexistent') do
-        get '/libkey?type=doi&identifier=foobar'
+        get '/libkey?type=doi&identifier=foobar&format=Article'
 
         assert_response :success
         assert response.body.blank?
       end
+    end
+  end
+
+  test 'libkey for non-existent identifier does not insert OpenAlex setup for non-article formats' do
+    # OpenAlex should only appear for articles
+    VCR.use_cassette('libkey nonexistent') do
+      get '/libkey?type=doi&identifier=foobar&format=Book'
+
+      assert_response :success
+      assert_select '.openalex-container', { count: 0 }
     end
   end
 

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -90,4 +90,37 @@ class ResultsHelperTest < ActionView::TestCase
     assert link.start_with?('https://mit.on.worldcat.org/search?')
     assert_includes link, 'queryString=climate+change'
   end
+
+  test 'article? returns true for Article format' do
+    assert article?('Article')
+    assert article?('Journal Article')
+    assert article?('Newspaper Article')
+  end
+
+  test 'article? returns true for lowercase article formats' do
+    assert article?('article')
+    assert article?('journal article')
+    assert article?('newspaper article')
+  end
+
+  test 'article? returns true for mixed case article formats' do
+    assert article?('ARTICLE')
+    assert article?('Article')
+    assert article?('JoUrNaL ArTiClE')
+  end
+
+  test 'article? returns false for non-article formats' do
+    assert_not article?('Journal')
+    assert_not article?('eBook')
+    assert_not article?('Book Chapter')
+    assert_not article?('Conference Proceeding')
+    assert_not article?('Reference Entry')
+    assert_not article?('Research Database')
+    assert_not article?('Dataset')
+  end
+
+  test 'article? returns false for blank or nil format' do
+    assert_not article?(nil)
+    assert_not article?('')
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

OpenAlex lookups currently triggers on non-article content types
(e.g., Research Databases, Journals, eBooks). This can result in
incorrect or misleading fulfillment links.

#### Relevant ticket(s):

- [USE-503](https://mitlibraries.atlassian.net/browse/USE-503)

#### How this addresses that need:

- Adds article? helper to check if format matches 'article'
  (catches Article, Magazine Article, Newsletter Article, etc.)
- Passes format parameter through LibKey request/view chain

#### Side effects of this change:

We'll see fewer OpenAlex links, but hopefully more accurate ones.

#### Side effects of this change:

We'll see fewer OpenAlex links, but hopefully more accurate ones.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-503]: https://mitlibraries.atlassian.net/browse/USE-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ