### PR TITLE
WIP towards Alma SRU model

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,9 +1,11 @@
 ALMA_OPENURL=https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?
+EXL_INST_ID=01MIT_INST
 TURNSTILE_SITEKEY=test-sitekey
 TURNSTILE_SECRET=test-secret
 FEATURE_TIMDEX_FULLTEXT=true
 FEATURE_GEODATA=false
 FEATURE_PRIMO_NDE_LINKS=false
+MIT_ALMA_URL=https://mit.alma.exlibrisgroup.com
 MIT_PRIMO_URL=https://mit.primo.exlibrisgroup.com
 OPENALEX_EMAIL=FAKE_OPENALEX_EMAIL
 PRIMO_API_KEY=FAKE_PRIMO_API_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 .env
 .env.development
 
+# qlty
+.qlty
+
 ## Environment normalization:
 /.bundle
 /vendor/bundle

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ See `Optional Environment Variables` for more information.
 ### Required Environment Variables
 
 - `ALMA_OPENURL`: The base URL for Alma openurls found in CDI records.
+- `EXL_INST_ID`: The Ex Libris Institution ID. Used for constructing URLs.
+- `MIT_ALMA_URL`: The base URL for MIT Libraries' Alma instance (used to generate SRU API lookups).
 - `MIT_PRIMO_URL`: The base URL for MIT Libraries' Primo instance (used to generate record links).
 - `PRIMO_API_KEY`: The Primo Search API key.
 - `PRIMO_API_URL`: The Primo Search API base URL.

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -77,14 +77,13 @@ class AlmaSru
   # 1. Remove the "alma" prefix if one is present. Otherwise, no manipulation of the submitted value should occur.
   # 2. Enforce the formatting requirements for a valid alma identifier (start with "99", and end with "6761").
   def self.validate_alma_id(raw)
-    parsed = if raw.start_with?('alma')
+    parsed = if raw.to_s.start_with?('alma')
                raw.delete_prefix('alma')
              else
                raw
              end
 
-    raise InvalidAlmaId unless parsed.to_s.start_with?('99')
-    raise InvalidAlmaId unless parsed.to_s.end_with?('6761')
+    raise InvalidAlmaId unless parsed.present? && parsed.match?(/\A99\d+6761\z/)
 
     parsed
   end
@@ -115,14 +114,28 @@ class AlmaSru
 
   # fetch_controlfield receives a parsed XML document (Nokogiri::XML::Document)
   # and returns the controlfield with an 001 tag, if one exists.
+  #
+  # This allows us to confirm that we've received the expected record back from
+  # the API, and not either a blank response or some other unexpected document.
   def self.fetch_controlfield(parsed_xml)
     parsed_xml.xpath("//holding:controlfield[@tag='001']", NAMESPACE)&.text
   end
 
   # format_availability receives a hash representing a single availability
-  # statement, and formats it for human readability.
+  # statement, and formats it for human readability. Values for "e" and "q" are
+  # required, while "c" and "d" are optional.
+  #
+  # A Sentry exception is captured if those required parameters are missing.
   def self.format_availability(availability)
-    "#{availability['e']&.humanize} at #{availability['q']} #{availability['c']} (#{availability['d']})"
+    if availability['e'].blank? || availability['q'].blank?
+      Sentry.capture_message('Missing required availability data')
+      return ''
+    end
+
+    phrase = "#{availability['e']&.humanize} at #{availability['q']} #{availability['c']}".squish
+    phrase += " (#{availability['d']})" if availability['d'].present?
+
+    phrase
   end
 
   def self.alma_base_url
@@ -130,7 +143,10 @@ class AlmaSru
   end
 
   def self.alma_sru_enabled?
-    return false if alma_base_url.to_s.empty? || exl_inst_id.to_s.empty?
+    if alma_base_url.to_s.empty? || exl_inst_id.to_s.empty?
+      Sentry.capture_message('Alma SRU not enabled')
+      return false
+    end
 
     true
   end

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Queries the Alma SRU endpoint for holdings data
+#
+# @reference https://developers.exlibrisgroup.com/alma/integrations/SRU/
+class AlmaSru
+  class LookupFailure < StandardError; end
+
+  class InvalidAlmaId < StandardError; end
+
+  NAMESPACE = { 'holding' => 'http://www.loc.gov/MARC21/slim' }.freeze
+
+  LOCATION_ORDER = {
+    'Hayden Library' => 0,
+    'Lewis Music Library' => 1,
+    'Rotch Library' => 2,
+    'Barker Library' => 3,
+    'Dewey Library' => 4
+  }.freeze
+
+  # lookup is the primary method of interacting with this model.
+  #
+  # It will receive an Alma ID, validate it, look it up in the Alma SRU, and return a formatted result.
+  #
+  # It accepts an "alma_client" argument for use when testing, but this is not used in normal operations.
+  def self.lookup(raw_identifier, alma_client: nil)
+    return [] unless alma_base_url
+
+    # Validate the raw identifier received. This will raise an InvalidAlmaId if validation fails.
+    identifier = validate_alma_id(raw_identifier)
+
+    # Build URL
+    url = alma_sru_url(identifier)
+
+    # Retrieve that URL
+    alma_http = setup(url, alma_client)
+
+    parse_response(alma_http.timeout(6).get(url), identifier)
+  rescue InvalidAlmaId
+    Rails.logger.debug("Invalid Alma ID: #{raw_identifier}")
+
+    []
+  rescue LookupFailure => e
+    Rails.logger.debug("Alma lookup failure: #{e}")
+
+    []
+  rescue HTTP::Error
+    Sentry.capture_message('Alma SRU connection failure')
+    Rails.logger.error('Alma SRU connection error')
+
+    []
+  end
+
+  # parse_response receives the raw response from the Alma SRU endpoint.
+  #
+  # For any non-200 response, it raises a LookupFailure.
+  #
+  # Other responses (in XML format) are parsed by Nokogiri, and we pluck content with an `AVA` tag.
+  def self.parse_response(raw_response, reference_identifier)
+    raise LookupFailure, raw_response.status unless raw_response.status == 200
+
+    parsed = Nokogiri::XML(raw_response.body.to_s)
+
+    # Confirm that control field 001 matches the identifier we received.
+    parsed_controlfield = fetch_controlfield(parsed)
+    raise LookupFailure, 'Control field mismatch' unless parsed_controlfield == reference_identifier
+
+    # Look up all AVA tags
+    parsed_availabilities = fetch_availabilities(parsed)
+
+    parsed_availabilities.map(&method(:format_availability))
+  end
+
+  # validate_alma_id ensures we are only submitting valid Alma IDs to the SRU endpoint.
+  #
+  # It needs to do two thigns:
+  # 1. Remove the "alma" prefix if one is present. Otherwise, no manipulation of the submitted value should occur.
+  # 2. Enforce the formatting requirements for a valid alma identifier (start with "99", and end with "6761").
+  def self.validate_alma_id(raw)
+    parsed = if raw.start_with?('alma')
+               raw.delete_prefix('alma')
+             else
+               raw
+             end
+
+    raise InvalidAlmaId unless parsed.to_s.start_with?('99')
+    raise InvalidAlmaId unless parsed.to_s.end_with?('6761')
+
+    parsed
+  end
+
+  # ava_to_hash takes an XML element that represents a single availability record
+  # and converts it to a hash. Each code is a key, while its text is the value.
+  def self.ava_to_hash(node)
+    rebuilt = {}
+
+    node.children.each do |child|
+      rebuilt[child.attribute_nodes[0].value] = child.text if child.instance_of?(Nokogiri::XML::Element)
+    end
+
+    rebuilt
+  end
+
+  # fetch_availabilities receives a parsed XML document (Nokogiri::XML::Document)
+  #
+  # This document is parsed using xpath to select on the nodes with an tag of AVA,
+  # and these are then sorted based on a preferred library order.
+  def self.fetch_availabilities(parsed_xml)
+    ava_list = parsed_xml.xpath("//holding:datafield[@tag='AVA']", NAMESPACE)
+
+    ava_list
+      .map { |el| ava_to_hash(el) }
+      .sort_by { |el| [LOCATION_ORDER.fetch(el['q'], 999), el['q'].to_s] }
+  end
+
+  # fetch_controlfield receives a parsed XML document (Nokogiri::XML::Document)
+  # and returns the controlfield with an 001 tag, if one exists.
+  def self.fetch_controlfield(parsed_xml)
+    parsed_xml.xpath("//holding:controlfield[@tag='001']", NAMESPACE)&.text
+  end
+
+  # format_availability receives a hash representing a single availability
+  # statement, and formats it for human readability.
+  def self.format_availability(availability)
+    "#{availability['e']&.humanize} at #{availability['q']} #{availability['c']} (#{availability['d']})"
+  end
+
+  def self.alma_base_url
+    ENV.fetch('MIT_ALMA_URL', nil)
+  end
+
+  def self.alma_sru_url(identifier)
+    # example identifier: 990000959610106761
+    "#{alma_base_url}/view/sru/#{ENV.fetch('EXL_INST_ID')}?version=1.2&operation=searchRetrieve&recordSchema=marcxml" \
+      "&query=alma.all_for_ui=#{identifier}"
+  end
+
+  def self.setup(url, alma_client)
+    alma_client || HTTP.persistent(url)
+  end
+end

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -24,7 +24,7 @@ class AlmaSru
   #
   # It accepts an "alma_client" argument for use when testing, but this is not used in normal operations.
   def self.lookup(raw_identifier, alma_client: nil)
-    return [] unless alma_base_url
+    return [] unless alma_sru_enabled?
 
     # Validate the raw identifier received. This will raise an InvalidAlmaId if validation fails.
     identifier = validate_alma_id(raw_identifier)
@@ -73,7 +73,7 @@ class AlmaSru
 
   # validate_alma_id ensures we are only submitting valid Alma IDs to the SRU endpoint.
   #
-  # It needs to do two thigns:
+  # It needs to do two things:
   # 1. Remove the "alma" prefix if one is present. Otherwise, no manipulation of the submitted value should occur.
   # 2. Enforce the formatting requirements for a valid alma identifier (start with "99", and end with "6761").
   def self.validate_alma_id(raw)
@@ -129,10 +129,20 @@ class AlmaSru
     ENV.fetch('MIT_ALMA_URL', nil)
   end
 
+  def self.alma_sru_enabled?
+    return false if alma_base_url.to_s.empty? || exl_inst_id.to_s.empty?
+
+    true
+  end
+
   def self.alma_sru_url(identifier)
-    # example identifier: 990000959610106761
-    "#{alma_base_url}/view/sru/#{ENV.fetch('EXL_INST_ID')}?version=1.2&operation=searchRetrieve&recordSchema=marcxml" \
+    # example identifier: 9935177389906761
+    "#{alma_base_url}/view/sru/#{exl_inst_id}?version=1.2&operation=searchRetrieve&recordSchema=marcxml" \
       "&query=alma.all_for_ui=#{identifier}"
+  end
+
+  def self.exl_inst_id
+    ENV.fetch('EXL_INST_ID', nil)
   end
 
   def self.setup(url, alma_client)

--- a/test/fixtures/alma/sru_nocontrol.xml
+++ b/test/fixtures/alma/sru_nocontrol.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <version>1.2</version>
+  <numberOfRecords>1</numberOfRecords>
+  <records>
+    <record>
+      <recordSchema>marcxml</recordSchema>
+      <recordPacking>xml</recordPacking>
+      <recordData>
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>03917cas  2200889 a 4500</leader>
+          <controlfield tag="005">20241127113448.0</controlfield>
+          <controlfield tag="008">741224c19599999nyuqr1p       0   a0eng^^</controlfield>
+          <datafield ind1=" " ind2=" " tag="010">
+            <subfield code="a">61019573 //r892</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="022">
+            <subfield code="a">0022-1481</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="030">
+            <subfield code="a">JHTRAO</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="032">
+            <subfield code="a">280380</subfield>
+            <subfield code="b">USPS</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(MCM)000293592</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(MCM)000293592MIT01</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)01782922</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)01713702</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)09764105</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(VERA)3557</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="037">
+            <subfield code="b">ASME, United Engineering Center, 345 E. 47th St., New York, NY 10017</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="040">
+            <subfield code="a">DLC</subfield>
+            <subfield code="c">DLC</subfield>
+            <subfield code="d">NSD</subfield>
+            <subfield code="d">DLC</subfield>
+            <subfield code="d">NSD</subfield>
+            <subfield code="d">SER</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">AIP</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">NSD</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">NST</subfield>
+            <subfield code="d">DLC</subfield>
+            <subfield code="d">MYG</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="042">
+            <subfield code="a">lc</subfield>
+            <subfield code="a">nsdp</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="049">
+            <subfield code="a">MYGG</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="0" tag="050">
+            <subfield code="a">TA1</subfield>
+            <subfield code="b">.J64</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="210">
+            <subfield code="a">J. heat transfer</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="222">
+            <subfield code="a">Journal of heat transfer</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="0" tag="245">
+            <subfield code="a">Journal of heat transfer.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="260">
+            <subfield code="a">New York, N.Y. :</subfield>
+            <subfield code="b">American Society of Mechanical Engineers,</subfield>
+            <subfield code="c">c1959-</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="300">
+            <subfield code="a">v. :</subfield>
+            <subfield code="b">ill. ;</subfield>
+            <subfield code="c">29 cm.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="310">
+            <subfield code="a">Quarterly</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="336">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="337">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="338">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="362">
+            <subfield code="a">Vol. 81, no. 1 (Feb. 1959)-</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="490">
+            <subfield code="a">Transactions of the ASME ;</subfield>
+            <subfield code="v">ser. C</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="500">
+            <subfield code="a">Title from cover.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="510">
+            <subfield code="a">Applied science &amp; technology index</subfield>
+            <subfield code="x">0003-6986</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Engineering index monthly (1984)</subfield>
+            <subfield code="x">0742-1974</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Engineering index bioengineering abstracts</subfield>
+            <subfield code="x">0736-6213</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Engineering index energy abstracts</subfield>
+            <subfield code="x">0093-8408</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Energy information abstracts</subfield>
+            <subfield code="x">0147-6521</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Environment abstracts</subfield>
+            <subfield code="x">0093-3287</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">FLUIDEX</subfield>
+            <subfield code="b">1978-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Abstract bulletin of the Institute of Paper Chemistry</subfield>
+            <subfield code="x">0020-3033</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Computer &amp; control abstracts</subfield>
+            <subfield code="x">0036-8113</subfield>
+            <subfield code="b">1968-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Electrical &amp; electronics abstracts</subfield>
+            <subfield code="x">0036-8105</subfield>
+            <subfield code="b">1968-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Physics abstracts. Science abstracts. Series A</subfield>
+            <subfield code="x">0036-8091</subfield>
+            <subfield code="b">1968-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Chemical abstracts</subfield>
+            <subfield code="x">0009-2258</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">SPIN</subfield>
+            <subfield code="b">1977-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Coal abstracts</subfield>
+            <subfield code="x">0309-4979</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Energy research abstracts</subfield>
+            <subfield code="x">0160-3604</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="510">
+            <subfield code="a">International aerospace abstracts</subfield>
+            <subfield code="x">0020-5842</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="510">
+            <subfield code="a">Nuclear science abstracts</subfield>
+            <subfield code="x">0029-5612</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="510">
+            <subfield code="a">Indexes to publications - American Society of Mechanical Engineers</subfield>
+            <subfield code="x">0569-8227</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="515">
+            <subfield code="a">Vols. for 1978-   lack series numeration.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="530">
+            <subfield code="a">Beginning 2000, full-text articles also available via the World Wide Web by subscription, in HTML, PDF, and PostScript formats. Tables of contents for 1996-1999 also available in HTML.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="580">
+            <subfield code="a">Also included in: American Society of Mechanical Engineers. Transactions of the American Society of Mechanical Engineers, 1959-&lt;1967&gt;</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Heat</subfield>
+            <subfield code="x">Transmission</subfield>
+            <subfield code="v">Periodicals.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="650">
+            <subfield code="a">Heat</subfield>
+            <subfield code="x">Transmission.</subfield>
+            <subfield code="2">fast</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Periodicals.</subfield>
+            <subfield code="2">lcgft</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Periodicals.</subfield>
+            <subfield code="2">fast</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="1" tag="780">
+            <subfield code="t">Transactions of the ASME</subfield>
+            <subfield code="w">(OCoLC)19731523</subfield>
+            <subfield code="w">(DLC)sc 89034060</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="787">
+            <subfield code="a">American Society of Mechanical Engineers.</subfield>
+            <subfield code="t">Transactions of the American Society of Mechanical Engineers</subfield>
+            <subfield code="w">(DLC) 02002053</subfield>
+            <subfield code="w">(OCoLC)1480830</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="793">
+            <subfield code="a">Journal of heat transfer [fiche]</subfield>
+            <subfield code="g">E36211 960018634</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="710">
+            <subfield code="a">American Society of Mechanical Engineers.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="830">
+            <subfield code="a">Transactions of the ASME (1959) ;</subfield>
+            <subfield code="v">ser. C.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">jle001205/1</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">depgy-nooclc210609</subfield>
+            <subfield code="d">210609</subfield>
+            <subfield code="i">depgy-nooclc</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT231208</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT241112</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="936">
+            <subfield code="a">Vol. 102, no. 4 (Nov. 1980) LIC</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="946">
+            <subfield code="m">unpiggy-tang</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="959">
+            <subfield code="b">LSA</subfield>
+            <subfield code="c">JRNAL</subfield>
+            <subfield code="h">No Call #</subfield>
+            <subfield code="o">8</subfield>
+            <subfield code="x">57</subfield>
+            <subfield code="v">All other volumes - use buttons to right</subfield>
+            <subfield code="z">Please check availability at top of page to verify the Annex owns the volume/year you want.</subfield>
+            <subfield code="f">ISSUE</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="961">
+            <subfield code="a">New York, N.Y. : American Society of Mechanical Engineers,</subfield>
+            <subfield code="a">1959</subfield>
+            <subfield code="a">nyu</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="969">
+            <subfield code="a">TA1</subfield>
+            <subfield code="a">JHTRAO</subfield>
+            <subfield code="a">01782922</subfield>
+            <subfield code="a">01713702</subfield>
+            <subfield code="a">09764105</subfield>
+            <subfield code="a">61019573 //r892</subfield>
+            <subfield code="a">0022-1481</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="994">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">990002935920106761</subfield>
+            <subfield code="8">22477267920006761</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="b">LSA</subfield>
+            <subfield code="c">Journal Collection (LSA4)</subfield>
+            <subfield code="d">TA.J86.H437</subfield>
+            <subfield code="e">available</subfield>
+            <subfield code="f">63</subfield>
+            <subfield code="g">0</subfield>
+            <subfield code="j">LSA4</subfield>
+            <subfield code="k">Hfcl</subfield>
+            <subfield code="p">1</subfield>
+            <subfield code="q">Library Storage Annex</subfield>
+            <subfield code="t">v.81 (1959)-v.131:no.1-6 (2009)</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">990002935920106761</subfield>
+            <subfield code="8">22477267070006761</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="b">ENG</subfield>
+            <subfield code="c">Staff Retrieval - request required</subfield>
+            <subfield code="d">FICHE No Call #</subfield>
+            <subfield code="e">check_holdings</subfield>
+            <subfield code="j">MFORM</subfield>
+            <subfield code="k">8</subfield>
+            <subfield code="p">2</subfield>
+            <subfield code="q">Barker Library</subfield>
+            <subfield code="t">v.92 (1970)-v.95 (1973),v.97 (1975)-v.119 (1997)</subfield>
+          </datafield>
+        </record>
+      </recordData>
+      <recordIdentifier>990002935920106761</recordIdentifier>
+      <recordPosition>1</recordPosition>
+    </record>
+  </records>
+  <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+    <xb:exact>true</xb:exact>
+    <xb:responseDate>2026-06-05T14:51:17-0400</xb:responseDate>
+  </extraResponseData>
+</searchRetrieveResponse>

--- a/test/fixtures/alma/sru_success.xml
+++ b/test/fixtures/alma/sru_success.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <version>1.2</version>
+  <numberOfRecords>1</numberOfRecords>
+  <records>
+    <record>
+      <recordSchema>marcxml</recordSchema>
+      <recordPacking>xml</recordPacking>
+      <recordData>
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>03917cas  2200889 a 4500</leader>
+          <controlfield tag="001">990002935920106761</controlfield>
+          <controlfield tag="005">20241127113448.0</controlfield>
+          <controlfield tag="008">741224c19599999nyuqr1p       0   a0eng^^</controlfield>
+          <datafield ind1=" " ind2=" " tag="010">
+            <subfield code="a">61019573 //r892</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="022">
+            <subfield code="a">0022-1481</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="030">
+            <subfield code="a">JHTRAO</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="032">
+            <subfield code="a">280380</subfield>
+            <subfield code="b">USPS</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(MCM)000293592</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(MCM)000293592MIT01</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)01782922</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)01713702</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)09764105</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(VERA)3557</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="037">
+            <subfield code="b">ASME, United Engineering Center, 345 E. 47th St., New York, NY 10017</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="040">
+            <subfield code="a">DLC</subfield>
+            <subfield code="c">DLC</subfield>
+            <subfield code="d">NSD</subfield>
+            <subfield code="d">DLC</subfield>
+            <subfield code="d">NSD</subfield>
+            <subfield code="d">SER</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">AIP</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">NSD</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">NST</subfield>
+            <subfield code="d">DLC</subfield>
+            <subfield code="d">MYG</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="042">
+            <subfield code="a">lc</subfield>
+            <subfield code="a">nsdp</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="049">
+            <subfield code="a">MYGG</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="0" tag="050">
+            <subfield code="a">TA1</subfield>
+            <subfield code="b">.J64</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="210">
+            <subfield code="a">J. heat transfer</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="222">
+            <subfield code="a">Journal of heat transfer</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="0" tag="245">
+            <subfield code="a">Journal of heat transfer.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="260">
+            <subfield code="a">New York, N.Y. :</subfield>
+            <subfield code="b">American Society of Mechanical Engineers,</subfield>
+            <subfield code="c">c1959-</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="300">
+            <subfield code="a">v. :</subfield>
+            <subfield code="b">ill. ;</subfield>
+            <subfield code="c">29 cm.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="310">
+            <subfield code="a">Quarterly</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="336">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="337">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="338">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="362">
+            <subfield code="a">Vol. 81, no. 1 (Feb. 1959)-</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="490">
+            <subfield code="a">Transactions of the ASME ;</subfield>
+            <subfield code="v">ser. C</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="500">
+            <subfield code="a">Title from cover.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="510">
+            <subfield code="a">Applied science &amp; technology index</subfield>
+            <subfield code="x">0003-6986</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Engineering index monthly (1984)</subfield>
+            <subfield code="x">0742-1974</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Engineering index bioengineering abstracts</subfield>
+            <subfield code="x">0736-6213</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Engineering index energy abstracts</subfield>
+            <subfield code="x">0093-8408</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Energy information abstracts</subfield>
+            <subfield code="x">0147-6521</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Environment abstracts</subfield>
+            <subfield code="x">0093-3287</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">FLUIDEX</subfield>
+            <subfield code="b">1978-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Abstract bulletin of the Institute of Paper Chemistry</subfield>
+            <subfield code="x">0020-3033</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Computer &amp; control abstracts</subfield>
+            <subfield code="x">0036-8113</subfield>
+            <subfield code="b">1968-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Electrical &amp; electronics abstracts</subfield>
+            <subfield code="x">0036-8105</subfield>
+            <subfield code="b">1968-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Physics abstracts. Science abstracts. Series A</subfield>
+            <subfield code="x">0036-8091</subfield>
+            <subfield code="b">1968-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Chemical abstracts</subfield>
+            <subfield code="x">0009-2258</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">SPIN</subfield>
+            <subfield code="b">1977-</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Coal abstracts</subfield>
+            <subfield code="x">0309-4979</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="510">
+            <subfield code="a">Energy research abstracts</subfield>
+            <subfield code="x">0160-3604</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="510">
+            <subfield code="a">International aerospace abstracts</subfield>
+            <subfield code="x">0020-5842</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="510">
+            <subfield code="a">Nuclear science abstracts</subfield>
+            <subfield code="x">0029-5612</subfield>
+          </datafield>
+          <datafield ind1="0" ind2=" " tag="510">
+            <subfield code="a">Indexes to publications - American Society of Mechanical Engineers</subfield>
+            <subfield code="x">0569-8227</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="515">
+            <subfield code="a">Vols. for 1978-   lack series numeration.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="530">
+            <subfield code="a">Beginning 2000, full-text articles also available via the World Wide Web by subscription, in HTML, PDF, and PostScript formats. Tables of contents for 1996-1999 also available in HTML.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="580">
+            <subfield code="a">Also included in: American Society of Mechanical Engineers. Transactions of the American Society of Mechanical Engineers, 1959-&lt;1967&gt;</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Heat</subfield>
+            <subfield code="x">Transmission</subfield>
+            <subfield code="v">Periodicals.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="650">
+            <subfield code="a">Heat</subfield>
+            <subfield code="x">Transmission.</subfield>
+            <subfield code="2">fast</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Periodicals.</subfield>
+            <subfield code="2">lcgft</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Periodicals.</subfield>
+            <subfield code="2">fast</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="1" tag="780">
+            <subfield code="t">Transactions of the ASME</subfield>
+            <subfield code="w">(OCoLC)19731523</subfield>
+            <subfield code="w">(DLC)sc 89034060</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="787">
+            <subfield code="a">American Society of Mechanical Engineers.</subfield>
+            <subfield code="t">Transactions of the American Society of Mechanical Engineers</subfield>
+            <subfield code="w">(DLC) 02002053</subfield>
+            <subfield code="w">(OCoLC)1480830</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="793">
+            <subfield code="a">Journal of heat transfer [fiche]</subfield>
+            <subfield code="g">E36211 960018634</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="710">
+            <subfield code="a">American Society of Mechanical Engineers.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="830">
+            <subfield code="a">Transactions of the ASME (1959) ;</subfield>
+            <subfield code="v">ser. C.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">jle001205/1</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">depgy-nooclc210609</subfield>
+            <subfield code="d">210609</subfield>
+            <subfield code="i">depgy-nooclc</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT221103</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT231208</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="910">
+            <subfield code="a">MARCIVEAUT241112</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="936">
+            <subfield code="a">Vol. 102, no. 4 (Nov. 1980) LIC</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="946">
+            <subfield code="m">unpiggy-tang</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="959">
+            <subfield code="b">LSA</subfield>
+            <subfield code="c">JRNAL</subfield>
+            <subfield code="h">No Call #</subfield>
+            <subfield code="o">8</subfield>
+            <subfield code="x">57</subfield>
+            <subfield code="v">All other volumes - use buttons to right</subfield>
+            <subfield code="z">Please check availability at top of page to verify the Annex owns the volume/year you want.</subfield>
+            <subfield code="f">ISSUE</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="961">
+            <subfield code="a">New York, N.Y. : American Society of Mechanical Engineers,</subfield>
+            <subfield code="a">1959</subfield>
+            <subfield code="a">nyu</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="969">
+            <subfield code="a">TA1</subfield>
+            <subfield code="a">JHTRAO</subfield>
+            <subfield code="a">01782922</subfield>
+            <subfield code="a">01713702</subfield>
+            <subfield code="a">09764105</subfield>
+            <subfield code="a">61019573 //r892</subfield>
+            <subfield code="a">0022-1481</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="994">
+            <subfield code="a">02</subfield>
+            <subfield code="b">MYG</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">990002935920106761</subfield>
+            <subfield code="8">22477267920006761</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="b">LSA</subfield>
+            <subfield code="c">Journal Collection (LSA4)</subfield>
+            <subfield code="d">TA.J86.H437</subfield>
+            <subfield code="e">available</subfield>
+            <subfield code="f">63</subfield>
+            <subfield code="g">0</subfield>
+            <subfield code="j">LSA4</subfield>
+            <subfield code="k">Hfcl</subfield>
+            <subfield code="p">1</subfield>
+            <subfield code="q">Library Storage Annex</subfield>
+            <subfield code="t">v.81 (1959)-v.131:no.1-6 (2009)</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">990002935920106761</subfield>
+            <subfield code="8">22477267070006761</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="b">ENG</subfield>
+            <subfield code="c">Staff Retrieval - request required</subfield>
+            <subfield code="d">FICHE No Call #</subfield>
+            <subfield code="e">check_holdings</subfield>
+            <subfield code="j">MFORM</subfield>
+            <subfield code="k">8</subfield>
+            <subfield code="p">2</subfield>
+            <subfield code="q">Barker Library</subfield>
+            <subfield code="t">v.92 (1970)-v.95 (1973),v.97 (1975)-v.119 (1997)</subfield>
+          </datafield>
+        </record>
+      </recordData>
+      <recordIdentifier>990002935920106761</recordIdentifier>
+      <recordPosition>1</recordPosition>
+    </record>
+  </records>
+  <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+    <xb:exact>true</xb:exact>
+    <xb:responseDate>2026-06-05T14:51:17-0400</xb:responseDate>
+  </extraResponseData>
+</searchRetrieveResponse>

--- a/test/fixtures/alma/sru_wrong_order.xml
+++ b/test/fixtures/alma/sru_wrong_order.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <version>1.2</version>
+  <numberOfRecords>1</numberOfRecords>
+  <records>
+    <record>
+      <recordSchema>marcxml</recordSchema>
+      <recordPacking>xml</recordPacking>
+      <recordData>
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>03917cas  2200889 a 4500</leader>
+          <controlfield tag="001">990002935920106761</controlfield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">990002935920106761</subfield>
+            <subfield code="8">22477267920006761</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="b">LSA</subfield>
+            <subfield code="c">Journal Collection (LSA4)</subfield>
+            <subfield code="d">TA.J86.H437</subfield>
+            <subfield code="e">available</subfield>
+            <subfield code="f">63</subfield>
+            <subfield code="g">0</subfield>
+            <subfield code="j">LSA4</subfield>
+            <subfield code="k">Hfcl</subfield>
+            <subfield code="p">1</subfield>
+            <subfield code="q">Library Storage Annex</subfield>
+            <subfield code="t">v.81 (1959)-v.131:no.1-6 (2009)</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">990002935920106761</subfield>
+            <subfield code="8">22477267070006761</subfield>
+            <subfield code="a">01MIT_INST</subfield>
+            <subfield code="b">ENG</subfield>
+            <subfield code="c">Staff Retrieval - request required</subfield>
+            <subfield code="d">FICHE No Call #</subfield>
+            <subfield code="e">check_holdings</subfield>
+            <subfield code="j">MFORM</subfield>
+            <subfield code="k">8</subfield>
+            <subfield code="p">2</subfield>
+            <subfield code="q">Barker Library</subfield>
+            <subfield code="t">v.92 (1970)-v.95 (1973),v.97 (1975)-v.119 (1997)</subfield>
+          </datafield>
+        </record>
+      </recordData>
+      <recordIdentifier>990002935920106761</recordIdentifier>
+      <recordPosition>1</recordPosition>
+    </record>
+  </records>
+  <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+    <xb:exact>true</xb:exact>
+    <xb:responseDate>2026-06-05T14:51:17-0400</xb:responseDate>
+  </extraResponseData>
+</searchRetrieveResponse>

--- a/test/models/alma_sru_test.rb
+++ b/test/models/alma_sru_test.rb
@@ -67,28 +67,50 @@ class AlmaSruTest < ActiveSupport::TestCase
 
   test 'lookup returns empty list for non-existent records' do
     output = StringIO.new
+    original_logger = Rails.logger
     Rails.logger = Logger.new(output)
 
-    VCR.use_cassette('alma sru nonexistent record') do
-      needle = 'alma9900000000006761'
+    begin
+      VCR.use_cassette('alma sru nonexistent record') do
+        needle = 'alma9900000000006761'
 
-      result = AlmaSru.lookup(needle)
+        result = AlmaSru.lookup(needle)
 
-      assert_equal(result, [])
+        assert_equal(result, [])
 
-      # This condition gets logged for local investigation due to control field mismatch
-      assert_match('Alma lookup failure: Control field mismatch', output.string)
+        # This condition gets logged for local investigation due to control field mismatch
+        assert_match('Alma lookup failure: Control field mismatch', output.string)
+      end
+    ensure
+      Rails.logger = original_logger
     end
   end
 
-  test 'lookup returns nil if env not set' do
-    needle = '990002935920106761'
+  test 'lookup returns empty list if alma URL not set' do
+    needle = 'alma990014651640106761'
+
+    VCR.use_cassette('alma sru single record') do
+      assert_equal(1, AlmaSru.lookup(needle).length)
+    end
+
     ClimateControl.modify(MIT_ALMA_URL: nil) do
       assert_equal([], AlmaSru.lookup(needle))
     end
   end
 
-  test 'lookup returns nil with non-complying ID' do
+  test 'lookup returns empty list if exl_inst_id not set' do
+    needle = 'alma990014651640106761'
+
+    VCR.use_cassette('alma sru single record') do
+      assert_equal(1, AlmaSru.lookup(needle).length)
+    end
+
+    ClimateControl.modify(EXL_INST_ID: nil) do
+      assert_equal([], AlmaSru.lookup(needle))
+    end
+  end
+
+  test 'lookup returns empty list with non-complying ID' do
     needle = 'foo'
 
     result = AlmaSru.lookup(needle)
@@ -99,34 +121,44 @@ class AlmaSruTest < ActiveSupport::TestCase
   test 'lookup survives failing to connect to Alma SRU' do
     alma_client = AlmaConnectionError.new
     output = StringIO.new
+    original_logger = Rails.logger
     Rails.logger = Logger.new(output)
 
     needle = 'alma990014651640106761'
 
-    assert_nothing_raised do
-      result = AlmaSru.lookup(needle, alma_client: alma_client)
+    begin
+      assert_nothing_raised do
+        result = AlmaSru.lookup(needle, alma_client: alma_client)
 
-      assert_equal([], result)
+        assert_equal([], result)
 
-      # This condition gets logged for local investigation
-      assert_match('Alma SRU connection error', output.string)
+        # This condition gets logged for local investigation
+        assert_match('Alma SRU connection error', output.string)
+      end
+    ensure
+      Rails.logger = original_logger
     end
   end
 
   test 'lookup survives Alma SRU errors' do
     alma_client = AlmaErrorResponse.new
     output = StringIO.new
+    original_logger = Rails.logger
     Rails.logger = Logger.new(output)
 
     needle = 'alma990014651640106761'
 
-    assert_nothing_raised do
-      result = AlmaSru.lookup(needle, alma_client: alma_client)
+    begin
+      assert_nothing_raised do
+        result = AlmaSru.lookup(needle, alma_client: alma_client)
 
-      assert_equal(result, [])
+        assert_equal(result, [])
 
-      # This condition gets logged for local investigation
-      assert_match('Alma lookup failure: 500', output.string)
+        # This condition gets logged for local investigation
+        assert_match('Alma lookup failure: 500', output.string)
+      end
+    ensure
+      Rails.logger = original_logger
     end
   end
 

--- a/test/models/alma_sru_test.rb
+++ b/test/models/alma_sru_test.rb
@@ -1,0 +1,229 @@
+require 'test_helper'
+
+class AlmaSruMockResponse
+  attr_reader :status
+
+  def initialize(status, body)
+    @status = status
+    @body = body
+  end
+
+  def to_s
+    @body
+  end
+end
+
+class AlmaConnectionError
+  def timeout(_)
+    self
+  end
+
+  def get(_url)
+    raise HTTP::ConnectionError, 'forced connection failure'
+  end
+end
+
+class AlmaErrorResponse
+  def timeout(_)
+    self
+  end
+
+  def get(_url)
+    AlmaSruMockResponse.new(500, 'internal server error')
+  end
+end
+
+class AlmaSruTest < ActiveSupport::TestCase
+  test 'lookup returns text for successful lookup' do
+    VCR.use_cassette('alma sru single record') do
+      needle = 'alma990014651640106761'
+
+      result = AlmaSru.lookup(needle)
+
+      assert_equal(result, ['Available at Rotch Library Stacks (NA680.C25 2007)'])
+    end
+  end
+
+  test 'lookup returns self-service locations first if multiples exist' do
+    VCR.use_cassette('alma sru multiple records') do
+      needle = '990002935920106761'
+
+      result = AlmaSru.lookup(needle)
+
+      assert_equal(result[0], 'Check holdings at Barker Library Staff Retrieval - request required (FICHE No Call #)')
+      assert_equal(result[1], 'Available at Library Storage Annex Journal Collection (LSA4) (TA.J86.H437)')
+    end
+  end
+
+  test 'lookup returns empty list if no availability' do
+    VCR.use_cassette('alma sru no availability') do
+      needle = 'alma9935053423706761'
+
+      result = AlmaSru.lookup(needle)
+
+      assert_equal(result, [])
+    end
+  end
+
+  test 'lookup returns empty list for non-existent records' do
+    output = StringIO.new
+    Rails.logger = Logger.new(output)
+
+    VCR.use_cassette('alma sru nonexistent record') do
+      needle = 'alma9900000000006761'
+
+      result = AlmaSru.lookup(needle)
+
+      assert_equal(result, [])
+
+      # This condition gets logged for local investigation due to control field mismatch
+      assert_match('Alma lookup failure: Control field mismatch', output.string)
+    end
+  end
+
+  test 'lookup returns nil if env not set' do
+    needle = '990002935920106761'
+    ClimateControl.modify(MIT_ALMA_URL: nil) do
+      assert_equal([], AlmaSru.lookup(needle))
+    end
+  end
+
+  test 'lookup returns nil with non-complying ID' do
+    needle = 'foo'
+
+    result = AlmaSru.lookup(needle)
+
+    assert_equal([], result)
+  end
+
+  test 'lookup survives failing to connect to Alma SRU' do
+    alma_client = AlmaConnectionError.new
+    output = StringIO.new
+    Rails.logger = Logger.new(output)
+
+    needle = 'alma990014651640106761'
+
+    assert_nothing_raised do
+      result = AlmaSru.lookup(needle, alma_client: alma_client)
+
+      assert_equal([], result)
+
+      # This condition gets logged for local investigation
+      assert_match('Alma SRU connection error', output.string)
+    end
+  end
+
+  test 'lookup survives Alma SRU errors' do
+    alma_client = AlmaErrorResponse.new
+    output = StringIO.new
+    Rails.logger = Logger.new(output)
+
+    needle = 'alma990014651640106761'
+
+    assert_nothing_raised do
+      result = AlmaSru.lookup(needle, alma_client: alma_client)
+
+      assert_equal(result, [])
+
+      # This condition gets logged for local investigation
+      assert_match('Alma lookup failure: 500', output.string)
+    end
+  end
+
+  test 'validate_alma_id succeeds with valid numeric input' do
+    needle = '990002935920106761'
+    assert_nothing_raised do
+      AlmaSru.validate_alma_id(needle)
+    end
+  end
+
+  test 'validate_alma_id succeeds despite an "alma" prefix' do
+    needle = 'alma990002935920106761'
+    assert_nothing_raised do
+      AlmaSru.validate_alma_id(needle)
+    end
+  end
+
+  test 'validate_alma_id raises InvalidAlmaId without required start sequence' do
+    assert_raises(AlmaSru::InvalidAlmaId) do
+      AlmaSru.validate_alma_id('0002935920106761')
+    end
+
+    assert_raises(AlmaSru::InvalidAlmaId) do
+      AlmaSru.validate_alma_id('alma0002935920106761')
+    end
+  end
+
+  test 'validate_alma_id raises InvalidAlmaId without required end sequence' do
+    assert_raises(AlmaSru::InvalidAlmaId) do
+      AlmaSru.validate_alma_id('99000293592010')
+    end
+
+    assert_raises(AlmaSru::InvalidAlmaId) do
+      AlmaSru.validate_alma_id('alma99000293592010')
+    end
+  end
+
+  test 'validate_alma_id raises InvalidAlmaId with wildly invalid input' do
+    assert_raises(AlmaSru::InvalidAlmaId) do
+      AlmaSru.validate_alma_id('foo')
+    end
+  end
+
+  test 'fetch_controlfield isolates the controlfield with tag 001' do
+    needle = '990002935920106761'
+
+    xml_content = File.read('test/fixtures/alma/sru_success.xml')
+    parsed = Nokogiri::XML(xml_content)
+    result = AlmaSru.fetch_controlfield(parsed)
+
+    assert_equal(result, needle)
+  end
+
+  test 'fetch_controlfield returns empty string if controlfield not found' do
+    xml_content = File.read('test/fixtures/alma/sru_nocontrol.xml')
+    parsed = Nokogiri::XML(xml_content)
+    result = AlmaSru.fetch_controlfield(parsed)
+
+    assert_equal(result, '')
+  end
+
+  test 'fetch_availabilities will list some libraries first' do
+    needle_first = 'Library Storage Annex'
+    needle_second = 'Barker Library'
+
+    xml_content = File.read('test/fixtures/alma/sru_wrong_order.xml')
+    parsed = Nokogiri::XML(xml_content)
+
+    raw_first = parsed.at_xpath("(//holding:datafield[@tag='AVA'])[1]/holding:subfield[@code='q']/text()", AlmaSru::NAMESPACE)&.text
+    raw_second = parsed.at_xpath("(//holding:datafield[@tag='AVA'])[2]/holding:subfield[@code='q']/text()", AlmaSru::NAMESPACE)&.text
+
+    assert_equal(needle_first, raw_first)
+    assert_equal(needle_second, raw_second)
+
+    result = AlmaSru.fetch_availabilities(parsed)
+
+    assert_equal(needle_second, result[0]['q'])
+    assert_equal(needle_first, result[1]['q'])
+  end
+
+  test 'format_availability returns availability in pattern of "E q c (d)"' do
+    ava_hash = {
+      'c' => 'charlie',
+      'd' => 'delta',
+      'e' => 'echo',
+      'q' => 'quebec'
+    }
+
+    assert_equal('Echo at quebec charlie (delta)', AlmaSru.format_availability(ava_hash))
+  end
+
+  # Is this the behavior we want?
+  test 'format_availability does not error with missing fields' do
+    ava_hash = {
+      'b' => 'beta'
+    }
+
+    assert_equal(' at   ()', AlmaSru.format_availability(ava_hash))
+  end
+end

--- a/test/models/alma_sru_test.rb
+++ b/test/models/alma_sru_test.rb
@@ -34,13 +34,14 @@ class AlmaErrorResponse
 end
 
 class AlmaSruTest < ActiveSupport::TestCase
+  # Lookup method
   test 'lookup returns text for successful lookup' do
     VCR.use_cassette('alma sru single record') do
       needle = 'alma990014651640106761'
 
       result = AlmaSru.lookup(needle)
 
-      assert_equal(result, ['Available at Rotch Library Stacks (NA680.C25 2007)'])
+      assert_equal(['Available at Rotch Library Stacks (NA680.C25 2007)'], result)
     end
   end
 
@@ -50,8 +51,8 @@ class AlmaSruTest < ActiveSupport::TestCase
 
       result = AlmaSru.lookup(needle)
 
-      assert_equal(result[0], 'Check holdings at Barker Library Staff Retrieval - request required (FICHE No Call #)')
-      assert_equal(result[1], 'Available at Library Storage Annex Journal Collection (LSA4) (TA.J86.H437)')
+      assert_equal('Check holdings at Barker Library Staff Retrieval - request required (FICHE No Call #)', result[0])
+      assert_equal('Available at Library Storage Annex Journal Collection (LSA4) (TA.J86.H437)', result[1])
     end
   end
 
@@ -61,28 +62,17 @@ class AlmaSruTest < ActiveSupport::TestCase
 
       result = AlmaSru.lookup(needle)
 
-      assert_equal(result, [])
+      assert_equal([], result)
     end
   end
 
   test 'lookup returns empty list for non-existent records' do
-    output = StringIO.new
-    original_logger = Rails.logger
-    Rails.logger = Logger.new(output)
+    VCR.use_cassette('alma sru nonexistent record') do
+      needle = 'alma9900000000006761'
 
-    begin
-      VCR.use_cassette('alma sru nonexistent record') do
-        needle = 'alma9900000000006761'
+      result = AlmaSru.lookup(needle)
 
-        result = AlmaSru.lookup(needle)
-
-        assert_equal(result, [])
-
-        # This condition gets logged for local investigation due to control field mismatch
-        assert_match('Alma lookup failure: Control field mismatch', output.string)
-      end
-    ensure
-      Rails.logger = original_logger
+      assert_equal([], result)
     end
   end
 
@@ -118,50 +108,47 @@ class AlmaSruTest < ActiveSupport::TestCase
     assert_equal([], result)
   end
 
+  test 'lookup returns empty list with empty string' do
+    needle = ''
+
+    result = AlmaSru.lookup(needle)
+
+    assert_equal([], result)
+  end
+
+  test 'lookup returns empty list with nil input' do
+    needle = nil
+
+    result = AlmaSru.lookup(needle)
+
+    assert_equal([], result)
+  end
+
   test 'lookup survives failing to connect to Alma SRU' do
     alma_client = AlmaConnectionError.new
-    output = StringIO.new
-    original_logger = Rails.logger
-    Rails.logger = Logger.new(output)
 
     needle = 'alma990014651640106761'
 
-    begin
-      assert_nothing_raised do
-        result = AlmaSru.lookup(needle, alma_client: alma_client)
+    assert_nothing_raised do
+      result = AlmaSru.lookup(needle, alma_client: alma_client)
 
-        assert_equal([], result)
-
-        # This condition gets logged for local investigation
-        assert_match('Alma SRU connection error', output.string)
-      end
-    ensure
-      Rails.logger = original_logger
+      assert_equal([], result)
     end
   end
 
   test 'lookup survives Alma SRU errors' do
     alma_client = AlmaErrorResponse.new
-    output = StringIO.new
-    original_logger = Rails.logger
-    Rails.logger = Logger.new(output)
 
     needle = 'alma990014651640106761'
 
-    begin
-      assert_nothing_raised do
-        result = AlmaSru.lookup(needle, alma_client: alma_client)
+    assert_nothing_raised do
+      result = AlmaSru.lookup(needle, alma_client: alma_client)
 
-        assert_equal(result, [])
-
-        # This condition gets logged for local investigation
-        assert_match('Alma lookup failure: 500', output.string)
-      end
-    ensure
-      Rails.logger = original_logger
+      assert_equal([], result)
     end
   end
 
+  # validate_alma_id method
   test 'validate_alma_id succeeds with valid numeric input' do
     needle = '990002935920106761'
     assert_nothing_raised do
@@ -172,6 +159,21 @@ class AlmaSruTest < ActiveSupport::TestCase
   test 'validate_alma_id succeeds despite an "alma" prefix' do
     needle = 'alma990002935920106761'
     assert_nothing_raised do
+      AlmaSru.validate_alma_id(needle)
+    end
+  end
+
+  test 'validate_alma_id raises InvalidAlmaId with non-numeric id' do
+    needle = '99000293foo5920106761'
+
+    assert_raises(AlmaSru::InvalidAlmaId) do
+      AlmaSru.validate_alma_id(needle)
+    end
+  end
+
+  test 'validate_alma_id raises InvalidAlmaId with a nil input' do
+    needle = nil
+    assert_raises(AlmaSru::InvalidAlmaId) do
       AlmaSru.validate_alma_id(needle)
     end
   end
@@ -202,6 +204,7 @@ class AlmaSruTest < ActiveSupport::TestCase
     end
   end
 
+  # fetch_controlfield method
   test 'fetch_controlfield isolates the controlfield with tag 001' do
     needle = '990002935920106761'
 
@@ -209,7 +212,7 @@ class AlmaSruTest < ActiveSupport::TestCase
     parsed = Nokogiri::XML(xml_content)
     result = AlmaSru.fetch_controlfield(parsed)
 
-    assert_equal(result, needle)
+    assert_equal(needle, result)
   end
 
   test 'fetch_controlfield returns empty string if controlfield not found' do
@@ -217,9 +220,10 @@ class AlmaSruTest < ActiveSupport::TestCase
     parsed = Nokogiri::XML(xml_content)
     result = AlmaSru.fetch_controlfield(parsed)
 
-    assert_equal(result, '')
+    assert_equal('', result)
   end
 
+  # fetch_availabilities method
   test 'fetch_availabilities will list some libraries first' do
     needle_first = 'Library Storage Annex'
     needle_second = 'Barker Library'
@@ -239,6 +243,7 @@ class AlmaSruTest < ActiveSupport::TestCase
     assert_equal(needle_first, result[1]['q'])
   end
 
+  # format_availability method
   test 'format_availability returns availability in pattern of "E q c (d)"' do
     ava_hash = {
       'c' => 'charlie',
@@ -250,12 +255,31 @@ class AlmaSruTest < ActiveSupport::TestCase
     assert_equal('Echo at quebec charlie (delta)', AlmaSru.format_availability(ava_hash))
   end
 
-  # Is this the behavior we want?
-  test 'format_availability does not error with missing fields' do
+  test 'format_availability returns a minimum statement if only e and q are present' do
+    ava_hash = {
+      'e' => 'echo',
+      'q' => 'quebec'
+    }
+
+    assert_equal('Echo at quebec', AlmaSru.format_availability(ava_hash))
+  end
+
+  test 'format_availability returns an empty string without both e and q present' do
     ava_hash = {
       'b' => 'beta'
     }
 
-    assert_equal(' at   ()', AlmaSru.format_availability(ava_hash))
+    assert_equal('', AlmaSru.format_availability(ava_hash))
+
+    ava_hash = {
+      'e' => 'echo'
+    }
+
+    assert_equal('', AlmaSru.format_availability(ava_hash))
+    ava_hash = {
+      'q' => 'quebec'
+    }
+
+    assert_equal('', AlmaSru.format_availability(ava_hash))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,16 @@ VCR.configure do |config|
   config.filter_sensitive_data('FAKE_THIRDIRON_ID') { ENV.fetch('THIRDIRON_ID').to_s }
   config.filter_sensitive_data('FAKE_THIRDIRON_KEY') { ENV.fetch('THIRDIRON_KEY').to_s }
   config.filter_sensitive_data('FAKE_OPENALEX_EMAIL') { ENV.fetch('OPENALEX_EMAIL').to_s }
+  # Filter cookie contents
+  config.before_record do |interaction|
+    cookies = interaction.response&.headers&.fetch('Set-Cookie', nil)
+    next unless cookies
+
+    interaction.response.headers['Set-Cookie'] = cookies.map do |cookie|
+      name = cookie.split('=', 2).first
+      "#{name}=<FILTERED_COOKIE>"
+    end
+  end
 end
 
 module ActiveSupport

--- a/test/vcr_cassettes/alma_sru_multiple_records.yml
+++ b/test/vcr_cassettes/alma_sru_multiple_records.yml
@@ -1,0 +1,407 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=990002935920106761&recordSchema=marcxml&version=1.2
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - Keep-Alive
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Request-Id:
+      - lD4sRAGIpn
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID=9D331D7C05EEAF4BA7C5E8C9588C3009.app02.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
+        Path=/; HttpOnly; SameSite=None; Secure
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1RuoKgw__XaR; Expires=Thu,
+        05-Jun-2036 20:28:17 GMT; Path=/; Secure; SameSite=None
+      - urm_se=1780951097555; Path=/; SameSite=None; Secure
+      - urm_st=1780950497555; Path=/; SameSite=None; Secure
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - 'object-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com
+        stats.g.doubleclick.net s3.amazonaws.com www.youtube.com youtube.com *.contentdm.oclc.org
+        iiif.nlm.nih.gov ;worker-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn
+        www.google-analytics.com stats.g.doubleclick.net s3.amazonaws.com www.youtube.com
+        youtube.com artic.contentdm.oclc.org ;upgrade-insecure-requests; report-uri
+        /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint; '
+      Report-To:
+      - '{"max_age":10886400,"endpoints":[{"url":"https://na06.alma.exlibrisgroup.com/infra/CSPReportEndpoint.jsp"}],"group":"csp-report-endpoint"}'
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 08 Jun 2026 20:28:17 GMT
+      Keep-Alive:
+      - timeout=20
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03917cas  2200889 a 4500</leader>
+                  <controlfield tag="001">990002935920106761</controlfield>
+                  <controlfield tag="005">20241127113448.0</controlfield>
+                  <controlfield tag="008">741224c19599999nyuqr1p       0   a0eng^^</controlfield>
+                  <datafield ind1=" " ind2=" " tag="010">
+                    <subfield code="a">61019573 //r892</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="022">
+                    <subfield code="a">0022-1481</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="030">
+                    <subfield code="a">JHTRAO</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="032">
+                    <subfield code="a">280380</subfield>
+                    <subfield code="b">USPS</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000293592</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000293592MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)01782922</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)01713702</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)09764105</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(VERA)3557</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="037">
+                    <subfield code="b">ASME, United Engineering Center, 345 E. 47th St., New York, NY 10017</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">DLC</subfield>
+                    <subfield code="c">DLC</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NST</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="042">
+                    <subfield code="a">lc</subfield>
+                    <subfield code="a">nsdp</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="050">
+                    <subfield code="a">TA1</subfield>
+                    <subfield code="b">.J64</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="210">
+                    <subfield code="a">J. heat transfer</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="222">
+                    <subfield code="a">Journal of heat transfer</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="245">
+                    <subfield code="a">Journal of heat transfer.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">New York, N.Y. :</subfield>
+                    <subfield code="b">American Society of Mechanical Engineers,</subfield>
+                    <subfield code="c">c1959-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">v. :</subfield>
+                    <subfield code="b">ill. ;</subfield>
+                    <subfield code="c">29 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="310">
+                    <subfield code="a">Quarterly</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="362">
+                    <subfield code="a">Vol. 81, no. 1 (Feb. 1959)-</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="490">
+                    <subfield code="a">Transactions of the ASME ;</subfield>
+                    <subfield code="v">ser. C</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Title from cover.</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Applied science &amp; technology index</subfield>
+                    <subfield code="x">0003-6986</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Engineering index monthly (1984)</subfield>
+                    <subfield code="x">0742-1974</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Engineering index bioengineering abstracts</subfield>
+                    <subfield code="x">0736-6213</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Engineering index energy abstracts</subfield>
+                    <subfield code="x">0093-8408</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Energy information abstracts</subfield>
+                    <subfield code="x">0147-6521</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Environment abstracts</subfield>
+                    <subfield code="x">0093-3287</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">FLUIDEX</subfield>
+                    <subfield code="b">1978-</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Abstract bulletin of the Institute of Paper Chemistry</subfield>
+                    <subfield code="x">0020-3033</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Computer &amp; control abstracts</subfield>
+                    <subfield code="x">0036-8113</subfield>
+                    <subfield code="b">1968-</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Electrical &amp; electronics abstracts</subfield>
+                    <subfield code="x">0036-8105</subfield>
+                    <subfield code="b">1968-</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Physics abstracts. Science abstracts. Series A</subfield>
+                    <subfield code="x">0036-8091</subfield>
+                    <subfield code="b">1968-</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Chemical abstracts</subfield>
+                    <subfield code="x">0009-2258</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">SPIN</subfield>
+                    <subfield code="b">1977-</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Coal abstracts</subfield>
+                    <subfield code="x">0309-4979</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Energy research abstracts</subfield>
+                    <subfield code="x">0160-3604</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="510">
+                    <subfield code="a">International aerospace abstracts</subfield>
+                    <subfield code="x">0020-5842</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="510">
+                    <subfield code="a">Nuclear science abstracts</subfield>
+                    <subfield code="x">0029-5612</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="510">
+                    <subfield code="a">Indexes to publications - American Society of Mechanical Engineers</subfield>
+                    <subfield code="x">0569-8227</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="515">
+                    <subfield code="a">Vols. for 1978-   lack series numeration.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="530">
+                    <subfield code="a">Beginning 2000, full-text articles also available via the World Wide Web by subscription, in HTML, PDF, and PostScript formats. Tables of contents for 1996-1999 also available in HTML.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="580">
+                    <subfield code="a">Also included in: American Society of Mechanical Engineers. Transactions of the American Society of Mechanical Engineers, 1959-&lt;1967&gt;</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Heat</subfield>
+                    <subfield code="x">Transmission</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="650">
+                    <subfield code="a">Heat</subfield>
+                    <subfield code="x">Transmission.</subfield>
+                    <subfield code="2">fast</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Periodicals.</subfield>
+                    <subfield code="2">lcgft</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Periodicals.</subfield>
+                    <subfield code="2">fast</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="1" tag="780">
+                    <subfield code="t">Transactions of the ASME</subfield>
+                    <subfield code="w">(OCoLC)19731523</subfield>
+                    <subfield code="w">(DLC)sc 89034060</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="787">
+                    <subfield code="a">American Society of Mechanical Engineers.</subfield>
+                    <subfield code="t">Transactions of the American Society of Mechanical Engineers</subfield>
+                    <subfield code="w">(DLC) 02002053</subfield>
+                    <subfield code="w">(OCoLC)1480830</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="793">
+                    <subfield code="a">Journal of heat transfer [fiche]</subfield>
+                    <subfield code="g">E36211 960018634</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="710">
+                    <subfield code="a">American Society of Mechanical Engineers.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="830">
+                    <subfield code="a">Transactions of the ASME (1959) ;</subfield>
+                    <subfield code="v">ser. C.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jle001205/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">depgy-nooclc210609</subfield>
+                    <subfield code="d">210609</subfield>
+                    <subfield code="i">depgy-nooclc</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT221103</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT231208</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT241112</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="936">
+                    <subfield code="a">Vol. 102, no. 4 (Nov. 1980) LIC</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="946">
+                    <subfield code="m">unpiggy-tang</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="959">
+                    <subfield code="b">LSA</subfield>
+                    <subfield code="c">JRNAL</subfield>
+                    <subfield code="h">No Call #</subfield>
+                    <subfield code="o">8</subfield>
+                    <subfield code="x">57</subfield>
+                    <subfield code="v">All other volumes - use buttons to right</subfield>
+                    <subfield code="z">Please check availability at top of page to verify the Annex owns the volume/year you want.</subfield>
+                    <subfield code="f">ISSUE</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">New York, N.Y. : American Society of Mechanical Engineers,</subfield>
+                    <subfield code="a">1959</subfield>
+                    <subfield code="a">nyu</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">TA1</subfield>
+                    <subfield code="a">JHTRAO</subfield>
+                    <subfield code="a">01782922</subfield>
+                    <subfield code="a">01713702</subfield>
+                    <subfield code="a">09764105</subfield>
+                    <subfield code="a">61019573 //r892</subfield>
+                    <subfield code="a">0022-1481</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990002935920106761</subfield>
+                    <subfield code="8">22477267920006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">LSA</subfield>
+                    <subfield code="c">Journal Collection (LSA4)</subfield>
+                    <subfield code="d">TA.J86.H437</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">63</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">LSA4</subfield>
+                    <subfield code="k">Hfcl</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Library Storage Annex</subfield>
+                    <subfield code="t">v.81 (1959)-v.131:no.1-6 (2009)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990002935920106761</subfield>
+                    <subfield code="8">22477267070006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">ENG</subfield>
+                    <subfield code="c">Staff Retrieval - request required</subfield>
+                    <subfield code="d">FICHE No Call #</subfield>
+                    <subfield code="e">check_holdings</subfield>
+                    <subfield code="j">MFORM</subfield>
+                    <subfield code="k">8</subfield>
+                    <subfield code="p">2</subfield>
+                    <subfield code="q">Barker Library</subfield>
+                    <subfield code="t">v.92 (1970)-v.95 (1973),v.97 (1975)-v.119 (1997)</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990002935920106761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2026-06-08T16:28:17-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Mon, 08 Jun 2026 20:28:17 GMT
+recorded_with: VCR 6.4.0

--- a/test/vcr_cassettes/alma_sru_multiple_records.yml
+++ b/test/vcr_cassettes/alma_sru_multiple_records.yml
@@ -19,16 +19,14 @@ http_interactions:
       message: OK
     headers:
       X-Request-Id:
-      - lD4sRAGIpn
+      - cefisv63dh
       P3p:
       - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
       Set-Cookie:
-      - JSESSIONID=9D331D7C05EEAF4BA7C5E8C9588C3009.app02.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
-        Path=/; HttpOnly; SameSite=None; Secure
-      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1RuoKgw__XaR; Expires=Thu,
-        05-Jun-2036 20:28:17 GMT; Path=/; Secure; SameSite=None
-      - urm_se=1780951097555; Path=/; SameSite=None; Secure
-      - urm_st=1780950497555; Path=/; SameSite=None; Secure
+      - JSESSIONID=<FILTERED_COOKIE>
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=<FILTERED_COOKIE>
+      - urm_se=<FILTERED_COOKIE>
+      - urm_st=<FILTERED_COOKIE>
       Access-Control-Allow-Methods:
       - GET
       Access-Control-Allow-Headers:
@@ -53,7 +51,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 08 Jun 2026 20:28:17 GMT
+      - Tue, 09 Jun 2026 16:01:06 GMT
       Keep-Alive:
       - timeout=20
       Connection:
@@ -400,8 +398,8 @@ http_interactions:
           </records>
           <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
             <xb:exact>true</xb:exact>
-            <xb:responseDate>2026-06-08T16:28:17-0400</xb:responseDate>
+            <xb:responseDate>2026-06-09T12:01:06-0400</xb:responseDate>
           </extraResponseData>
         </searchRetrieveResponse>
-  recorded_at: Mon, 08 Jun 2026 20:28:17 GMT
+  recorded_at: Tue, 09 Jun 2026 16:01:06 GMT
 recorded_with: VCR 6.4.0

--- a/test/vcr_cassettes/alma_sru_no_availability.yml
+++ b/test/vcr_cassettes/alma_sru_no_availability.yml
@@ -1,0 +1,286 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=9935053423706761&recordSchema=marcxml&version=1.2
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - Keep-Alive
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Request-Id:
+      - xwR864Y1xM
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID=C3DDF913D7252F92452F5696B50F815B.app04.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
+        Path=/; HttpOnly; SameSite=None; Secure
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1tuoKgw__f1o; Expires=Thu,
+        05-Jun-2036 20:28:17 GMT; Path=/; Secure; SameSite=None
+      - urm_se=1780951097055; Path=/; SameSite=None; Secure
+      - urm_st=1780950497055; Path=/; SameSite=None; Secure
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - 'object-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com
+        stats.g.doubleclick.net s3.amazonaws.com www.youtube.com youtube.com *.contentdm.oclc.org
+        iiif.nlm.nih.gov ;worker-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn
+        www.google-analytics.com stats.g.doubleclick.net s3.amazonaws.com www.youtube.com
+        youtube.com artic.contentdm.oclc.org ;upgrade-insecure-requests; report-uri
+        /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint; '
+      Report-To:
+      - '{"max_age":10886400,"endpoints":[{"url":"https://na06.alma.exlibrisgroup.com/infra/CSPReportEndpoint.jsp"}],"group":"csp-report-endpoint"}'
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 08 Jun 2026 20:28:17 GMT
+      Keep-Alive:
+      - timeout=20
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03192 am a2200565   4500</leader>
+                  <controlfield tag="001">9935053423706761</controlfield>
+                  <controlfield tag="005">20170117</controlfield>
+                  <controlfield tag="006">m     o  d</controlfield>
+                  <controlfield tag="007">cu ||||||m||||</controlfield>
+                  <controlfield tag="008">171205e2017||||xx |||||o|||||||||0|fre|d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">2-917902-69-8</subfield>
+                  </datafield>
+                  <datafield ind1="7" ind2=" " tag="024">
+                    <subfield code="a">10.4000/books.inha.12276</subfield>
+                    <subfield code="2">doi</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(CKB)4100000009914036</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(FrMaCLE)OB-inha-12276</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(oapen)https://directory.doabooks.org/handle/20.500.12854/45032</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(FrMaCLE)OB-inha-7185</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(PPN)24129181X</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(oapen)doab45032</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(EXLCZ)994100000009914036</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">FR-FrMaCLE</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="041">
+                    <subfield code="a">fre</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="100">
+                    <subfield code="a">Awad, Alaa</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="245">
+                    <subfield code="a">Dialogues artistiques avec les passés de l'Égypte :</subfield>
+                    <subfield code="b">Une perspective transnationale et transmédiale /</subfield>
+                    <subfield code="c">Mercedes Volait, Emmanuelle Perrin.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">Paris :</subfield>
+                    <subfield code="b">Publications de l’Institut national d’histoire de l’art,</subfield>
+                    <subfield code="c">2017.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">1 online resource (235 p.)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">computer</subfield>
+                    <subfield code="b">c</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">online resource</subfield>
+                    <subfield code="b">cr</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="520">
+                    <subfield code="a">Suez, Abou Simbel, Le Caire, Alger, Casablanca, Istanbul... Pour la première fois, des historiens de l'architecture et des conservateurs d'archives nous permettent d'accéder à un patrimoine culturel européen exceptionnel et méconnu : les archives produites par les entreprises du bâtiment et des travaux publics actives au sud de la Méditerranée, entre 1860 et 1970. Ouvrages d'art en acier ou béton armé, cités pour ouvriers et cadres expatriés, bâtiments publics mais aussi mobilier, décors, ouvrages effectués par des artisans d'art... Toutes ces réalisations témoignent d'une époque d'intenses échanges humains, techniques, et artistiques entre l'Europe et l'arc sud-est de la Méditerranée. Photographies anciennes destinées à promouvoir le travail des entrepreneurs, photographies de chantier, dessins d'architectes, croquis et carnets documentant les innovations techniques, plaquettes publicitaires... le livre est illustré par plus de 200 dessins et photographies provenant directement des fonds d'archives des constructeurs. Cet ouvrage est le résultat du projet de coopération transnationale "ARCHING : ARchives d'INGénierie européenne" (2010-2012) conduit dans le cadre du programme Culture 2007-2013 de la Commission européenne, auquel ont participé cinq institutions : l'Ecomusée du Bois-du-Luc (Belgique), la Cité de l'architecture et du patrimoine (France), InVisu (CNRS-INHA) (France), le Dipartimento di Architettura disegno-storia-progetto de l'université de Florence (Italie), Archmuseum (Turquie).  Suez, Abu Simbel, Cairo, Algiers, Casablanca, Istanbul... This work of pioneering research by architectural historians and archivists gives us access to an exceptional field of European cultural heritage: the records of buildings and public works contractors active on the southern shores of the Mediterranean between 1860 and 1970. It covers all the construction trades, from steel or reinforced concrete bridges and dams, housing for laborers and expats, and public buildings,…</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="540">
+                    <subfield code="a">OpenEdition Books License</subfield>
+                    <subfield code="u">https://www.openedition.org/12554</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="546">
+                    <subfield code="a">French</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="4" tag="650">
+                    <subfield code="a">Architecture</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="4" tag="650">
+                    <subfield code="a">architecte</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="4" tag="650">
+                    <subfield code="a">entreprises de la construction</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="4" tag="650">
+                    <subfield code="a">architecture</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="4" tag="650">
+                    <subfield code="a">construction companies</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="653">
+                    <subfield code="a">egyptomania</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="653">
+                    <subfield code="a">historicism</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="653">
+                    <subfield code="a">painting</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="653">
+                    <subfield code="a">theater</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="653">
+                    <subfield code="a">decorative arts</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="653">
+                    <subfield code="a">heritage</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="653">
+                    <subfield code="a">architecture</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Bardaouil, Sam</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Bishop, Elizabeth</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Chauffour, Sébastien</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">el-Wakil, Leïla</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Fathy, Hassan</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Garnier, Bénédicte</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Humbert, Jean-Marcel</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Khachab, Walid El</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Ormos, István</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Radwan, Nadia</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Volait, Mercedes</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Volait, Mercedes</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="700">
+                    <subfield code="a">Perrin, Emmanuelle</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="720">
+                    <subfield code="a">Mercedes Volait</subfield>
+                    <subfield code="4">aut</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="720">
+                    <subfield code="a">Emmanuelle Perrin</subfield>
+                    <subfield code="4">aut</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="8" tag="776">
+                    <subfield code="z">2-918371-12-2</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="8" tag="776">
+                    <subfield code="z">979-1-0973-1500-9</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="793">
+                    <subfield code="a">DOAB Library.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="906">
+                    <subfield code="a">BOOK</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="946">
+                    <subfield code="z">RTCTFebook</subfield>
+                    <subfield code="m">CollConsol2026</subfield>
+                    <subfield code="9">local</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53650867050006761</subfield>
+                    <subfield code="c">61535080440006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="m">DOAB Directory of Open Access Books</subfield>
+                    <subfield code="t">DOAB Directory of Open Access Books</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="0">9935053423706761</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53542422790006761</subfield>
+                    <subfield code="c">61535080440006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="m">DOAB Directory of Open Access Books</subfield>
+                    <subfield code="t">DOAB Directory of Open Access Books</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="0">9935053423706761</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>9935053423706761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2026-06-08T16:28:17-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Mon, 08 Jun 2026 20:28:17 GMT
+recorded_with: VCR 6.4.0

--- a/test/vcr_cassettes/alma_sru_no_availability.yml
+++ b/test/vcr_cassettes/alma_sru_no_availability.yml
@@ -19,16 +19,14 @@ http_interactions:
       message: OK
     headers:
       X-Request-Id:
-      - xwR864Y1xM
+      - QE84k9NmR2
       P3p:
       - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
       Set-Cookie:
-      - JSESSIONID=C3DDF913D7252F92452F5696B50F815B.app04.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
-        Path=/; HttpOnly; SameSite=None; Secure
-      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1tuoKgw__f1o; Expires=Thu,
-        05-Jun-2036 20:28:17 GMT; Path=/; Secure; SameSite=None
-      - urm_se=1780951097055; Path=/; SameSite=None; Secure
-      - urm_st=1780950497055; Path=/; SameSite=None; Secure
+      - JSESSIONID=<FILTERED_COOKIE>
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=<FILTERED_COOKIE>
+      - urm_se=<FILTERED_COOKIE>
+      - urm_st=<FILTERED_COOKIE>
       Access-Control-Allow-Methods:
       - GET
       Access-Control-Allow-Headers:
@@ -53,7 +51,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 08 Jun 2026 20:28:17 GMT
+      - Tue, 09 Jun 2026 16:01:07 GMT
       Keep-Alive:
       - timeout=20
       Connection:
@@ -279,8 +277,8 @@ http_interactions:
           </records>
           <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
             <xb:exact>true</xb:exact>
-            <xb:responseDate>2026-06-08T16:28:17-0400</xb:responseDate>
+            <xb:responseDate>2026-06-09T12:01:07-0400</xb:responseDate>
           </extraResponseData>
         </searchRetrieveResponse>
-  recorded_at: Mon, 08 Jun 2026 20:28:17 GMT
+  recorded_at: Tue, 09 Jun 2026 16:01:07 GMT
 recorded_with: VCR 6.4.0

--- a/test/vcr_cassettes/alma_sru_nonexistent_record.yml
+++ b/test/vcr_cassettes/alma_sru_nonexistent_record.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=9900000000006761&recordSchema=marcxml&version=1.2
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - Keep-Alive
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Request-Id:
+      - vjyUp6BOWm
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID=FCED354C1662C2CD3FE99660AA1094A3.app03.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
+        Path=/; HttpOnly; SameSite=None; Secure
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1SeoKgw__ob6; Expires=Fri,
+        06-Jun-2036 00:16:10 GMT; Path=/; Secure; SameSite=None
+      - urm_se=1780964770126; Path=/; SameSite=None; Secure
+      - urm_st=1780964170126; Path=/; SameSite=None; Secure
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - 'object-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com
+        stats.g.doubleclick.net s3.amazonaws.com www.youtube.com youtube.com *.contentdm.oclc.org
+        iiif.nlm.nih.gov ;worker-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn
+        www.google-analytics.com stats.g.doubleclick.net s3.amazonaws.com www.youtube.com
+        youtube.com artic.contentdm.oclc.org ;upgrade-insecure-requests; report-uri
+        /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint; '
+      Report-To:
+      - '{"max_age":10886400,"endpoints":[{"url":"https://na06.alma.exlibrisgroup.com/infra/CSPReportEndpoint.jsp"}],"group":"csp-report-endpoint"}'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '420'
+      Date:
+      - Tue, 09 Jun 2026 00:16:10 GMT
+      Keep-Alive:
+      - timeout=20
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>0</numberOfRecords>
+          <records/>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2026-06-08T20:16:10-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Tue, 09 Jun 2026 00:16:10 GMT
+recorded_with: VCR 6.4.0

--- a/test/vcr_cassettes/alma_sru_nonexistent_record.yml
+++ b/test/vcr_cassettes/alma_sru_nonexistent_record.yml
@@ -19,16 +19,14 @@ http_interactions:
       message: OK
     headers:
       X-Request-Id:
-      - vjyUp6BOWm
+      - QBJY0Rl9Hk
       P3p:
       - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
       Set-Cookie:
-      - JSESSIONID=FCED354C1662C2CD3FE99660AA1094A3.app03.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
-        Path=/; HttpOnly; SameSite=None; Secure
-      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1SeoKgw__ob6; Expires=Fri,
-        06-Jun-2036 00:16:10 GMT; Path=/; Secure; SameSite=None
-      - urm_se=1780964770126; Path=/; SameSite=None; Secure
-      - urm_st=1780964170126; Path=/; SameSite=None; Secure
+      - JSESSIONID=<FILTERED_COOKIE>
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=<FILTERED_COOKIE>
+      - urm_se=<FILTERED_COOKIE>
+      - urm_st=<FILTERED_COOKIE>
       Access-Control-Allow-Methods:
       - GET
       Access-Control-Allow-Headers:
@@ -51,7 +49,7 @@ http_interactions:
       Content-Length:
       - '420'
       Date:
-      - Tue, 09 Jun 2026 00:16:10 GMT
+      - Tue, 09 Jun 2026 16:01:06 GMT
       Keep-Alive:
       - timeout=20
       Connection:
@@ -67,8 +65,8 @@ http_interactions:
           <records/>
           <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
             <xb:exact>true</xb:exact>
-            <xb:responseDate>2026-06-08T20:16:10-0400</xb:responseDate>
+            <xb:responseDate>2026-06-09T12:01:06-0400</xb:responseDate>
           </extraResponseData>
         </searchRetrieveResponse>
-  recorded_at: Tue, 09 Jun 2026 00:16:10 GMT
+  recorded_at: Tue, 09 Jun 2026 16:01:06 GMT
 recorded_with: VCR 6.4.0

--- a/test/vcr_cassettes/alma_sru_single_record.yml
+++ b/test/vcr_cassettes/alma_sru_single_record.yml
@@ -19,16 +19,14 @@ http_interactions:
       message: OK
     headers:
       X-Request-Id:
-      - MsRANxfCdH
+      - soQ4UmfGM7
       P3p:
       - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
       Set-Cookie:
-      - JSESSIONID=0D60BA63676F7AE167C9631D032C1E48.app03.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
-        Path=/; HttpOnly; SameSite=None; Secure
-      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1SeoKgw__ob6; Expires=Thu,
-        05-Jun-2036 20:28:16 GMT; Path=/; Secure; SameSite=None
-      - urm_se=1780951096156; Path=/; SameSite=None; Secure
-      - urm_st=1780950496156; Path=/; SameSite=None; Secure
+      - JSESSIONID=<FILTERED_COOKIE>
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=<FILTERED_COOKIE>
+      - urm_se=<FILTERED_COOKIE>
+      - urm_st=<FILTERED_COOKIE>
       Access-Control-Allow-Methods:
       - GET
       Access-Control-Allow-Headers:
@@ -53,7 +51,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 08 Jun 2026 20:28:16 GMT
+      - Tue, 09 Jun 2026 15:59:03 GMT
       Keep-Alive:
       - timeout=20
       Connection:
@@ -289,8 +287,8 @@ http_interactions:
           </records>
           <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
             <xb:exact>true</xb:exact>
-            <xb:responseDate>2026-06-08T16:28:16-0400</xb:responseDate>
+            <xb:responseDate>2026-06-09T11:59:03-0400</xb:responseDate>
           </extraResponseData>
         </searchRetrieveResponse>
-  recorded_at: Mon, 08 Jun 2026 20:28:16 GMT
+  recorded_at: Tue, 09 Jun 2026 15:59:03 GMT
 recorded_with: VCR 6.4.0

--- a/test/vcr_cassettes/alma_sru_single_record.yml
+++ b/test/vcr_cassettes/alma_sru_single_record.yml
@@ -1,0 +1,296 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=990014651640106761&recordSchema=marcxml&version=1.2
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - Keep-Alive
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Request-Id:
+      - MsRANxfCdH
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID=0D60BA63676F7AE167C9631D032C1E48.app03.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801;
+        Path=/; HttpOnly; SameSite=None; Secure
+      - __Secure-UqZBpD3n3naPR20-9Fvn5i-TQ-tFoshbYtbA9YCEpg3UXgo_=v1SeoKgw__ob6; Expires=Thu,
+        05-Jun-2036 20:28:16 GMT; Path=/; Secure; SameSite=None
+      - urm_se=1780951096156; Path=/; SameSite=None; Secure
+      - urm_st=1780950496156; Path=/; SameSite=None; Secure
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - 'object-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com
+        stats.g.doubleclick.net s3.amazonaws.com www.youtube.com youtube.com *.contentdm.oclc.org
+        iiif.nlm.nih.gov ;worker-src blob: ''self'' *.exlibrisgroup.com *.exlibrisgroup.com.cn
+        www.google-analytics.com stats.g.doubleclick.net s3.amazonaws.com www.youtube.com
+        youtube.com artic.contentdm.oclc.org ;upgrade-insecure-requests; report-uri
+        /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint; '
+      Report-To:
+      - '{"max_age":10886400,"endpoints":[{"url":"https://na06.alma.exlibrisgroup.com/infra/CSPReportEndpoint.jsp"}],"group":"csp-report-endpoint"}'
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 08 Jun 2026 20:28:16 GMT
+      Keep-Alive:
+      - timeout=20
+      Connection:
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>02275cam  22005654a 4500</leader>
+                  <controlfield tag="001">990014651640106761</controlfield>
+                  <controlfield tag="005">20241127214106.0</controlfield>
+                  <controlfield tag="008">060915s2007    mauae    b    000 0deng^^</controlfield>
+                  <datafield ind1=" " ind2=" " tag="010">
+                    <subfield code="a">2006030939</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="015">
+                    <subfield code="a">GBA724048</subfield>
+                    <subfield code="2">bnb</subfield>
+                  </datafield>
+                  <datafield ind1="7" ind2=" " tag="016">
+                    <subfield code="a">013704232</subfield>
+                    <subfield code="2">Uk</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">9780262532914 (pbk. : alk. paper)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">0262532913 (pbk. : alk. paper)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)001465164MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)71427217</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">DLC</subfield>
+                    <subfield code="c">DLC</subfield>
+                    <subfield code="d">BAKER</subfield>
+                    <subfield code="d">UKM</subfield>
+                    <subfield code="d">BTCTA</subfield>
+                    <subfield code="d">C#P</subfield>
+                    <subfield code="d">YDXCP</subfield>
+                    <subfield code="d">MYG</subfield>
+                    <subfield code="d">OrLoB-B</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="050">
+                    <subfield code="a">NA680.C25 2007</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="082">
+                    <subfield code="a">724/.6</subfield>
+                    <subfield code="2">22</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="100">
+                    <subfield code="a">Cadwell, Mike,</subfield>
+                    <subfield code="d">1952-</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="245">
+                    <subfield code="a">Strange details /</subfield>
+                    <subfield code="c">Michael Cadwell.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">Cambridge, Mass. :</subfield>
+                    <subfield code="b">MIT Press,</subfield>
+                    <subfield code="c">c2007.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">xxi, 183 p. :</subfield>
+                    <subfield code="b">ill., plans ;</subfield>
+                    <subfield code="c">21 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="490">
+                    <subfield code="a">Writing architecture</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="504">
+                    <subfield code="a">Includes bibliographical references.</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="505">
+                    <subfield code="t">Introduction : "making strange" --</subfield>
+                    <subfield code="g">1.</subfield>
+                    <subfield code="t">Swimming at the Querini Stampali Foundation --</subfield>
+                    <subfield code="g">2.</subfield>
+                    <subfield code="t">The Jacobs House, Burning Fields --</subfield>
+                    <subfield code="g">3.</subfield>
+                    <subfield code="t">Flooded at the Farnsworth House --</subfield>
+                    <subfield code="g">4.</subfield>
+                    <subfield code="t">The Yale Center for British Art, yellow light and blue shadow.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Architecture, Modern</subfield>
+                    <subfield code="y">20th century</subfield>
+                    <subfield code="v">Case studies.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Building</subfield>
+                    <subfield code="v">Case studies.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="650">
+                    <subfield code="a">Building.</subfield>
+                    <subfield code="2">fast</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="650">
+                    <subfield code="a">Architecture, Modern.</subfield>
+                    <subfield code="2">fast</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Case studies.</subfield>
+                    <subfield code="2">lcgft</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Case studies.</subfield>
+                    <subfield code="2">fast</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="648">
+                    <subfield code="a">20th century</subfield>
+                    <subfield code="2">fast</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="648">
+                    <subfield code="a">20th century.</subfield>
+                    <subfield code="2">fast</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="2" tag="856">
+                    <subfield code="3">Table of contents only</subfield>
+                    <subfield code="u">http://www.loc.gov/catdir/toc/ecip071/2006030939.html</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="830">
+                    <subfield code="a">Writing architecture.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">pj070719</subfield>
+                    <subfield code="i">pj</subfield>
+                    <subfield code="d">070719</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT221103</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT231208</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT241113</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="949">
+                    <subfield code="4">IP</subfield>
+                    <subfield code="a">r</subfield>
+                    <subfield code="b">RTC</subfield>
+                    <subfield code="c">STACK</subfield>
+                    <subfield code="o">0</subfield>
+                    <subfield code="p">39080032070994</subfield>
+                    <subfield code="x">01</subfield>
+                    <subfield code="h">NA680.C25 2007</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="956">
+                    <subfield code="u">http://catalog.hathitrust.org/api/volumes/oclc/71427217.html</subfield>
+                    <subfield code="3">Hathi Trust</subfield>
+                    <subfield code="x">HathiETAS</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">Cambridge, Mass. : MIT Press,</subfield>
+                    <subfield code="a">2007</subfield>
+                    <subfield code="a">mau</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">724/.6</subfield>
+                    <subfield code="a">NA680.C25 2007</subfield>
+                    <subfield code="a">71427217</subfield>
+                    <subfield code="a">2006030939</subfield>
+                    <subfield code="a">9780262532914 (pbk. : alk. paper)</subfield>
+                    <subfield code="a">0262532913 (pbk. : alk. paper)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="983">
+                    <subfield code="a">digitized</subfield>
+                    <subfield code="c">20230810</subfield>
+                    <subfield code="k">HathiTrust</subfield>
+                    <subfield code="u">005575003</subfield>
+                    <subfield code="x">ic</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990014651640106761</subfield>
+                    <subfield code="8">22500544240006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">RTC</subfield>
+                    <subfield code="c">Stacks</subfield>
+                    <subfield code="d">NA680.C25 2007</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">1</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">STACK</subfield>
+                    <subfield code="k">0</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Rotch Library</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990014651640106761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2026-06-08T16:28:16-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Mon, 08 Jun 2026 20:28:16 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
**Why are these changes being introduced:**

For performance reasons, we stripped out holdings information from our initial Primo API call. However, we do want to display these holdings to users where they are available - so we need to add them back as an async API lookup.

**Relevant ticket:**

https://mitlibraries.atlassian.net/browse/use-598

**How does this address that need:**

This adds an AlmaSru model that will handle these async lookups. This ticket calls for only the model, the rest of the integration will happen in subsequent tickets.

The model provides a lookup method which accepts an identifier argument. It validates that identifier, submits it to the Alma SRU endpoint, receives the result, and parses that response into a human-friendly format.

**PLEASE NOTE:** There is no visible impact to this PR in a browser. You will need to interact with `AlmaSru` in a console, either within Heroku in the PR build, or locally in your terminal.

**Document any side effects to this change:**

We consult a variety of external APIs in this application, and each of them follows slightly different patterns. Hopefully this does not exacerbate that range terribly.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

**Please note:** - this implementation does newly rely on an already-defined ENV variable, so you'll see a change in .env.test. The value itself is already in this file in several places, so I don't believe it is a concern to add it in the way I'm doing here.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

There are a few questions I'd like to ask be considered during code review:

1. What behavior do we want if any of the relied-upon subfields is ever not present? The phrase from Primo that I'm aiming to replicate is, apparently, `e q c (d)` - and all the records I've inspected during testing have had these populated (along with a range of others that are hit-or-miss). For the moment, I've written a test making clear that each of these is treated as optional - which results in a rather non-sensical statement if all four are ever blank.

In an alternative case, I could define each of these four as required during processing, and return a placeholder statement when warranted (either because one value is missing, some percentage of values is missing, etc)

2. Copilot is consistently flagging that `validate_alma_id` is too permissive, because it doesn't flag characters in the value beyond the "alma" prefix. I've written a test in the suite to confirm that characters like this don't cause a breakage, which I think is sufficient - but I'm open to a counterargument here that we should be enforcing an all-numeric format.

3. I'm proposing a test pattern for certain events to get logged for local debugging, but this is starting to feel like it is more trouble than it is worth. I'd like to have some visibility into certain outcomes from this model, but I don't feel confident that any of the available options are what we need. Sentry is overkill, I don't want to pollute the log stream in production with error messages that aren't actually errors, and confirming that the debug messages are working as intended is proving challenging without causing other issues (see Copilot messages).

There are other Copilot and Qlty flags being thrown, but I'm not convinced any of them are worth considering at this point, and I'm wary of re-submitting another round of changes only to hear about new issues on unchanged lines of code.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
