### PR TITLE
USE-591: Always show active tab, even if it would be hidden in More menu

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -156,9 +156,9 @@
 // --------------------------------------
 
 .result.use, .result.primo {
-  padding: 48px 0;
+  padding: 32px 0 32px;
   margin: 0;
-  border-bottom: 1px solid $color-gray-400;
+  border-bottom: 1px solid $color-gray-200;
   border-top: none;
 
   &:first-child {

--- a/app/javascript/source_tabs.js
+++ b/app/javascript/source_tabs.js
@@ -3,93 +3,189 @@
 // Source: https://css-tricks.com/container-adapting-tabs-with-more-button/
 // ===========================================================================
 
-// Store references to relevant selectors
-const container = document.querySelector('#tabs')
-const primary = container.querySelector('.primary')
-const primaryItems = container.querySelectorAll('.primary > li:not(.-more)')
+// Initialize tab bar functionality
+const initTabs = () => {
+  // Store references to relevant selectors
+  const container = document.querySelector('#tabs')
+  if (!container) return // Exit if tabs element doesn't exist
+  if (container.classList.contains('has-js')) return // Already initialized
 
-// Add a class to turn off graceful degradation style
-container.classList.add('has-js')
+  const primary = container.querySelector('.primary')
+  const primaryItems = container.querySelectorAll('.primary > li:not(.-more)')
 
-// insert "more" button and duplicate the original tab bar items
-primary.insertAdjacentHTML('beforeend', `
-  <li class="-more">
-    <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="more-options">
-      More <i class="fa-light fa-chevron-down"></i>
-    </button>
-    <ul class="-secondary" id="more-options" aria-label="More options">
-      ${primary.innerHTML}
-    </ul>
-  </li>
-`)
-const secondary = container.querySelector('.-secondary')
-const secondaryItems = secondary.querySelectorAll('li')
-const allItems = container.querySelectorAll('li')
-const moreLi = primary.querySelector('.-more')
-const moreBtn = moreLi.querySelector('button')
+  // Add a class to turn off graceful degradation style
+  container.classList.add('has-js')
 
-// When the more button is clicked, toggle classes to indicate the secondary menu is open
-moreBtn.addEventListener('click', (e) => {
-  e.preventDefault()
-  container.classList.toggle('--show-secondary')
-  moreBtn.setAttribute('aria-expanded', container.classList.contains('--show-secondary'))
-})
+  // insert "more" button and duplicate the original tab bar items
+  primary.insertAdjacentHTML('beforeend', `
+    <li class="-more">
+      <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="more-options">
+        More <i class="fa-light fa-chevron-down"></i>
+      </button>
+      <ul class="-secondary" id="more-options" aria-label="More options">
+        ${primary.innerHTML}
+      </ul>
+    </li>
+  `)
+  const secondary = container.querySelector('.-secondary')
+  const secondaryItems = secondary.querySelectorAll('li')
+  const allItems = container.querySelectorAll('li')
+  const moreLi = primary.querySelector('.-more')
+  const moreBtn = moreLi.querySelector('button')
 
-// Maximum number of tabs to show in the primary tab bar at once
-const MAX_TABS = 10
-
-// adapt tabs
-const doAdapt = () => {
-
-  // reveal all items for the calculation
-  allItems.forEach((item) => {
-    item.classList.remove('--hidden')
+  // Store original DOM order by index for each li
+  Array.from(primary.querySelectorAll('li:not(.-more)')).forEach((li, index) => {
+    li.dataset.originalIndex = index
+  })
+  Array.from(secondary.querySelectorAll('li:not(.-more)')).forEach((li, index) => {
+    li.dataset.originalIndex = index
   })
 
-  // hide items that won't fit in the Primary tab bar, or exceed MAX_TABS
-  // once a tab is hidden, all subsequent tabs are also hidden to preserve order
-  let stopWidth = moreBtn.offsetWidth
-  let hiddenItems = []
-  let shouldHide = false
-  const primaryWidth = primary.offsetWidth
-  primaryItems.forEach((item, i) => {
-    if(!shouldHide && i < MAX_TABS && primaryWidth >= stopWidth + item.offsetWidth) {
-      stopWidth += item.offsetWidth
-    } else {
-      shouldHide = true
-      item.classList.add('--hidden')
-      hiddenItems.push(i)
-    }
+  // When the more button is clicked, toggle classes to indicate the secondary menu is open
+  moreBtn.addEventListener('click', (e) => {
+    e.preventDefault()
+    container.classList.toggle('--show-secondary')
+    moreBtn.setAttribute('aria-expanded', container.classList.contains('--show-secondary'))
   })
-  
-  // toggle the visibility of More button and items in Secondary menu
-  if(!hiddenItems.length) {
-    moreLi.classList.add('--hidden')
-    container.classList.remove('--show-secondary')
-    moreBtn.setAttribute('aria-expanded', false)
-  }
-  else {  
-    secondaryItems.forEach((item, i) => {
-      if(!hiddenItems.includes(i)) {
+
+  // Maximum number of tabs to show in the primary tab bar at once
+  const MAX_TABS = 10
+
+  // adapt tabs
+  const doAdapt = () => {
+
+    // reveal all items for the calculation
+    allItems.forEach((item) => {
+      item.classList.remove('--hidden')
+    })
+
+    // Get primary items in current DOM order (re-query each time, direct children only)
+    const currentPrimaryItems = Array.from(primary.querySelectorAll(':scope > li:not(.-more)'))
+
+    // hide items that won't fit in the Primary tab bar, or exceed MAX_TABS
+    // once a tab is hidden, all subsequent tabs are also hidden to preserve order
+    let stopWidth = moreBtn.offsetWidth
+    let hiddenItems = []
+    let shouldHide = false
+    const primaryWidth = primary.offsetWidth
+    currentPrimaryItems.forEach((item, i) => {
+      if(!shouldHide && i < MAX_TABS && primaryWidth >= stopWidth + item.offsetWidth) {
+        stopWidth += item.offsetWidth
+      } else {
+        shouldHide = true
         item.classList.add('--hidden')
+        hiddenItems.push(i)
       }
     })
+    
+    // toggle the visibility of More button and items in Secondary menu
+    if(!hiddenItems.length) {
+      moreLi.classList.add('--hidden')
+      container.classList.remove('--show-secondary')
+      moreBtn.setAttribute('aria-expanded', false)
+    }
+    else {  
+      // Re-query secondary items in current DOM order (direct children only)
+      const currentSecondaryItems = Array.from(secondary.querySelectorAll(':scope > li:not(.-more)'))
+      currentSecondaryItems.forEach((item, i) => {
+        if(!hiddenItems.includes(i)) {
+          item.classList.add('--hidden')
+        }
+      })
+    }
+
+    // Handle active hidden tab - move it to position 2 (right after "All")
+    const activeLink = primary.querySelector('a.active')
+    if (activeLink) {
+      const activeLi = activeLink.parentElement
+
+      if (activeLi.classList.contains('--hidden')) {
+        const activeIndex = currentPrimaryItems.indexOf(activeLi)
+
+        // If active tab is not at position 0 (All) or position 1, move it to position 1
+        if (activeIndex > 1) {
+          const liAtPos1 = currentPrimaryItems[1]
+          
+          // Swap in primary by moving active before position 1
+          primary.insertBefore(activeLi, liAtPos1)
+
+          // Find matching items in secondary by original index
+          const activeOriginalIndex = parseInt(activeLi.dataset.originalIndex)
+          const pos1OriginalIndex = parseInt(liAtPos1.dataset.originalIndex)
+
+          const currentSecondaryItems = Array.from(secondary.querySelectorAll(':scope > li:not(.-more)'))
+          const secondaryActive = currentSecondaryItems.find(li =>
+            parseInt(li.dataset.originalIndex) === activeOriginalIndex
+          )
+          const secondaryPos1 = currentSecondaryItems.find(li =>
+            parseInt(li.dataset.originalIndex) === pos1OriginalIndex
+          )
+
+          // Swap in secondary
+          if (secondaryActive && secondaryPos1) {
+            secondary.insertBefore(secondaryActive, secondaryPos1)
+          }
+
+          // Recalculate visibility after swap
+          const updatedPrimaryItems = Array.from(primary.querySelectorAll(':scope > li:not(.-more)'))
+          const updatedSecondaryItems = Array.from(secondary.querySelectorAll(':scope > li:not(.-more)'))
+
+          // Clear hidden from all items before recalculating
+          updatedPrimaryItems.forEach(item => item.classList.remove('--hidden'))
+          updatedSecondaryItems.forEach(item => item.classList.remove('--hidden'))
+          moreLi.classList.remove('--hidden')
+
+          // Recalculate which items fit
+          let newStopWidth = moreBtn.offsetWidth
+          let newHiddenItems = []
+          let newShouldHide = false
+
+          updatedPrimaryItems.forEach((item, i) => {
+            if (!newShouldHide && i < MAX_TABS && primaryWidth >= newStopWidth + item.offsetWidth) {
+              newStopWidth += item.offsetWidth
+            } else {
+              newShouldHide = true
+              item.classList.add('--hidden')
+              newHiddenItems.push(i)
+            }
+          })
+
+          // Update secondary visibility
+          if (!newHiddenItems.length) {
+            moreLi.classList.add('--hidden')
+            container.classList.remove('--show-secondary')
+            moreBtn.setAttribute('aria-expanded', false)
+          } else {
+            moreLi.classList.remove('--hidden')
+            updatedSecondaryItems.forEach((item, i) => {
+              if (!newHiddenItems.includes(i)) {
+                item.classList.add('--hidden')
+              }
+            })
+          }
+        }
+      }
+    }
   }
+
+  // Adapt the tabs to fit the viewport
+  doAdapt() // immediately on load
+  window.addEventListener('resize', doAdapt) // on window resize
+
+  // hide Secondary menu on the outside click
+  document.addEventListener('click', (e) => {
+    let el = e.target
+    while(el) {
+      if(el === moreBtn) {
+        return;
+      }
+      el = el.parentNode
+    }
+    container.classList.remove('--show-secondary')
+    moreBtn.setAttribute('aria-expanded', false)
+  })
 }
 
-// Adapt the tabs to fit the viewport
-doAdapt() // immediately on load
-window.addEventListener('resize', doAdapt) // on window resize
-
-// hide Secondary menu on the outside click
-document.addEventListener('click', (e) => {
-  let el = e.target
-  while(el) {
-    if(el === moreBtn) {
-      return;
-    }
-    el = el.parentNode
-  }
-  container.classList.remove('--show-secondary')
-  moreBtn.setAttribute('aria-expanded', false)
-})
+// Initialize on page load and after Turbo navigates
+// turbo:load fires on both initial page load and subsequent Turbo navigations
+document.addEventListener('turbo:load', initTabs)

--- a/app/javascript/source_tabs.js
+++ b/app/javascript/source_tabs.js
@@ -11,7 +11,6 @@ const initTabs = () => {
   if (container.classList.contains('has-js')) return // Already initialized
 
   const primary = container.querySelector('.primary')
-  const primaryItems = container.querySelectorAll('.primary > li:not(.-more)')
 
   // Add a class to turn off graceful degradation style
   container.classList.add('has-js')
@@ -28,7 +27,6 @@ const initTabs = () => {
     </li>
   `)
   const secondary = container.querySelector('.-secondary')
-  const secondaryItems = secondary.querySelectorAll('li')
   const allItems = container.querySelectorAll('li')
   const moreLi = primary.querySelector('.-more')
   const moreBtn = moreLi.querySelector('button')
@@ -188,7 +186,10 @@ const initTabs = () => {
 
 // Initialize on page load and after Turbo navigates
 // turbo:load fires on both initial page load and subsequent Turbo navigations
-document.addEventListener('turbo:load', initTabs)
+ if (!window.__timdexSourceTabsTurboListenerAdded) {
+   window.__timdexSourceTabsTurboListenerAdded = true
+   document.addEventListener('turbo:load', initTabs)
+ }
 
 // Run immediately in case turbo:load already fired before this script loaded
 // (happens on first search when Turbo Drive loads the page containing this script)

--- a/app/javascript/source_tabs.js
+++ b/app/javascript/source_tabs.js
@@ -189,3 +189,7 @@ const initTabs = () => {
 // Initialize on page load and after Turbo navigates
 // turbo:load fires on both initial page load and subsequent Turbo navigations
 document.addEventListener('turbo:load', initTabs)
+
+// Run immediately in case turbo:load already fired before this script loaded
+// (happens on first search when Turbo Drive loads the page containing this script)
+initTabs()


### PR DESCRIPTION
#### Developer
Because we hide tabs that don't fit the screen width, we noticed that if a tab that's hidden is the active tab it's hard to know that visually.

This work makes sure the active tab is pinned into position 2 (right after the "All" option).

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
