### PR TITLE
USE-471: Adding About to USE navigation

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -92,11 +92,7 @@
             font-size: 1.8rem;
             font-weight: $fw-medium;
             @include text-decoration-animation;
-
-            &:hover {
-                text-decoration: underline;
-                color: $color-white;
-            }            
+            @include headerUnderlinedLinks;       
         }
     }
 }

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -2,19 +2,6 @@
 // #SEARCH BITS
 // ------------------------
 
-/* Shared link styling */
-@mixin searchUnderlinedLinks {
-  color: $color-text-oncolor;
-  font-weight: $fw-medium;
-  text-decoration: underline;
-  text-decoration-color: $color-red-500;
-  text-underline-offset: 0.5rem;  
-
-  &:hover {
-    color: $color-red-400;
-  }
-}
-
 /* New USE UI search styles */
 #search-form {
   margin: 0;
@@ -299,7 +286,7 @@
   gap: 24px;
 
   a {
-    @include searchUnderlinedLinks();
+    @include headerUnderlinedLinks();
   }
 
   .semantic-search-toggle {
@@ -310,7 +297,7 @@
       background-color: transparent;
       border: none;
       cursor: pointer;
-      @include searchUnderlinedLinks();
+      @include headerUnderlinedLinks();
 
       &::before {
         background-color: $color-gray-800;

--- a/app/assets/stylesheets/partials/_source_tabs.scss
+++ b/app/assets/stylesheets/partials/_source_tabs.scss
@@ -37,7 +37,7 @@
     border-bottom: 0;  
     white-space: nowrap;
 
-    @include searchUnderlinedLinks;
+    @include headerUnderlinedLinks;
 
     &:hover {
       border-color: $color-gray-700;
@@ -87,7 +87,7 @@
         width: 100%;
 
         &.active {
-          @include searchUnderlinedLinks;
+          @include headerUnderlinedLinks;
         }
 
         &:hover {

--- a/app/assets/stylesheets/partials/_typography.scss
+++ b/app/assets/stylesheets/partials/_typography.scss
@@ -22,6 +22,19 @@
   }
 }
 
+/* Shared link styling */
+@mixin headerUnderlinedLinks {
+  color: $color-text-oncolor;
+  font-weight: $fw-medium;
+  text-decoration: underline;
+  text-decoration-color: $color-red-500;
+  text-underline-offset: 0.5rem;  
+
+  &:hover {
+    color: $color-red-400;
+  }
+}
+
 // Override fonts from the theme gem, done temporarily for USE UI
 body {
   font-family: $base-font;

--- a/app/views/layouts/_site_header.html.erb
+++ b/app/views/layouts/_site_header.html.erb
@@ -18,12 +18,14 @@
           <a href="/" class="platform-name"><%= ENV.fetch('PLATFORM_NAME') %></a>
         <% end %>
       </h1>
-      <% if Feature.enabled?(:geodata) %>
-        <nav class="main-navigation" aria-label="Main navigation">
-          <%= nav_link_to("GIS at MIT", "https://libraries.mit.edu/gis") %>
-          <%= nav_link_to("Ask GIS", "https://libraries.mit.edu/ask-gis") %>
-        </nav>
-      <% end %>
+      <nav class="main-navigation" aria-label="Main navigation">
+        <% if Feature.enabled?(:geodata) %>
+            <%= nav_link_to("GIS at MIT", "https://libraries.mit.edu/gis") %>
+            <%= nav_link_to("Ask GIS", "https://libraries.mit.edu/ask-gis") %>
+        <% else %>
+            <%= nav_link_to("About", "https://libraries.mit.edu/new-search/") %>
+        <% end %>
+      </nav>
     </header>
     <%= render partial: 'search/form' unless Feature.enabled?(:geodata) %>
   </div>


### PR DESCRIPTION
#### Developer
As we approach the launch of USE, we wanted to include an about item in the navigation. This work adds that item and uses the existing responsive behavior.

This PR also centralizes the red underlined link styling into a shared mixin and applies it to the navigation items.

Turning this into a hamburger menu on smaller screens will come in a future ticket.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
