### PR TITLE
Implement natural language search opt-in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   helper Mitlibraries::Theme::Engine.helpers
 
+  before_action :set_natural_language_search_optin
+
   # Set active tab based on params (no persistent cookie). This intentionally
   # avoids storing the user's last-used tab in a cookie per UXWS request.
   def set_active_tab
@@ -30,5 +32,9 @@ class ApplicationController < ActionController::Base
 
   def valid_tab?(tab)
     all_tabs.include?(tab)
+  end
+
+  def set_natural_language_search_optin
+    @natural_language_search_optin = cookies[:natural_language_search_optin] == 'true'
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
     # inject session preference for boolean type if it is present
     params[:booleanType] = cookies[:boolean_type] || 'AND'
 
-    # inject queryMode from cookie if not provided in URL params
+    # inject hybrid queryMode if opted-in and no queryMode param provided
     params[:queryMode] = 'hybrid' if params[:queryMode].blank? && cookies[:natural_language_search_optin] == 'true'
 
     @enhanced_query = Enhancer.new(params).enhanced_query

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,11 @@ class SearchController < ApplicationController
     # inject session preference for boolean type if it is present
     params[:booleanType] = cookies[:boolean_type] || 'AND'
 
+    # inject queryMode from cookie if not provided in URL params
+    params[:queryMode] = 'hybrid' if params[:queryMode].blank? && cookies[:natural_language_search_optin] == 'true'
+
     @enhanced_query = Enhancer.new(params).enhanced_query
+    @show_nls_warning = show_nls_warning?
 
     # Load GeoData results if applicable
     if Feature.enabled?(:geodata)
@@ -441,5 +445,11 @@ class SearchController < ApplicationController
     return true if ActiveSupport::SecurityUtils.secure_compare(params[:format_token], ENV.fetch('FORMAT_TOKEN', ''))
 
     false
+  end
+
+  # show_nls_warning? determines if the user should see a warning that results are not using natural language search.
+  # Shows when: user is opted-in AND viewing a Primo-only tab (which only supports keyword search).
+  def show_nls_warning?
+    @natural_language_search_optin && primo_tabs.include?(@active_tab)
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 class StaticController < ApplicationController
   def style_guide; end
 
@@ -9,5 +11,30 @@ class StaticController < ApplicationController
     end
 
     redirect_back_or_to root_path
+  end
+
+  def natural_language_search_optin
+    optin = params[:natural_language_search_optin]
+    if %w[true false].include?(optin)
+      cookies[:natural_language_search_optin] = optin
+    else
+      cookies.delete :natural_language_search_optin
+    end
+
+    # Redirect to return_to param if it's a safe local path, otherwise root
+    return_to = params[:return_to].presence
+    safe_return_to = nil
+    if return_to
+      begin
+        parsed = URI.parse(return_to)
+        # Only allow local paths with no host or scheme
+        if parsed.path&.start_with?('/') && !return_to.start_with?('//') && parsed.host.nil? && parsed.scheme.nil?
+          safe_return_to = return_to
+        end
+      rescue URI::InvalidURIError
+        safe_return_to = nil
+      end
+    end
+    redirect_to(safe_return_to || root_path)
   end
 end

--- a/app/javascript/controllers/natural_language_search_toggle_controller.js
+++ b/app/javascript/controllers/natural_language_search_toggle_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  toggle(event) {
+    event.preventDefault()
+    
+    const isCurrentlyOn = this.element.classList.contains('toggled-on')
+    const newState = isCurrentlyOn ? 'false' : 'true'
+    
+    this.setOptinState(newState)
+  }
+
+  setOptinState(state) {
+    // Build the redirect URL to return to the current results page
+    const redirectUrl = window.location.pathname + window.location.search
+    
+    // Make a GET request to the toggle endpoint
+    const url = new URL('/natural_language_search_optin', window.location.origin)
+    url.searchParams.set('natural_language_search_optin', state)
+    url.searchParams.set('return_to', redirectUrl)
+    
+    // Navigate to the toggle URL, which will redirect back with the new cookie set
+    window.location.href = url.toString()
+  }
+}

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -11,8 +11,8 @@
   </div>
   <div class="search-actions">
     <a href="https://libraries.mit.edu/search-advanced" data-matomo-click="Search, Advanced Search Engaged, Tab: {{getActiveTabName}}">Advanced search</a>
-    <div class="semantic-search-toggle toggled-off" data-matomo-seen="Semantic Search Toggle, Seen by user, Tab: {{getActiveTabName}}">
-      <button type="button" data-matomo-click="Semantic Search Toggle, Toggle Clicked, Was: {{getToggleState}}">Natural language search</button>
+    <div class="semantic-search-toggle <%= @natural_language_search_optin ? 'toggled-on' : 'toggled-off' %>" data-controller="natural-language-search-toggle" data-matomo-seen="Semantic Search Toggle, Seen by user, Tab: {{getActiveTabName}}">
+      <button type="button" aria-pressed="<%= @natural_language_search_optin %>" data-action="click->natural-language-search-toggle#toggle" data-matomo-click="Semantic Search Toggle, Toggle Clicked, Was: {{getToggleState}}">Natural language search</button>
       <a href="#" data-matomo-click="Semantic Search Toggle, Learn more Clicked, Tab: {{getActiveTabName}}">Learn more</a>
     </div>
   </div>

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -18,7 +18,6 @@
       <% elsif @results.present? && @errors.blank? %>
 
         <h2 class="results-context" data-matomo-seen="Search, Results Found, Tab: {{getActiveTabName}}"><%= results_summary(@pagination[:hits]) %></h2>
-        <p class="results-context-description"><%= tab_description %></p>
         <% if @show_nls_warning %>
           <%= render partial: 'search/nls_alert' %>
         <% end %>

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -18,7 +18,10 @@
       <% elsif @results.present? && @errors.blank? %>
 
         <h2 class="results-context" data-matomo-seen="Search, Results Found, Tab: {{getActiveTabName}}"><%= results_summary(@pagination[:hits]) %></h2>
-        <%= render partial: 'search/nls_alert' %>
+        <p class="results-context-description"><%= tab_description %></p>
+        <% if @show_nls_warning %>
+          <%= render partial: 'search/nls_alert' %>
+        <% end %>
         <div id="results-layout-wrapper">
           <main id="results">
             <ol class="results-list use" data-matomo-click="Results, Link Engaged, Link: {{getElementText}}; Tab: {{getActiveTabName}}" start="<%= @pagination[:start] %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get 'style-guide', to: 'static#style_guide'
 
   get 'boolpref', to: 'static#boolpref'
+  get 'natural_language_search_optin', to: 'static#natural_language_search_optin'
 
   get 'robots.txt', to: 'robots#robots'
 end

--- a/test/controllers/natural_language_search_optin_test.rb
+++ b/test/controllers/natural_language_search_optin_test.rb
@@ -1,0 +1,310 @@
+require 'test_helper'
+require 'cgi'
+
+class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
+  def mock_timdex_success
+    mock_response = mock('timdex_response')
+    mock_errors = mock('timdex_errors')
+    mock_errors.stubs(:details).returns({})
+    mock_errors.stubs(:to_h).returns({})
+    mock_response.stubs(:errors).returns(mock_errors)
+
+    mock_data = mock('timdex_data')
+    mock_search = mock('timdex_search')
+    sample_result = {
+      'title' => 'Sample Result',
+      'timdexRecordId' => 'test-123',
+      'contentType' => ['Article']
+    }
+    mock_search.stubs(:to_h).returns({
+                                       'hits' => 1,
+                                       'aggregations' => {},
+                                       'records' => [sample_result]
+                                     })
+    mock_data.stubs(:search).returns(mock_search)
+    mock_data.stubs(:to_h).returns({
+                                     'search' => {
+                                       'hits' => 1,
+                                       'aggregations' => {},
+                                       'records' => [sample_result]
+                                     }
+                                   })
+    mock_response.stubs(:data).returns(mock_data)
+
+    TimdexBase::Client.stubs(:query).returns(mock_response)
+  end
+
+  def mock_primo_success
+    sample_doc = {
+      api: 'primo',
+      title: 'Sample Primo Result',
+      format: 'Article'
+    }
+
+    mock_primo = mock('primo_search')
+    mock_primo.stubs(:search).returns({ 'docs' => [sample_doc], 'info' => { 'total' => 1 } })
+    PrimoSearch.stubs(:new).returns(mock_primo)
+
+    mock_normalizer = mock('normalizer')
+    mock_normalizer.stubs(:normalize).returns([sample_doc])
+    NormalizePrimoResults.stubs(:new).returns(mock_normalizer)
+  end
+
+  test 'route with natural_language_search_optin=true sets cookie' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+    assert_response :redirect
+    assert_equal cookies['natural_language_search_optin'], 'true'
+  end
+
+  test 'route with natural_language_search_optin=false sets cookie to false' do
+    get '/natural_language_search_optin?natural_language_search_optin=false'
+    assert_response :redirect
+    assert_equal cookies['natural_language_search_optin'], 'false'
+  end
+
+  test 'route with no parameter deletes cookie' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+    assert_equal cookies['natural_language_search_optin'], 'true'
+
+    get '/natural_language_search_optin'
+    assert_response :redirect
+
+    # Rails sets cookies to empty string when deleted via cookies.delete
+    assert(cookies['natural_language_search_optin'].blank?)
+  end
+
+  test 'route redirects to return_to when provided' do
+    get '/natural_language_search_optin?natural_language_search_optin=true&return_to=/results?q=test'
+    assert_response :redirect
+    assert_redirected_to '/results?q=test'
+  end
+
+  test 'route redirects to root when no referer or return_to' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+    assert_response :redirect
+    assert_redirected_to root_path
+  end
+
+  test 'toggle shows toggled-off by default (no cookie)' do
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_select 'div.semantic-search-toggle.toggled-off'
+  end
+
+  test 'toggle shows toggled-on when opted-in' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_select 'div.semantic-search-toggle.toggled-on'
+  end
+
+  test 'toggle shows toggled-off when opted-out' do
+    get '/natural_language_search_optin?natural_language_search_optin=false'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_select 'div.semantic-search-toggle.toggled-off'
+  end
+
+  test 'route with return_to redirects to that path' do
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+
+    return_to = '/results?q=test&tab=timdex&page=2'
+    get "/natural_language_search_optin?natural_language_search_optin=true&return_to=#{CGI.escape(return_to)}"
+
+    assert_response :redirect
+    assert_redirected_to return_to
+  end
+
+  test '@natural_language_search_optin is true when cookie is true' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], true
+  end
+
+  test '@natural_language_search_optin is false when cookie is false' do
+    get '/natural_language_search_optin?natural_language_search_optin=false'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], false
+  end
+
+  test '@natural_language_search_optin is false when no cookie' do
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], false
+  end
+
+  test 'URL param queryMode overrides cookie' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+    assert_equal cookies['natural_language_search_optin'], 'true'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex&queryMode=keyword'
+
+    assert_response :success
+    assert_equal cookies['natural_language_search_optin'], 'true'
+  end
+
+  test 'cookie unchanged after search with URL param override' do
+    get '/natural_language_search_optin?natural_language_search_optin=false'
+    assert_equal cookies['natural_language_search_optin'], 'false'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex&queryMode=hybrid'
+
+    assert_response :success
+    assert_equal cookies['natural_language_search_optin'], 'false'
+  end
+
+  test 'cookie=true, no param: user is opted-in' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+    mock_timdex_success
+
+    get '/results?q=test&tab=timdex'
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], true
+  end
+
+  test 'cookie=false, no param: user is opted-out' do
+    get '/natural_language_search_optin?natural_language_search_optin=false'
+    mock_timdex_success
+
+    get '/results?q=test&tab=timdex'
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], false
+  end
+
+  test 'no cookie, no param: user is not opted-in' do
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], false
+  end
+
+  test 'cookie-driven queryMode works on timdex tab' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+    mock_timdex_success
+
+    get '/results?q=test&tab=timdex'
+    assert_response :success
+  end
+
+  test 'cookie-driven queryMode works on all tab' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_timdex_success
+    mock_primo_success
+
+    get '/results?q=test&tab=all'
+    assert_response :success
+  end
+
+  test 'warning shows on Primo tab when opted-in' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_primo_success
+    get '/results?q=test&tab=cdi'
+
+    assert_response :success
+    assert_select 'aside.nls-alert', count: 1
+  end
+
+  test 'warning does not show on TIMDEX tab when opted-in' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_select 'aside.nls-alert', count: 0
+  end
+
+  test 'warning does not show on articles tab when opted-out' do
+    get '/natural_language_search_optin?natural_language_search_optin=false'
+
+    mock_primo_success
+    get '/results?q=test&tab=cdi'
+
+    assert_response :success
+    assert_select 'aside.nls-alert', count: 0
+  end
+
+  test 'warning does not show on articles tab with no opt-in cookie' do
+    mock_primo_success
+    get '/results?q=test&tab=cdi'
+
+    assert_response :success
+    assert_select 'aside.nls-alert', count: 0
+  end
+
+  test 'warning shows on alma tab when opted-in' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_primo_success
+    get '/results?q=test&tab=alma'
+
+    assert_response :success
+    assert_select 'aside.nls-alert', count: 1
+  end
+
+  test 'warning shows on cdi tab when opted-in' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_primo_success
+    get '/results?q=test&tab=cdi'
+
+    assert_response :success
+    assert_select 'aside.nls-alert', count: 1
+  end
+
+  test '@show_nls_warning is true when opted-in on Primo tab' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_primo_success
+    get '/results?q=test&tab=cdi'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['show_nls_warning'], true
+  end
+
+  test '@show_nls_warning is false when opted-in on TIMDEX tab' do
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['show_nls_warning'], false
+  end
+
+  test '@show_nls_warning is false when opted-out on Primo tab' do
+    get '/natural_language_search_optin?natural_language_search_optin=false'
+
+    mock_primo_success
+    get '/results?q=test&tab=cdi'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['show_nls_warning'], false
+  end
+end

--- a/test/controllers/natural_language_search_optin_test.rb
+++ b/test/controllers/natural_language_search_optin_test.rb
@@ -85,6 +85,12 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  test 'external URLs redirect to route' do
+    get '/natural_language_search_optin?natural_language_search_optin=true&return_to=https://example.com/evil'
+    assert_response :redirect
+    assert_redirected_to root_path
+  end
+
   test 'toggle shows toggled-off by default (no cookie)' do
     mock_timdex_success
     get '/results?q=test&tab=timdex'
@@ -240,7 +246,7 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
     assert_select 'aside.nls-alert', count: 0
   end
 
-  test 'warning does not show on articles tab when opted-out' do
+  test 'warning does not show on cdi tab when opted-out' do
     get '/natural_language_search_optin?natural_language_search_optin=false'
 
     mock_primo_success
@@ -250,7 +256,7 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
     assert_select 'aside.nls-alert', count: 0
   end
 
-  test 'warning does not show on articles tab with no opt-in cookie' do
+  test 'warning does not show on cdi tab with no opt-in cookie' do
     mock_primo_success
     get '/results?q=test&tab=cdi'
 


### PR DESCRIPTION
#### Why these changes are being introduced:

We want users to be able to decide whether to use
hybrid (termed 'natural language search' in the
public UI) or lexical search. USE-577 implemented
the frontend work on this feature; this ticket
implements the controller layer.

#### Relevant ticket(s):

- [USE-576](https://mitlibraries.atlassian.net/browse/USE-576)
- [USE-577](https://mitlibraries.atlassian.net/browse/USE-577)

#### How this addresses that need:

This adds natural language search opt-in cookie,
which is toggled via a stimulus controller. When
the cookie is set, hybrid search is the default
query mode. When it is not set, the query mode
falls back to lexical search (or other default
mode specified by env).

This behavior can be overridden by supplying a
`queryMode` param manually. For example, if a user has the NLS cookie set but adds `queryMode=semantic` to their query string, the search will execute
in semantic mode, not hybrid.

If NLS is not available for a given tab, a
message displays to notify the user of the
limitation.

#### Side effects of this change:

Tests for this feature are stored in a separate
file. This is different from how we usually do
things, but there are so many conditions to test
that I did not want to pollute the search
controller test file further.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-576]: https://mitlibraries.atlassian.net/browse/USE-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[USE-577]: https://mitlibraries.atlassian.net/browse/USE-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ