### PR TITLE
USE-438: Swap markup of eyebrow and title for screen readers, render reversed with CSS

### DIFF
--- a/app/assets/stylesheets/partials/_results.scss
+++ b/app/assets/stylesheets/partials/_results.scss
@@ -178,18 +178,26 @@
     background-color: transparent;
   }
 
+  .title-lockup {
+    display: flex;
+    gap: 12px;
+    flex-direction: column-reverse;
+    margin-bottom: 8px;
+  }
+
   .eyebrow {
     color: $color-text-secondary;
     font-size: 1.3rem;
     font-weight: $fw-medium;
     letter-spacing: 0.05em;
     text-transform: uppercase;
+    margin-bottom: 0;
   }
 
   .record-title {
     font-size: 2.4rem;
     line-height: 1.3;
-    margin-bottom: 8px;
+    margin-bottom: 0;
 
     a {
       @include underlinedLinks;

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,6 +1,7 @@
 <li class="result use" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
     <div class="title-lockup">
+      <%# NOTE: the order of the two items in this lockup are being swapped visually with CSS. The markup is ordered to make the screen reading experience more logical %>
       <h3 class="record-title">
         <%= link_to_result(result) %>
       </h3>

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,11 +1,13 @@
 <li class="result use" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if result[:eyebrow].present? %>
-      <p class="eyebrow"><%= result[:eyebrow] %></p>
-    <% end %>
-    <h3 class="record-title">
-      <%= link_to_result(result) %>
-    </h3>
+    <div class="title-lockup">
+      <h3 class="record-title">
+        <%= link_to_result(result) %>
+      </h3>
+      <% if result[:eyebrow].present? %>
+        <p class="eyebrow"><%= result[:eyebrow] %></p>
+      <% end %>
+    </div>
 
     <div class="result-metadata">
 

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -1,6 +1,7 @@
 <li class="result primo" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
     <div class="title-lockup">
+      <%# NOTE: the order of the two items in this lockup are being swapped visually with CSS. The markup is ordered to make the screen reading experience more logical %>
       <h3 class="record-title">
         <% if result[:links]&.find { |link| link['kind'] == 'full record' } %>
           <%= link_to(result[:title], result[:links].find { |link| link['kind'] == 'full record' }['url'], data: { content_piece: 'Result Title' }) %>

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -1,15 +1,17 @@
 <li class="result primo" data-record-id="<%= result[:identifier] %>" data-matomo-seen="Results, Result Seen, Tab: {{getActiveTabName}}" data-track-content data-content-name="Result">
   <div class="result-content">
-    <% if result[:eyebrow].present? %>
-      <p class="eyebrow"><%= result[:eyebrow] %></p>
-    <% end %>
-    <h3 class="record-title">
-      <% if result[:links]&.find { |link| link['kind'] == 'full record' } %>
-        <%= link_to(result[:title], result[:links].find { |link| link['kind'] == 'full record' }['url'], data: { content_piece: 'Result Title' }) %>
-      <% else %>
-        <%= result[:title] %>
+    <div class="title-lockup">
+      <h3 class="record-title">
+        <% if result[:links]&.find { |link| link['kind'] == 'full record' } %>
+          <%= link_to(result[:title], result[:links].find { |link| link['kind'] == 'full record' }['url'], data: { content_piece: 'Result Title' }) %>
+        <% else %>
+          <%= result[:title] %>
+        <% end %>
+      </h3>
+      <% if result[:eyebrow].present? %>
+        <p class="eyebrow"><%= result[:eyebrow] %></p>
       <% end %>
-    </h3>
+    </div>
 
     <%# FRBR indicator: show a small callout and link to the Primo record %>
     <% if result[:dedup_record] %>


### PR DESCRIPTION
#### Developer
We currently have the eyebrow above the result title in markup. This means screen readers read the eyebrow first without any context of the title.

This work reverses the order in the markup but returns it to the current visual order using flex-direction. Now screen readers will read the title and the next piece of information is the material type.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
