### PR TITLE
USE-551: Applying secondary link styling to purple visited links

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -286,6 +286,7 @@
     -webkit-line-clamp: 1;
     margin-bottom: 4px;
     padding-bottom: 4px;
+    line-height: 1.3;
 
     li {
       font-weight: $fw-normal;

--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -161,6 +161,10 @@
   border-bottom: 1px solid $color-gray-400;
   border-top: none;
 
+  a:link, a:visited {
+    color: $color-text-primary;
+  }
+
   &:first-child {
     padding-top: 0;
   }
@@ -281,22 +285,23 @@
     line-clamp: 1;
     -webkit-line-clamp: 1;
     margin-bottom: 4px;
+    padding-bottom: 4px;
 
     li {
       font-weight: $fw-normal;
 
       a {
-        text-decoration: none;
-
-        &:hover {
-          text-decoration: underline;
-        }
+        @include underlinedSecondaryLinks;
       }
     }
   }
 
   .result-source {
     font-size: $fs-base;
+
+    a {
+      @include underlinedSecondaryLinks;
+    }
   }
 
   .inner-heading {

--- a/app/assets/stylesheets/partials/_typography.scss
+++ b/app/assets/stylesheets/partials/_typography.scss
@@ -11,6 +11,17 @@
   }
 }
 
+@mixin underlinedSecondaryLinks {
+  @include underlinedLinks;
+  text-decoration-color: $color-gray-400;
+  text-underline-offset: 0.4rem;
+
+  &:hover {
+    color: $color-blue-500;
+    text-decoration-color: $color-blue-500;
+  }
+}
+
 // Override fonts from the theme gem, done temporarily for USE UI
 body {
   font-family: $base-font;


### PR DESCRIPTION
#### Developer
After adding source links to result metadata, the links often showed up as purple visited links since they were commonly our website or tools.

I went into this work hoping to apply a global style, but a lot of the rules applying magenta to visited links have more specificity than a global rule probably should have.

This work instead:
* Fixes the magenta source link styling
* Adds a secondary subtle underlined link style
* Also applies this style to contributors to make all links in metadata have obvious visual affordance.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
