### PR TITLE
Adds about natural language search page and links

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,6 +3,8 @@ require 'uri'
 class StaticController < ApplicationController
   def style_guide; end
 
+  def about_natural_language_search; end
+
   def boolpref
     if params[:boolean_type].present?
       cookies[:boolean_type] = params[:boolean_type]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
   end
 
   def index_page_title
-    ENV.fetch('PLATFORM_NAME', nil) ? "Search #{ENV.fetch('PLATFORM_NAME')} | MIT Libraries" : 'Search | MIT Libraries'
+    ENV.fetch('PLATFORM_NAME', nil) ? ENV.fetch('PLATFORM_NAME') : 'Search | MIT Libraries'
   end
 
   def results_page_title(query, character_limit = 50)

--- a/app/models/normalize_timdex_record.rb
+++ b/app/models/normalize_timdex_record.rb
@@ -11,7 +11,7 @@ class NormalizeTimdexRecord
     'Research Databases' => ['Research Databases', 'https://libguides.mit.edu/az/databases'],
     'MIT Libraries Website' => ['Library Website', 'https://libraries.mit.edu/'],
     'MIT Alma' => ['MIT Libraries Catalog',
-                   "#{ENV.fetch('MIT_PRIMO_URL')}/discovery/search?vid=#{ENV.fetch('PRIMO_VID')}&lang=en"]
+                   "#{ENV.fetch('MIT_PRIMO_URL', nil)}/discovery/search?vid=#{ENV.fetch('PRIMO_VID', nil)}&lang=en"]
   }.freeze
 
   def initialize(record, query)

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -13,7 +13,7 @@
     <a href="https://libraries.mit.edu/search-advanced" data-matomo-click="Search, Advanced Search Engaged, Tab: {{getActiveTabName}}">Advanced search</a>
     <div class="semantic-search-toggle <%= @natural_language_search_optin ? 'toggled-on' : 'toggled-off' %>" data-controller="natural-language-search-toggle" data-matomo-seen="Semantic Search Toggle, Seen by user, Tab: {{getActiveTabName}}">
       <button type="button" aria-pressed="<%= @natural_language_search_optin %>" data-action="click->natural-language-search-toggle#toggle" data-matomo-click="Semantic Search Toggle, Toggle Clicked, Was: {{getToggleState}}">Natural language search</button>
-      <a href="#" data-matomo-click="Semantic Search Toggle, Learn more Clicked, Tab: {{getActiveTabName}}">Learn more</a>
+      <%= link_to "Learn more", about_natural_language_search_path, data: { matomo_click: "Semantic Search Toggle, Learn more Clicked, Tab: {{getActiveTabName}}" } %>
     </div>
   </div>
 </form>

--- a/app/views/search/_nls_alert.html.erb
+++ b/app/views/search/_nls_alert.html.erb
@@ -1,4 +1,4 @@
 <aside class="nls-alert">
   <i class="fa-regular fa-circle-exclamation"></i>
-  <p>Natural language search is not available for these results<a href="#">Learn more</a></p>
+  <p>Natural language search is not available for these results <%= link_to "Learn more", about_natural_language_search_path, data: { turbo_frame: "_top" } %></p>
 </aside>

--- a/app/views/static/about_natural_language_search.html.erb
+++ b/app/views/static/about_natural_language_search.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, "About Natural Language Search" %>
+
+<div class="container">
+  <h2>Opting in to Natural Language Search</h2>
+
+  <h3>What does turning on the Natural Language Search (NLS) do?</h3>
+
+  <p>By default, this search tool uses traditional keyword matching.</p>
+ 
+  <p>If you enable the Natural Language Search (NLS) option, the search tries to understand the meaning and intent behind your search terms, not just matching exact keywords.</p>
+
+  <p>For example, if you search for "climate change impacts," the NLS can find results about "global warming effects" or "environmental shifts"&mdash;even if those exact words don't appear together or at all in the source.</p>
+
+  <p>You can opt-in and out of the NLS to try both options to see which results are better for different types of queries. We'll remember your last choice to make it easier to continue where you left off.</p>
+
+  <h3>How can I tell you what I think about NLS?</h3>
+
+  <p><a href="https://libraries.mit.edu/use-feedback">Send us your feedback!</a> Sharing your experiences (good and bad) will help us understand how to make these search options work better.</p>
+  <p>In our experience, NLS works well for:</p>
+  <ul>
+    <li>Natural language queries ("what causes ocean acidification?")</li>
+    <li>Concept-based searches rather than exact phrases</li>
+    <li>Exploratory research where related terms are valuable</li>
+  </ul>
+
+  <p>Traditional keyword searching works well for:</p>
+  <ul>
+    <li>Specific item searches (i.e. pasting an article title or full citation into the search box)</li>
+  </ul>
+
+  <p>Do you agree? <a href="https://libraries.mit.edu/use-feedback">Let us know what you think.</a></p>
+
+  <h3>Are there any limitations I should be aware of?</h3>
+
+  <p>This search tool (the default on the MIT Libraries homepage) searches across many MIT Libraries catalogs, indexes, and content sources and not all of these can be searched with NLS. You'll still get results from all sources - but we will revert to traditional keyword matching when NLS is not possible.</p>
+
+  <p>That means if you have enabled NLS, this is what you'll get on each tab:</p>
+  <ul>
+    <li>All tab (default): results listing "Articles, Books &amp; More" as a source use traditional keyword matching, all other results use NLS</li>
+    <li>Articles/Books &amp; Media tabs: all results use traditional keyword matching</li>
+    <li>All other tabs: all results use NLS</li>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get 'turnstile', to: 'turnstile#show', as: 'turnstile'
   post 'turnstile/verify', to: 'turnstile#verify', as: 'turnstile_verify'
   get 'style-guide', to: 'static#style_guide'
+  get 'about-natural-language-search', to: 'static#about_natural_language_search'
 
   get 'boolpref', to: 'static#boolpref'
   get 'natural_language_search_optin', to: 'static#natural_language_search_optin'

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class StaticControllerTest < ActionDispatch::IntegrationTest
+  test 'about natural language search page returns success' do
+    get about_natural_language_search_path
+
+    assert_response :success
+  end
+
+  test 'style guide page returns success' do
+    get style_guide_path
+
+    assert_response :success
+  end
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -81,7 +81,7 @@ class ApplicationHelperTest < ActionView::TestCase
     ClimateControl.modify PLATFORM_NAME: 'GeoData' do
       query = { q: 'foo' }
       record = { 'title' => 'bar' }
-      assert_equal 'Search GeoData | MIT Libraries', index_page_title
+      assert_equal 'GeoData', index_page_title
       assert_equal 'foo | GeoData | MIT Libraries', results_page_title(query)
       assert_equal 'bar | GeoData | MIT Libraries', record_page_title(record)
     end


### PR DESCRIPTION
Why are these changes being introduced:

* To provide users with information about the natural language search
  feature, how to use it, and limitations to be aware of.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/USE-601

How does this address that need:

* Creates static page with content

NOTE: a separate commit adjusting index page title is also included
NOTE: a separate bugfix for geodata introduced recently is also included.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
