### PR TITLE
Render fulfillment container only when applicable

### DIFF
--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -86,15 +86,15 @@ module ResultsHelper
   # @param result [Hash] A normalized Primo result hash
   # @return [Boolean] True if the result has links, availability, or ThirdIron/OpenAlex triggers
   def result_get?(result)
-    has_renderable_links?(result) ||
+    renderable_links?(result) ||
       result[:availability].present? ||
       (Feature.enabled?(:oa_always) && article?(result[:format])) ||
-      has_thirdiron_content?(result)
+      thirdiron_content?(result)
   end
 
   private
 
-  def has_renderable_links?(result)
+  def renderable_links?(result)
     return false unless result[:links].present?
     return true if Feature.enabled?(:record_link)
 
@@ -102,7 +102,7 @@ module ResultsHelper
     result[:links].any? { |link| link['kind'].downcase != 'full record' }
   end
 
-  def has_thirdiron_content?(result)
+  def thirdiron_content?(result)
     ThirdIron.enabled? && (
       result[:doi].present? ||
       result[:pmid].present? ||

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -80,4 +80,33 @@ module ResultsHelper
 
     format.match?(/\barticle\b/i)
   end
+
+  # Determines if a result has any fulfillment links to render
+  #
+  # @param result [Hash] A normalized Primo result hash
+  # @return [Boolean] True if the result has links, availability, or ThirdIron/OpenAlex triggers
+  def result_get?(result)
+    has_renderable_links?(result) ||
+      result[:availability].present? ||
+      (Feature.enabled?(:oa_always) && article?(result[:format])) ||
+      has_thirdiron_content?(result)
+  end
+
+  private
+
+  def has_renderable_links?(result)
+    return false unless result[:links].present?
+    return true if Feature.enabled?(:record_link)
+
+    # If record_link is disabled, exclude results that have ONLY "full record" links
+    result[:links].any? { |link| link['kind'].downcase != 'full record' }
+  end
+
+  def has_thirdiron_content?(result)
+    ThirdIron.enabled? && (
+      result[:doi].present? ||
+      result[:pmid].present? ||
+      (result[:format]&.downcase == 'journal' && result[:issn].present?)
+    )
+  end
 end

--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -25,7 +25,10 @@ export default class extends Controller {
             }
           }
         } else {
+          // Remove empty loader
           this.element.remove()
+
+          // Remove parent empty container, confirming first that it's empty
           if (!parentElement.textContent.trim()) {
             parentElement.remove()
           }

--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -23,24 +23,24 @@ export default class extends Controller {
     fetch(this.urlValue)
       .then(response => response.text())
       .then(html => {
-        const parentElement = this.element.parentElement;
+        const parentElement = this.element.parentElement
         // Strip HTML comments and trim whitespace
-        const cleanedHtml = this.stripHtmlComments(html).trim();
+        const cleanedHtml = this.stripHtmlComments(html).trim()
         // Replace the entire element with the fetched HTML, or remove if empty
         if (cleanedHtml) {
-          this.element.outerHTML = cleanedHtml;
+          this.element.outerHTML = cleanedHtml
           // Hide primo links if libkey link is present
           if (parentElement.querySelector('.libkey-link')) {
-            const resultGet = parentElement.closest('.result-get');
+            const resultGet = parentElement.closest('.result-get')
             if (resultGet) {
-              const primoLinks = resultGet.querySelectorAll('.primo-link');
+              const primoLinks = resultGet.querySelectorAll('.primo-link')
               // removing instead of hiding to avoid layout issues when selecting which link to highlight
-              primoLinks.forEach(link => link.remove());
+              primoLinks.forEach(link => link.remove())
             }
           }
         } else {
           // Remove result-get container (no fulfillment links)
-          parentElement.remove();
+          parentElement.remove()
         }
       })
   }

--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -7,28 +7,14 @@ export default class extends Controller {
     this.load()
   }
 
-  stripHtmlComments(input) {
-    let previous
-    let output = input
-
-    do {
-      previous = output
-      output = output.replace(/<!--[\s\S]*?-->/g, '')
-    } while (output !== previous)
-
-    return output
-  }
-
   load() {
     fetch(this.urlValue)
       .then(response => response.text())
       .then(html => {
         const parentElement = this.element.parentElement
-        // Strip HTML comments and trim whitespace
-        const cleanedHtml = this.stripHtmlComments(html).trim()
         // Replace the entire element with the fetched HTML, or remove if empty
-        if (cleanedHtml) {
-          this.element.outerHTML = cleanedHtml
+        if (html.trim()) {
+          this.element.outerHTML = html
           // Hide primo links if libkey link is present
           if (parentElement.querySelector('.libkey-link')) {
             const resultGet = parentElement.closest('.result-get')
@@ -39,11 +25,9 @@ export default class extends Controller {
             }
           }
         } else {
-          // Remove only this loader element
-          this.element.remove();
-          // Remove result-get container if it's now empty (no fulfillment links and no other content)
+          this.element.remove()
           if (!parentElement.textContent.trim()) {
-            parentElement.remove();
+            parentElement.remove()
           }
         }
       })

--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -7,13 +7,25 @@ export default class extends Controller {
     this.load()
   }
 
+  stripHtmlComments(input) {
+    let previous
+    let output = input
+
+    do {
+      previous = output
+      output = output.replace(/<!--[\s\S]*?-->/g, '')
+    } while (output !== previous)
+
+    return output
+  }
+
   load() {
     fetch(this.urlValue)
       .then(response => response.text())
       .then(html => {
         const parentElement = this.element.parentElement;
         // Strip HTML comments and trim whitespace
-        const cleanedHtml = html.replace(/<!--[\s\S]*?-->/g, '').trim();
+        const cleanedHtml = this.stripHtmlComments(html).trim();
         // Replace the entire element with the fetched HTML, or remove if empty
         if (cleanedHtml) {
           this.element.outerHTML = cleanedHtml;

--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -12,16 +12,23 @@ export default class extends Controller {
       .then(response => response.text())
       .then(html => {
         const parentElement = this.element.parentElement;
-        // Replace the entire element with the fetched HTML
-        this.element.outerHTML = html;
-        // Hide primo links if libkey link is present
-        if (parentElement.querySelector('.libkey-link')) {
-          const resultGet = parentElement.closest('.result-get');
-          if (resultGet) {
-            const primoLinks = resultGet.querySelectorAll('.primo-link');
-            // removing instead of hiding to avoid layout issues when selecting which link to highlight
-            primoLinks.forEach(link => link.remove());
+        // Strip HTML comments and trim whitespace
+        const cleanedHtml = html.replace(/<!--[\s\S]*?-->/g, '').trim();
+        // Replace the entire element with the fetched HTML, or remove if empty
+        if (cleanedHtml) {
+          this.element.outerHTML = cleanedHtml;
+          // Hide primo links if libkey link is present
+          if (parentElement.querySelector('.libkey-link')) {
+            const resultGet = parentElement.closest('.result-get');
+            if (resultGet) {
+              const primoLinks = resultGet.querySelectorAll('.primo-link');
+              // removing instead of hiding to avoid layout issues when selecting which link to highlight
+              primoLinks.forEach(link => link.remove());
+            }
           }
+        } else {
+          // Remove result-get container (no fulfillment links)
+          parentElement.remove();
         }
       })
   }

--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -39,8 +39,12 @@ export default class extends Controller {
             }
           }
         } else {
-          // Remove result-get container (no fulfillment links)
-          parentElement.remove()
+          // Remove only this loader element
+          this.element.remove();
+          // Remove result-get container if it's now empty (no fulfillment links and no other content)
+          if (!parentElement.textContent.trim()) {
+            parentElement.remove();
+          }
         }
       })
   }

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -75,6 +75,8 @@
         <% end %>
       </div>
 
+
+      <% if result_get?(result) %>
       <div class="result-get">
         <% if result[:links].present? %>
           <% result[:links].each do |link| %>
@@ -120,6 +122,7 @@
           <%= render(partial: 'trigger_browzine', locals: { issn: result[:issn] }) %>
         <% end %>
       </div>
+      <% end %>
     <% end %>
   </div>
 </li>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,8 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  config.action_view.annotate_rendered_view_with_filenames = true
+  # Disabled because annotation comments pollute dynamically-loaded HTML fragments (e.g. ThirdIron responses)
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -111,4 +111,84 @@ class ResultsHelperTest < ActionView::TestCase
     assert_not article?(nil)
     assert_not article?('')
   end
+
+  test 'result_get? returns true when result has links' do
+    assert result_get?({ links: [{ 'kind' => 'PDF', 'url' => 'https://example.com' }] })
+  end
+
+  test 'result_get? returns true when result has availability' do
+    assert result_get?({ availability: 'Available' })
+  end
+
+  test 'result_get? returns true when ThirdIron enabled and result has doi' do
+    ClimateControl.modify(THIRDIRON_ID: '123', THIRDIRON_KEY: 'abc') do
+      assert result_get?({ doi: '10.1234/test' })
+    end
+  end
+
+  test 'result_get? returns true when ThirdIron enabled and result has pmid' do
+    ClimateControl.modify(THIRDIRON_ID: '123', THIRDIRON_KEY: 'abc') do
+      assert result_get?({ pmid: '12345678' })
+    end
+  end
+
+  test 'result_get? returns true when ThirdIron enabled and result is a journal with issn' do
+    ClimateControl.modify(THIRDIRON_ID: '123', THIRDIRON_KEY: 'abc') do
+      assert result_get?({ format: 'Journal', issn: '1234-5678' })
+    end
+  end
+
+  test 'result_get? returns true when oa_always enabled and result is an article' do
+    ClimateControl.modify(FEATURE_OA_ALWAYS: 'true') do
+      assert result_get?({ format: 'Article' })
+    end
+  end
+
+  test 'result_get? returns false when result has no fulfillment content' do
+    ClimateControl.modify(THIRDIRON_ID: nil, THIRDIRON_KEY: nil, FEATURE_OA_ALWAYS: nil) do
+      assert_not result_get?({})
+      assert_not result_get?({ format: 'Book' })
+    end
+  end
+
+  test 'result_get? returns false when ThirdIron disabled even with doi' do
+    ClimateControl.modify(THIRDIRON_ID: nil, THIRDIRON_KEY: nil) do
+      assert_not result_get?({ doi: '10.1234/test' })
+    end
+  end
+
+  test 'result_get? returns false when oa_always disabled and result has no links' do
+    ClimateControl.modify(FEATURE_OA_ALWAYS: nil, THIRDIRON_ID: nil, THIRDIRON_KEY: nil) do
+      assert_not result_get?({ format: 'Article' })
+    end
+  end
+
+  test 'result_get? returns false when result has only full record link and feature is disabled' do
+    ClimateControl.modify(FEATURE_RECORD_LINK: nil, THIRDIRON_ID: nil, THIRDIRON_KEY: nil, FEATURE_OA_ALWAYS: nil) do
+      assert_not result_get?({ links: [{ 'kind' => 'Full Record', 'url' => 'https://example.com' }] })
+    end
+  end
+
+  test 'result_get? returns true when result has only full record link and feature is enabled' do
+    ClimateControl.modify(FEATURE_RECORD_LINK: 'true', THIRDIRON_ID: nil, THIRDIRON_KEY: nil, FEATURE_OA_ALWAYS: nil) do
+      assert result_get?({ links: [{ 'kind' => 'Full Record', 'url' => 'https://example.com' }] })
+    end
+  end
+
+  test 'result_get? returns true when result has PDF link even if record_link feature is disabled' do
+    ClimateControl.modify(FEATURE_RECORD_LINK: nil, THIRDIRON_ID: nil, THIRDIRON_KEY: nil, FEATURE_OA_ALWAYS: nil) do
+      assert result_get?({ links: [{ 'kind' => 'PDF', 'url' => 'https://example.com' }] })
+    end
+  end
+
+  test 'result_get? returns true when result has both full record and PDF links even if record_link feature is disabled' do
+    ClimateControl.modify(FEATURE_RECORD_LINK: nil, THIRDIRON_ID: nil, THIRDIRON_KEY: nil, FEATURE_OA_ALWAYS: nil) do
+      assert result_get?({
+        links: [
+          { 'kind' => 'Full Record', 'url' => 'https://example.com' },
+          { 'kind' => 'PDF', 'url' => 'https://pdf.example.com' }
+        ]
+      })
+    end
+  end
 end

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -184,11 +184,11 @@ class ResultsHelperTest < ActionView::TestCase
   test 'result_get? returns true when result has both full record and PDF links even if record_link feature is disabled' do
     ClimateControl.modify(FEATURE_RECORD_LINK: nil, THIRDIRON_ID: nil, THIRDIRON_KEY: nil, FEATURE_OA_ALWAYS: nil) do
       assert result_get?({
-        links: [
-          { 'kind' => 'Full Record', 'url' => 'https://example.com' },
-          { 'kind' => 'PDF', 'url' => 'https://pdf.example.com' }
-        ]
-      })
+                           links: [
+                             { 'kind' => 'Full Record', 'url' => 'https://example.com' },
+                             { 'kind' => 'PDF', 'url' => 'https://pdf.example.com' }
+                           ]
+                         })
     end
   end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

The fulfillment link container currently renders
as an empty div when no links are available. This
pollutes the DOM and affects spacing.

#### Relevant ticket(s):

- [USE-611](https://mitlibraries.atlassian.net/browse/USE-611)

#### How this addresses that need:

Primo link removal moves further up in the control
flow, because that check is not applicable if the
parent element is gone.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-611]: https://mitlibraries.atlassian.net/browse/USE-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ