### PR TITLE
USE-471: Tighten spacing between results

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -178,6 +178,10 @@
     background-color: transparent;
   }
 
+  // Trim bottom margins on last item to ensure consistent spacing between results
+  .result-content > div:last-child, 
+  .result-metadata > div:last-child { margin-bottom: 0; }
+
   .eyebrow {
     color: $color-text-secondary;
     font-size: 1.3rem;

--- a/app/views/search/_highlights.html.erb
+++ b/app/views/search/_highlights.html.erb
@@ -1,11 +1,13 @@
 <% highlights = trim_highlights(result) %>
 <% return unless highlights&.any? %>
 
-<h4 class="inner-heading">Search term found in:</h4>
-<ul class="list-unbulleted truncate-list">
-  <% highlights.each do |h| %>
-    <% h['matchedPhrases'].each do |phrase| %>
-      <li><strong><%= format_highlight_label(h['matchedField']) %>:</strong> <%= sanitize(phrase, tags: ['span']) %></li>
+<div class="result-highlights use">
+  <h4 class="inner-heading">Search term found in:</h4>
+  <ul class="list-unbulleted truncate-list">
+    <% highlights.each do |h| %>
+      <% h['matchedPhrases'].each do |phrase| %>
+        <li><strong><%= format_highlight_label(h['matchedField']) %>:</strong> <%= sanitize(phrase, tags: ['span']) %></li>
+      <% end %>
     <% end %>
-  <% end %>
-</ul>
+  </ul>
+</div>

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -59,9 +59,7 @@
       <% end %>
     </div>
 
-    <div class="result-highlights use">
-      <%= render partial: 'search/highlights', locals: { result: result } %>
-    </div>
+    <%= render partial: 'search/highlights', locals: { result: result } %>
 
     <% if Feature.enabled?(:record_link) %>
       <div class="result-get">


### PR DESCRIPTION
#### Developer
After many rounds of small tweaks, the visual spacing between results in USE had grown to be a bit larger than desired. This work tightens up the spacing between results.

The highlights container div was rendering even when empty. This work also moves the containing div into the partial to be rendered conditionally.

Bottom margins have been trimmed from the last child div to ensure the spacing is consistent.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
