### PR TITLE
Update Browzine link text

### DIFF
--- a/app/models/browzine.rb
+++ b/app/models/browzine.rb
@@ -40,7 +40,7 @@ class Browzine < ThirdIron
 
     {
       link: json_response['data'][0]['browzineWebLink'],
-      text: 'View journal contents'
+      text: 'Browse journal'
     }
   end
 

--- a/app/models/libkey.rb
+++ b/app/models/libkey.rb
@@ -76,7 +76,7 @@ class Libkey < ThirdIron
 
     {
       link: external_data['data']['browzineWebLink'],
-      text: 'Browse journal issue'
+      text: 'Browse journal'
     }
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

USE is currently using language for 2 Browzine
links as they exist in Primo VE now. These will
change with Primo NDE, so USE can be updated now.

#### Relevant ticket(s):

- [USE-590](https://mitlibraries.atlassian.net/browse/USE-590)

#### How this addresses that need:

This updates all Browzine links to read, "Browze journal."

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-590]: https://mitlibraries.atlassian.net/browse/USE-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ