### PR TITLE
USE-577: Add semantic search toggle UI to USE

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -572,20 +572,17 @@
 // RESULTS LIST NLS ALERT
 aside.nls-alert {
   margin-bottom: 40px;
+  display: flex;
+  gap: 6px;
+
+  i {
+    color: $color-magenta-500;
+    margin-top: 2px;
+  }
 
   p {
     font-weight: $fw-medium;
-
-    &::before {
-      display: inline-block;
-      height: 16px;
-      width: 16px;        
-      color: $color-icon-primary;
-      font: var(--fa-font-regular);
-      content: '\f06a';
-      margin-right: 6px;
-      color: $color-magenta-500;
-    }
+    line-height: 1.35;
 
     a {
       padding-left: 8px;

--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -413,7 +413,7 @@
 
   .results-context-description {
     color: $color-text-secondary;
-    margin-bottom: 40px;
+    margin-bottom: 12px;
   }
 
   #results-section {
@@ -565,6 +565,38 @@
       .core-sidebar-items {
         flex-direction: column;
       }      
+    }
+  }
+}
+
+// RESULTS LIST NLS ALERT
+aside.nls-alert {
+  margin-bottom: 40px;
+
+  p {
+    font-weight: $fw-medium;
+
+    &::before {
+      display: inline-block;
+      height: 16px;
+      width: 16px;        
+      color: $color-icon-primary;
+      font: var(--fa-font-regular);
+      content: '\f06a';
+      margin-right: 6px;
+      color: $color-magenta-500;
+    }
+
+    a {
+      padding-left: 8px;
+      font-weight: $fw-normal;
+      font-size: 1.4rem;
+      color: $color-text-secondary;
+      text-decoration-color: $color-gray-300;
+
+      &:hover {
+        text-decoration-color: $color-text-secondary;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -271,9 +271,61 @@
   padding-top: 16px;
   padding-bottom: 8px;
   display: flex;
+  justify-content: space-between;
   gap: 24px;
 
   a {
     @include searchUnderlinedLinks();
   }
+
+  .semantic-search-toggle {
+    display: flex;
+    gap: 12px;
+
+    button {
+      background-color: transparent;
+      border: none;
+      cursor: pointer;
+      @include searchUnderlinedLinks();
+
+      &::before {
+        background-color: $color-gray-900;
+        color: $color-text-oncolor;
+        font-size: 1rem;
+        font-weight: $fw-medium;
+        letter-spacing: 0.08em;
+        padding: 4px 6px;
+        border-radius: 4px;
+        display: inline-block;
+        margin-right: 8px;
+    }
+    }
+    
+    a {
+      color: $color-gray-400;
+      font-weight: $fw-normal;
+      text-decoration-color: $color-gray-700;
+
+      &:hover {
+        color: $color-gray-300;
+        text-decoration-color: $color-gray-400;
+      }
+    }
+
+    &.toggled-on {
+      button::before {
+        background-color: $color-magenta-700;
+        content: "ON";
+      }
+    }
+
+    &.toggled-off {
+      button::before {
+        content: "OFF";
+      }
+    }    
+  }
 }
+
+
+

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -325,6 +325,11 @@
       }
     }    
   }
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    gap: 12px;
+  }
 }
 
 

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -289,12 +289,12 @@
       @include searchUnderlinedLinks();
 
       &::before {
-        background-color: $color-gray-900;
+        background-color: $color-gray-800;
         color: $color-text-oncolor;
-        font-size: 1rem;
-        font-weight: $fw-medium;
+        font-size: 1.1rem;
+        font-weight: $fw-bold;
         letter-spacing: 0.08em;
-        padding: 4px 6px;
+        padding: 5px 8px;
         border-radius: 4px;
         display: inline-block;
         margin-right: 8px;

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -280,7 +280,7 @@
 
   .semantic-search-toggle {
     display: flex;
-    gap: 12px;
+    gap: 6px;
 
     button {
       background-color: transparent;

--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -45,6 +45,7 @@ $color-purple-700: #990099;
 $color-green-800: #009900;
 
 // MAGENTA
+$color-magenta-500: #FF33FF;
 $color-magenta-700: #CC00CC;
 
 // ---------------

--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -44,6 +44,9 @@ $color-purple-700: #990099;
 // GREEN
 $color-green-800: #009900;
 
+// MAGENTA
+$color-magenta-700: #CC00CC;
+
 // ---------------
 // SEMANTIC COLORS
 

--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -12,6 +12,7 @@ $color-gray-400: #b3b3b3;
 $color-gray-500: #999;
 $color-gray-600: #808080;
 $color-gray-700: #666;
+$color-gray-800: #4D4D4D;
 $color-gray-900: #333;
 $color-gray-950: #1a1a1a;
 $color-gray-975: #191919;

--- a/app/javascript/matomo_tracking.js
+++ b/app/javascript/matomo_tracking.js
@@ -280,20 +280,16 @@ function getCurrentResultsPage() {
 // Returns an empty string if the toggle element is not found.
 // ---------------------------------------------------------------------------
 function getToggleState(el) {
-  if (!el) return "";
+  // Walk up from the triggered element to find the semantic-search-toggle container,
+  // then select the button inside it. Optional chaining (?.) ensures safe traversal.
+  const button = el?.closest('.semantic-search-toggle')?.querySelector('button');
   
-  // Find the nearest ancestor with .semantic-search-toggle class
-  const toggleContainer = el.closest('.semantic-search-toggle');
-  if (!toggleContainer) return "";
+  // Extract content property from the ::before pseudo-element's computed styles.
+  // CSS content values include quotes (e.g., "ON"), so we default to empty string if no button.
+  const beforeContent = button ? window.getComputedStyle(button, '::before').content : '';
   
-  // Get the button element inside the toggle container
-  const button = toggleContainer.querySelector('button');
-  if (!button) return "";
-  
-  // Read computed style of the ::before pseudo-element
-  const beforeContent = window.getComputedStyle(button, '::before').content;
-  
-  // Remove quotes and whitespace: "ON" → ON
+  // Remove surrounding quotes (both " and ') and trim whitespace.
+  // Result: "ON" becomes ON, "OFF" becomes OFF, '' stays ''.
   return beforeContent.replace(/["']/g, '').trim();
 }
 

--- a/app/javascript/matomo_tracking.js
+++ b/app/javascript/matomo_tracking.js
@@ -275,6 +275,29 @@ function getCurrentResultsPage() {
 }
 
 // ---------------------------------------------------------------------------
+// Get the toggle state from the nearest .semantic-search-toggle ancestor.
+// Reads the ::before pseudo-element content and returns "ON" or "OFF".
+// Returns an empty string if the toggle element is not found.
+// ---------------------------------------------------------------------------
+function getToggleState(el) {
+  if (!el) return "";
+  
+  // Find the nearest ancestor with .semantic-search-toggle class
+  const toggleContainer = el.closest('.semantic-search-toggle');
+  if (!toggleContainer) return "";
+  
+  // Get the button element inside the toggle container
+  const button = toggleContainer.querySelector('button');
+  if (!button) return "";
+  
+  // Read computed style of the ::before pseudo-element
+  const beforeContent = window.getComputedStyle(button, '::before').content;
+  
+  // Remove quotes and whitespace: "ON" → ON
+  return beforeContent.replace(/["']/g, '').trim();
+}
+
+// ---------------------------------------------------------------------------
 // Register helpers on window.MatomoHelpers so they can be referenced with the
 // {{functionName}} syntax in data-matomo-seen and data-matomo-click attributes.
 // Add new helpers here as needed.
@@ -283,4 +306,5 @@ window.MatomoHelpers = {
   getActiveTabName,
   getElementText,
   getCurrentResultsPage,
+  getToggleState,
 };

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -12,7 +12,7 @@
   <div class="search-actions"  data-matomo-click="Search, Advanced Search Engaged, Tab: {{getActiveTabName}}">
     <a href="https://libraries.mit.edu/search-advanced">Advanced search</a>
     <div class="semantic-search-toggle toggled-off">
-      <button type="button">Turn on natural language search</button>
+      <button type="button">Natural language search</button>
       <a href="#">Learn more</a>
     </div>
   </div>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -9,11 +9,11 @@
     <input id="tab-to-target" type="hidden" name="tab" value="<%= @active_tab %>">
     <button type="submit" class="btn button-primary">Search</button>
   </div>
-  <div class="search-actions"  data-matomo-click="Search, Advanced Search Engaged, Tab: {{getActiveTabName}}">
-    <a href="https://libraries.mit.edu/search-advanced">Advanced search</a>
-    <div class="semantic-search-toggle toggled-off">
-      <button type="button">Natural language search</button>
-      <a href="#">Learn more</a>
+  <div class="search-actions">
+    <a href="https://libraries.mit.edu/search-advanced" data-matomo-click="Search, Advanced Search Engaged, Tab: {{getActiveTabName}}">Advanced search</a>
+    <div class="semantic-search-toggle toggled-off" data-matomo-seen="Semantic Search Toggle, Seen by user, Tab: {{getActiveTabName}}">
+      <button type="button" data-matomo-click="Semantic Search Toggle, Toggle Clicked, Was: {{getToggleState}}">Natural language search</button>
+      <a href="#" data-matomo-click="Semantic Search Toggle, Learn more Clicked, Tab: {{getActiveTabName}}">Learn more</a>
     </div>
   </div>
 </form>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -11,6 +11,10 @@
   </div>
   <div class="search-actions"  data-matomo-click="Search, Advanced Search Engaged, Tab: {{getActiveTabName}}">
     <a href="https://libraries.mit.edu/search-advanced">Advanced search</a>
+    <div class="semantic-search-toggle toggled-off">
+      <button type="button">Turn on natural language search</button>
+      <a href="#">Learn more</a>
+    </div>
   </div>
 </form>
 

--- a/app/views/search/_nls_alert.html.erb
+++ b/app/views/search/_nls_alert.html.erb
@@ -1,3 +1,4 @@
 <aside class="nls-alert">
-  <p>Natural language search is not available yet for these results<a href="#">Learn more</a></p>
+  <i class="fa-regular fa-circle-exclamation"></i>
+  <p>Natural language search is not available for these results<a href="#">Learn more</a></p>
 </aside>

--- a/app/views/search/_nls_alert.html.erb
+++ b/app/views/search/_nls_alert.html.erb
@@ -1,0 +1,3 @@
+<aside class="nls-alert">
+  <p>Natural language search is not available yet for these results<a href="#">Learn more</a></p>
+</aside>

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -20,6 +20,7 @@
 
         <h2 class="results-context" data-matomo-seen="Search, Results Found, Tab: {{getActiveTabName}}"><%= results_summary(@pagination[:hits]) %></h2>
         <p class="results-context-description"><%= tab_description %></p>
+        <%= render partial: 'search/nls_alert' %>
         <div id="results-layout-wrapper">
           <main id="results">
             <ol class="results-list use" data-matomo-click="Results, Link Engaged, Link: {{getElementText}}; Tab: {{getActiveTabName}}" start="<%= @pagination[:start] %>">


### PR DESCRIPTION
#### Developer
To prepare for a user-toggled path to turning on our new semantic search feature, we need a UI element for the user to be able to do this. This work introduces the UI element with two states (ON/OFF) and a link placeholder to send the user to a page with more details.

This work also introduces the intended Matomo tracking events.

**Note to reviewer:** There's a class `toggled-off` that can be switched to `toggled-on` that updates the color and text of the ON/OFF indicator.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
