### PR TITLE
Display availability statements when relevant

### DIFF
--- a/app/controllers/alma_controller.rb
+++ b/app/controllers/alma_controller.rb
@@ -1,0 +1,15 @@
+class AlmaController < ApplicationController
+  layout false
+
+  def sru
+    return unless AlmaSru.enabled? && expected_params?
+
+    @availability = AlmaSru.lookup(params[:doc_id])
+  end
+
+  private
+
+  def expected_params?
+    params[:doc_id].present?
+  end
+end

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -139,36 +139,6 @@ module RecordHelper
     subjects.map { |subject| subject['value'].uniq(&:downcase) }.uniq { |values| values.map(&:downcase) }
   end
 
-  # Formats availability information for display.
-  # Expects:
-  # - status: a string indicating availability status
-  # - location: an array with three elements: [library name, location name, call number]
-  # - other_availability: a boolean string indicating if there is availability at other locations
-  def availability(status, location, other_availability)
-    blurb = case status.downcase
-            # `available` is a common status used in Alma/Primo VE for items that are not checked out and should be
-            # on the shelf
-            when 'available'
-              "#{icon('check')} Available in #{location(location)}"
-            # `check_holdings`: unclear when (or if) this is used. Bento handled this so we did too assuming it was
-            # meaningful
-            when 'check_holdings'
-              "#{icon('question')} May be available in #{location(location)}"
-            # 'unavailable' is used for items that are checked out, missing, or otherwise not on the shelf
-            when 'unavailable'
-              "#{icon('times')} Not currently available in #{location(location)}"
-            # Unclear if there are other statuses we should handle here. For now we log and display a generic message.
-            else
-              Rails.logger.error("Unhandled availability status: #{status.inspect}")
-              "#{icon('question')} Uncertain availability in #{location(location)} #{status}"
-            end
-
-    blurb += ' and other locations.' if other_availability.present?
-
-    # We are generating HTML in this helper, so we need to mark it as safe or it will be escaped in the view.
-    blurb.html_safe
-  end
-
   # Fontawesome helper.
   #
   # Accepts name of the icon and optionally a collection. Defaults to solid sharp collection.
@@ -178,12 +148,6 @@ module RecordHelper
   # to allow passing in additional aria attributes rather than always hiding.
   def icon(fa, collection = 'fa-sharp fa-solid')
     "<i class='#{collection} fa-#{fa}' aria-hidden='true''></i>"
-  end
-
-  # Formats location information for availability display.
-  # Expects an array with three elements: [library name, location name, call number]
-  def location(loc)
-    "<strong>#{loc[:name]}</strong> #{loc[:collection]} (#{loc[:call_number]})"
   end
 
   private

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -147,7 +147,7 @@ module RecordHelper
   # purely for decoration. If an icon is used in a more meaningful way, we should extend this helper
   # to allow passing in additional aria attributes rather than always hiding.
   def icon(fa, collection = 'fa-sharp fa-solid')
-    "<i class='#{collection} fa-#{fa}' aria-hidden='true''></i>"
+    "<i class='#{collection} fa-#{fa}' aria-hidden='true'></i>"
   end
 
   private

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -97,7 +97,7 @@ module ResultsHelper
   # @return [Boolean] True if the result has links, availability, or ThirdIron/OpenAlex triggers
   def result_get?(result)
     renderable_links?(result) ||
-      result[:availability].present? ||
+      AlmaSru.valid_alma_id?(result[:identifier]) ||
       (Feature.enabled?(:oa_always) && article?(result[:format])) ||
       thirdiron_content?(result)
   end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -97,7 +97,6 @@ module ResultsHelper
   # @return [Boolean] True if the result has links, availability, or ThirdIron/OpenAlex triggers
   def result_get?(result)
     renderable_links?(result) ||
-      AlmaSru.valid_alma_id?(result[:identifier]) ||
       (Feature.enabled?(:oa_always) && article?(result[:format])) ||
       thirdiron_content?(result)
   end

--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -1,10 +1,28 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = { url: String }
+  static values = { url: String, lazyLoading: Boolean }
 
   connect() {
-    this.load()
+    if (this.lazyLoadingValue) {
+      // The content loader included a lazy loading directive.
+      this.observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            this.load()
+            this.observer.disconnect()
+          }
+        }
+      )
+      this.observer.observe(this.element)
+    } else {
+      // Load the content immediately.
+      this.load()
+    }
+  }
+
+  disconnect() {
+    this.observer?.disconnect()
   }
 
   load() {

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -27,7 +27,10 @@ class AlmaSru
     return [] unless enabled?
 
     # Validate the raw identifier received. This will raise an InvalidAlmaId if validation fails.
-    identifier = validate_alma_id(raw_identifier)
+    raise InvalidAlmaId unless valid_alma_id?(raw_identifier)
+
+    # Extract numeric portion from provided raw identifier
+    identifier = extract_alma_id(raw_identifier)
 
     # Build URL
     url = alma_sru_url(identifier)
@@ -69,23 +72,6 @@ class AlmaSru
     parsed_availabilities = fetch_availabilities(parsed)
 
     parsed_availabilities.map(&method(:format_availability))
-  end
-
-  # validate_alma_id ensures we are only submitting valid Alma IDs to the SRU endpoint.
-  #
-  # It needs to do two things:
-  # 1. Remove the "alma" prefix if one is present. Otherwise, no manipulation of the submitted value should occur.
-  # 2. Enforce the formatting requirements for a valid alma identifier (start with "99", and end with "6761").
-  def self.validate_alma_id(raw)
-    parsed = if raw.to_s.start_with?('alma')
-               raw.delete_prefix('alma')
-             else
-               raw
-             end
-
-    raise InvalidAlmaId unless parsed.present? && parsed.match?(/\A99\d+6761\z/)
-
-    parsed
   end
 
   # ava_to_hash takes an XML element that represents a single availability record
@@ -149,6 +135,37 @@ class AlmaSru
     end
 
     true
+  end
+
+  # extract_alma_id receives a hypothetical document ID that references an alma
+  # record, and strips out any `alma` prefix which _may_ exist. This is a
+  # compensating strategy for our discovery environment attaching this prefix to
+  # flag the record as coming from alma, rather than other collections.
+  def self.extract_alma_id(raw)
+    if raw.to_s.start_with?('alma')
+      raw.to_s.delete_prefix('alma')
+    else
+      raw.to_s
+    end
+  end
+
+  # valid_alma_id? receives a document identifier and attempts to determine
+  # whether it is a reference to an alma document. This involves using a regular
+  # expression to confirm five attributes:
+  # 1. The identifier can be converted to a string
+  # 2. The identifier may begin with "alma"
+  # 3. After any "alma" prefix, the next two characters must be "99"
+  # 4. Following this must be a sequence of only digits
+  # 5. The identifier must end with "6761"
+  #
+  # The method returns "true" if all of these conditions are met, otherwise it
+  # returns "false". No further action is taken for failing results, as this
+  # method is called for a wide range of identifiers.
+  def self.valid_alma_id?(raw)
+    return false unless raw.present?
+    return true if raw.to_s.match?(/\A(alma)?99\d+6761\z/)
+
+    false
   end
 
   def self.alma_sru_url(identifier)

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -24,7 +24,7 @@ class AlmaSru
   #
   # It accepts an "alma_client" argument for use when testing, but this is not used in normal operations.
   def self.lookup(raw_identifier, alma_client: nil)
-    return [] unless alma_sru_enabled?
+    return [] unless enabled?
 
     # Validate the raw identifier received. This will raise an InvalidAlmaId if validation fails.
     identifier = validate_alma_id(raw_identifier)
@@ -142,7 +142,7 @@ class AlmaSru
     ENV.fetch('MIT_ALMA_URL', nil)
   end
 
-  def self.alma_sru_enabled?
+  def self.enabled?
     if alma_base_url.to_s.empty? || exl_inst_id.to_s.empty?
       Sentry.capture_message('Alma SRU not enabled')
       return false

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -71,7 +71,12 @@ class AlmaSru
     # Look up all AVA tags
     parsed_availabilities = fetch_availabilities(parsed)
 
-    parsed_availabilities.map(&method(:format_availability))
+    # Format list of entries
+    results = parsed_availabilities.map(&method(:format_availability))
+
+    # Reduce list to a single item if multiples exist
+    results[0] += ' and other locations' if results.length > 1
+    results.first(1)
   end
 
   # ava_to_hash takes an XML element that represents a single availability record

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -123,8 +123,9 @@ class AlmaSru
       return ''
     end
 
-    phrase = "#{_phrase_start(availability['e'])} <strong>#{availability['q']}</strong> #{availability['c']}".squish
-    phrase += " (#{availability['d']})" if availability['d'].present?
+    phrase = "#{_phrase_start(ERB::Util.html_escape(availability['e'].to_s))} <strong>#{ERB::Util.html_escape(availability['q'].to_s)}</strong> " \
+             "#{ERB::Util.html_escape(availability['c'].to_s)}".squish
+    phrase += " (#{ERB::Util.html_escape(availability['d'].to_s)})" if availability['d'].present?
     phrase
   end
 
@@ -151,12 +152,12 @@ class AlmaSru
   end
 
   def self.enabled?
-    if alma_base_url.to_s.empty? || exl_inst_id.to_s.empty?
-      Sentry.capture_message('Alma SRU not enabled')
-      return false
-    end
+    return @enabled if instance_variable_defined?(:@enabled)
 
-    true
+    @enabled = alma_base_url.to_s.present? && exl_inst_id.to_s.present?
+    Sentry.capture_message('Alma SRU not enabled') unless @enabled
+
+    @enabled
   end
 
   # extract_alma_id receives a hypothetical document ID that references an alma

--- a/app/models/alma_sru.rb
+++ b/app/models/alma_sru.rb
@@ -123,10 +123,27 @@ class AlmaSru
       return ''
     end
 
-    phrase = "#{availability['e']&.humanize} at #{availability['q']} #{availability['c']}".squish
+    phrase = "#{_phrase_start(availability['e'])} <strong>#{availability['q']}</strong> #{availability['c']}".squish
     phrase += " (#{availability['d']})" if availability['d'].present?
-
     phrase
+  end
+
+  def self._phrase_start(status)
+    case status
+    when 'available'
+      "#{_icon('check')} Available in "
+    when 'check_holdings'
+      "#{_icon('question')} May be available in "
+    when 'unavailable'
+      "#{_icon('times')} Not currently available in "
+    else
+      Rails.logger.error("Unhandled availability status: #{status}")
+      "#{_icon('question')} Uncertain availability (#{status.humanize}) in "
+    end
+  end
+
+  def self._icon(icon, collection = 'fa-sharp fa-solid')
+    "<i class='#{collection} fa-#{icon}' aria-hidden='true'></i>"
   end
 
   def self.alma_base_url

--- a/app/models/normalize_primo_record.rb
+++ b/app/models/normalize_primo_record.rb
@@ -31,8 +31,6 @@ class NormalizePrimoRecord
       numbering:,
       chapter_numbering:,
       thumbnail:,
-      availability:,
-      other_availability:,
       dedup_record: dedup_url.present?
     }
   end
@@ -315,20 +313,6 @@ class NormalizePrimoRecord
 
     subs = @record['pnx']['display']['subject']
     subs.flat_map { |sub| sub.split(' ;  ') }
-  end
-
-  def availability
-    return unless location
-
-    @record['delivery']['bestlocation']['availabilityStatus']
-  end
-
-  def other_availability
-    return unless @record['delivery']
-    return unless @record['delivery']['bestlocation']
-    return unless @record['delivery']['holding']
-
-    @record['delivery']['holding'].length > 1
   end
 
   # FRBR Group check based on:

--- a/app/views/alma/sru.html.erb
+++ b/app/views/alma/sru.html.erb
@@ -1,7 +1,9 @@
 <% if AlmaSru.enabled? && @availability.present? %>
   <div class="availability">
     <% @availability.each do |statement| %>
-      <%= link_to(statement.html_safe, "#{PrimoLinkBuilder.new(record_id: params[:doc_id], context: 'L').full_record_link}#getit_link1_0", data: {content_piece: 'Availability Link' }) %><br>
+      <%= link_to(sanitize(statement, tags: %w[i strong], attributes: %w[class aria-hidden]),
+                  "#{PrimoLinkBuilder.new(record_id: params[:doc_id], context: 'L').full_record_link}#getit_link1_0",
+                  data: {content_piece: 'Availability Link' }) %><br>
     <% end %>
   </div>
 <% end %>

--- a/app/views/alma/sru.html.erb
+++ b/app/views/alma/sru.html.erb
@@ -1,9 +1,9 @@
 <% if AlmaSru.enabled? && @availability.present? %>
   <div class="availability">
     <% @availability.each do |statement| %>
-      <%= link_to(sanitize(statement, tags: %w[i strong], attributes: %w[class aria-hidden]),
+      <p><%= link_to(sanitize(statement, tags: %w[i strong], attributes: %w[class aria-hidden]),
                   "#{PrimoLinkBuilder.new(record_id: params[:doc_id], context: 'L').full_record_link}#getit_link1_0",
-                  data: {content_piece: 'Availability Link' }) %><br>
+                  data: {content_piece: 'Availability Link' }) %></p>
     <% end %>
   </div>
 <% end %>

--- a/app/views/alma/sru.html.erb
+++ b/app/views/alma/sru.html.erb
@@ -1,0 +1,7 @@
+<% if AlmaSru.enabled? && @availability.present? %>
+  <div class="availability">
+    <% @availability.each do |statement| %>
+      <%= link_to(statement, '#', data: {content_piece: 'Availability Link' }) %><br>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/alma/sru.html.erb
+++ b/app/views/alma/sru.html.erb
@@ -1,7 +1,7 @@
 <% if AlmaSru.enabled? && @availability.present? %>
   <div class="availability">
     <% @availability.each do |statement| %>
-      <%= link_to(statement, "#{PrimoLinkBuilder.new(record_id: params[:doc_id], context: 'L').full_record_link}#getit_link1_0", data: {content_piece: 'Availability Link' }) %><br>
+      <%= link_to(statement.html_safe, "#{PrimoLinkBuilder.new(record_id: params[:doc_id], context: 'L').full_record_link}#getit_link1_0", data: {content_piece: 'Availability Link' }) %><br>
     <% end %>
   </div>
 <% end %>

--- a/app/views/alma/sru.html.erb
+++ b/app/views/alma/sru.html.erb
@@ -1,7 +1,7 @@
 <% if AlmaSru.enabled? && @availability.present? %>
   <div class="availability">
     <% @availability.each do |statement| %>
-      <%= link_to(statement, '#', data: {content_piece: 'Availability Link' }) %><br>
+      <%= link_to(statement, "#{PrimoLinkBuilder.new(record_id: params[:doc_id], context: 'L').full_record_link}#getit_link1_0", data: {content_piece: 'Availability Link' }) %><br>
     <% end %>
   </div>
 <% end %>

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -113,16 +113,6 @@
           <%= render(partial: 'trigger_almasru', locals: { doc_id: result[:identifier] }) %>
         <% end %>
 
-        <% if result[:availability].present? %>
-          <div class="availability">
-          <% if result[:links]&.find { |link| link['kind'] == 'full record' } %>
-            <%= link_to(availability(result[:availability], result[:location], result[:other_availability]), result[:links].find { |link| link['kind'] == 'full record' }['url'], data: { content_piece: 'Availability Link' }) %>
-          <% else %>
-            <%= availability(result[:availability], result[:location], result[:other_availability]) %>
-          <% end %>
-          </div>
-        <% end %>
-
         <%# Trigger BrowZine lookup (render inside result-get so injected HTML
             is part of the flex `.result-get` area and receives expected styles) %>
         <% if ThirdIron.enabled? && result[:format].downcase == 'journal' && result[:issn].present? %>

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -109,7 +109,7 @@
           <%= render(partial: 'trigger_openalex_setup', locals: { doi: result[:doi], pmid: result[:pmid] }) %>
         <% end %>
 
-        <% if AlmaSru.enabled? %>
+        <% if AlmaSru.enabled? && AlmaSru.valid_alma_id?(result[:identifier]) %>
           <%= render(partial: 'trigger_almasru', locals: { doc_id: result[:identifier] }) %>
         <% end %>
 

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -78,6 +78,9 @@
         <% end %>
       </div>
 
+      <% if AlmaSru.enabled? && AlmaSru.valid_alma_id?(result[:identifier]) %>
+        <%= render(partial: 'trigger_almasru', locals: { doc_id: result[:identifier] }) %>
+      <% end %>
 
       <% if result_get?(result) %>
       <div class="result-get">
@@ -107,10 +110,6 @@
         <%# Only show OpenAccess links for articles %>
         <% if Feature.enabled?(:oa_always) && article?(result[:format]) %>
           <%= render(partial: 'trigger_openalex_setup', locals: { doi: result[:doi], pmid: result[:pmid] }) %>
-        <% end %>
-
-        <% if AlmaSru.enabled? && AlmaSru.valid_alma_id?(result[:identifier]) %>
-          <%= render(partial: 'trigger_almasru', locals: { doc_id: result[:identifier] }) %>
         <% end %>
 
         <%# Trigger BrowZine lookup (render inside result-get so injected HTML

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -109,6 +109,10 @@
           <%= render(partial: 'trigger_openalex_setup', locals: { doi: result[:doi], pmid: result[:pmid] }) %>
         <% end %>
 
+        <% if AlmaSru.enabled? %>
+          <%= render(partial: 'trigger_almasru', locals: { doc_id: result[:identifier] }) %>
+        <% end %>
+
         <% if result[:availability].present? %>
           <div class="availability">
           <% if result[:links]&.find { |link| link['kind'] == 'full record' } %>

--- a/app/views/search/_trigger_almasru.html.erb
+++ b/app/views/search/_trigger_almasru.html.erb
@@ -1,6 +1,6 @@
 <% return unless AlmaSru.enabled? %>
 
-<% data_url = "/almasru?doc_id=#{doc_id}" %>
+<% data_url = almasru_path(doc_id: doc_id) %>
 
 <span class="availability-container"
   data-controller="content-loader"

--- a/app/views/search/_trigger_almasru.html.erb
+++ b/app/views/search/_trigger_almasru.html.erb
@@ -4,6 +4,7 @@
 
 <span class="availability-container"
   data-controller="content-loader"
-  data-content-loader-url-value=<%= data_url %>>
+  data-content-loader-url-value="<%= data_url %>"
+  data-content-loader-lazy-loading-value="">
     <span class="skeleton-loader">&nbsp;</span>
 </span>

--- a/app/views/search/_trigger_almasru.html.erb
+++ b/app/views/search/_trigger_almasru.html.erb
@@ -1,0 +1,9 @@
+<% return unless AlmaSru.enabled? %>
+
+<% data_url = "/almasru?doc_id=#{doc_id}" %>
+
+<span class="availability-container"
+  data-controller="content-loader"
+  data-content-loader-url-value=<%= data_url %>>
+    <span class="skeleton-loader">&nbsp;</span>
+</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
 
   get 'analyze', to: 'tacos#analyze'
 
-  get 'libkey', to: 'thirdiron#libkey'
+  get 'almasru', to: 'alma#sru'
   get 'browzine', to: 'thirdiron#browzine'
+  get 'libkey', to: 'thirdiron#libkey'
   get 'oa_work', to: 'openalex#work'
 
   get 'record/(:id)',

--- a/test/controllers/alma_controller_test.rb
+++ b/test/controllers/alma_controller_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class AlmaControllerTest < ActionDispatch::IntegrationTest
+  test 'alma sru route exists with no content' do
+    get almasru_path
+
+    assert :success
+    assert response.body.blank?
+  end
+
+  test 'alma sru route returns nothing for gibberish content' do
+    needle = 'foo'
+    get almasru_path(doc_id: needle)
+
+    assert :success
+    assert response.body.blank?
+  end
+
+  test 'alma sru route returns nothing if lookup returns content with no AVA' do
+    VCR.use_cassette('alma sru no availability') do
+      needle = 'alma9935053423706761'
+      get almasru_path(doc_id: needle)
+
+      assert :success
+      assert response.body.blank?
+    end
+  end
+
+  test 'alma sru route returns HTML for successful lookup' do
+    VCR.use_cassette('alma sru single record') do
+      needle = 'alma990014651640106761'
+      get almasru_path(doc_id: needle)
+
+      assert :success
+      assert_select 'div.availability a', { count: 1 }
+    end
+  end
+
+  test 'alma sru route returns multiple statements with multiple AVA' do
+    VCR.use_cassette('alma sru multiple records') do
+      needle = 'alma990002935920106761'
+      get almasru_path(doc_id: needle)
+
+      assert :success
+      assert_select 'div.availability a', { count: 2 }
+    end
+  end
+
+  test 'alma sru route does nothing for valid id if required env undefined' do
+    VCR.use_cassette('alma sru single record') do
+      needle = 'alma990014651640106761'
+      get almasru_path(doc_id: needle)
+
+      assert :success
+      refute response.body.blank?
+
+      ClimateControl.modify(MIT_ALMA_URL: nil) do
+        get almasru_path(doc_id: needle)
+
+        assert :success
+        assert response.body.blank?
+      end
+    end
+  end
+end

--- a/test/controllers/alma_controller_test.rb
+++ b/test/controllers/alma_controller_test.rb
@@ -33,16 +33,18 @@ class AlmaControllerTest < ActionDispatch::IntegrationTest
 
       assert :success
       assert_select 'div.availability a', { count: 1 }
+      refute_includes response.body, 'and other locations'
     end
   end
 
-  test 'alma sru route returns multiple statements with multiple AVA' do
+  test 'alma sru route returns one statement including "and other locations" with multiple AVA' do
     VCR.use_cassette('alma sru multiple records') do
       needle = 'alma990002935920106761'
       get almasru_path(doc_id: needle)
 
       assert :success
-      assert_select 'div.availability a', { count: 2 }
+      assert_select 'div.availability a', { count: 1 }
+      assert_includes response.body, 'and other locations'
     end
   end
 

--- a/test/controllers/alma_controller_test.rb
+++ b/test/controllers/alma_controller_test.rb
@@ -4,7 +4,7 @@ class AlmaControllerTest < ActionDispatch::IntegrationTest
   test 'alma sru route exists with no content' do
     get almasru_path
 
-    assert :success
+    assert_response :success
     assert response.body.blank?
   end
 
@@ -12,7 +12,7 @@ class AlmaControllerTest < ActionDispatch::IntegrationTest
     needle = 'foo'
     get almasru_path(doc_id: needle)
 
-    assert :success
+    assert_response :success
     assert response.body.blank?
   end
 
@@ -21,7 +21,7 @@ class AlmaControllerTest < ActionDispatch::IntegrationTest
       needle = 'alma9935053423706761'
       get almasru_path(doc_id: needle)
 
-      assert :success
+      assert_response :success
       assert response.body.blank?
     end
   end
@@ -31,7 +31,7 @@ class AlmaControllerTest < ActionDispatch::IntegrationTest
       needle = 'alma990014651640106761'
       get almasru_path(doc_id: needle)
 
-      assert :success
+      assert_response :success
       assert_select 'div.availability a', { count: 1 }
       refute_includes response.body, 'and other locations'
     end
@@ -42,7 +42,7 @@ class AlmaControllerTest < ActionDispatch::IntegrationTest
       needle = 'alma990002935920106761'
       get almasru_path(doc_id: needle)
 
-      assert :success
+      assert_response :success
       assert_select 'div.availability a', { count: 1 }
       assert_includes response.body, 'and other locations'
     end
@@ -53,13 +53,13 @@ class AlmaControllerTest < ActionDispatch::IntegrationTest
       needle = 'alma990014651640106761'
       get almasru_path(doc_id: needle)
 
-      assert :success
+      assert_response :success
       refute response.body.blank?
 
       ClimateControl.modify(MIT_ALMA_URL: nil) do
         get almasru_path(doc_id: needle)
 
-        assert :success
+        assert_response :success
         assert response.body.blank?
       end
     end

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -360,7 +360,7 @@ class RecordHelperTest < ActionView::TestCase
   end
 
   test 'icon helper generates properly formatted HTML' do
-    expected = "<i class='fa-sharp fa-solid fa-question' aria-hidden='true''></i>"
+    expected = "<i class='fa-sharp fa-solid fa-question' aria-hidden='true'></i>"
     assert_equal expected, icon('question')
   end
 end

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -342,30 +342,6 @@ class RecordHelperTest < ActionView::TestCase
     assert_nil deduplicate_subjects(subjects)
   end
 
-  test 'availability helper handles known statuses correctly' do
-    location = {
-      name: 'Main Library',
-      collection: 'First Floor',
-      call_number: 'QA76.73.R83 2023'
-    }
-
-    available_blurb = availability('available', location, false)
-    assert_includes available_blurb, 'Available in'
-    assert_includes available_blurb, location(location)
-
-    check_holdings_blurb = availability('check_holdings', location, false)
-    assert_includes check_holdings_blurb, 'May be available in'
-    assert_includes check_holdings_blurb, location(location)
-
-    unavailable_blurb = availability('unavailable', location, false)
-    assert_includes unavailable_blurb, 'Not currently available in'
-    assert_includes unavailable_blurb, location(location)
-
-    unknown_blurb = availability('unknown_status', location, false)
-    assert_includes unknown_blurb, 'Uncertain availability in'
-    assert_includes unknown_blurb, location(location)
-  end
-
   test 'icon helper returns fontawesome icon with default sharp solid collection' do
     icon_html = icon('check')
     assert_includes icon_html, 'fa-sharp'

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -116,8 +116,8 @@ class ResultsHelperTest < ActionView::TestCase
     assert result_get?({ links: [{ 'kind' => 'PDF', 'url' => 'https://example.com' }] })
   end
 
-  test 'result_get? returns true when result has availability' do
-    assert result_get?({ availability: 'Available' })
+  test 'result_get? returns true when result has a valid Alma ID' do
+    assert result_get?({ identifier: 'alma9912346761' })
   end
 
   test 'result_get? returns true when ThirdIron enabled and result has doi' do

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -116,8 +116,8 @@ class ResultsHelperTest < ActionView::TestCase
     assert result_get?({ links: [{ 'kind' => 'PDF', 'url' => 'https://example.com' }] })
   end
 
-  test 'result_get? returns true when result has a valid Alma ID' do
-    assert result_get?({ identifier: 'alma9912346761' })
+  test 'result_get? does not activate because of a valid Alma ID' do
+    assert_not result_get?({ identifier: 'alma9912346761' })
   end
 
   test 'result_get? returns true when ThirdIron enabled and result has doi' do

--- a/test/models/alma_sru_test.rb
+++ b/test/models/alma_sru_test.rb
@@ -45,14 +45,17 @@ class AlmaSruTest < ActiveSupport::TestCase
     end
   end
 
-  test 'lookup returns self-service locations first if multiples exist' do
+  test 'lookup returns a single entry, prioritizing self-service locations first, if multiples exist' do
     VCR.use_cassette('alma sru multiple records') do
       needle = '990002935920106761'
 
       result = AlmaSru.lookup(needle)
 
-      assert_equal('Check holdings at Barker Library Staff Retrieval - request required (FICHE No Call #)', result[0])
-      assert_equal('Available at Library Storage Annex Journal Collection (LSA4) (TA.J86.H437)', result[1])
+      assert_equal(1, result.length)
+      assert_equal(
+        'Check holdings at Barker Library Staff Retrieval - request required (FICHE No Call #) and other locations',
+        result[0]
+      )
     end
   end
 
@@ -150,11 +153,13 @@ class AlmaSruTest < ActiveSupport::TestCase
 
   # valid_alma_id? method
   test 'valid_alma_id? returns true for valid inputs' do
+    # rubocop:disable Style/NumericLiterals
     needles = [
       990002935920106761,
       '990002935920106761',
       'alma990002935920106761'
     ]
+    # rubocop:enable Style/NumericLiterals
 
     needles.each do |needle|
       assert_equal(true, AlmaSru.valid_alma_id?(needle))

--- a/test/models/alma_sru_test.rb
+++ b/test/models/alma_sru_test.rb
@@ -99,6 +99,8 @@ class AlmaSruTest < ActiveSupport::TestCase
     end
 
     ClimateControl.modify(EXL_INST_ID: nil) do
+      AlmaSru.remove_instance_variable(:@enabled)
+
       assert_equal([], AlmaSru.lookup(needle))
     end
   end

--- a/test/models/alma_sru_test.rb
+++ b/test/models/alma_sru_test.rb
@@ -41,7 +41,10 @@ class AlmaSruTest < ActiveSupport::TestCase
 
       result = AlmaSru.lookup(needle)
 
-      assert_equal(['Available at Rotch Library Stacks (NA680.C25 2007)'], result)
+      assert_equal(
+        ["<i class='fa-sharp fa-solid fa-check' aria-hidden='true'></i> Available in <strong>Rotch Library</strong> Stacks (NA680.C25 2007)"],
+        result
+      )
     end
   end
 
@@ -52,10 +55,7 @@ class AlmaSruTest < ActiveSupport::TestCase
       result = AlmaSru.lookup(needle)
 
       assert_equal(1, result.length)
-      assert_equal(
-        'Check holdings at Barker Library Staff Retrieval - request required (FICHE No Call #) and other locations',
-        result[0]
-      )
+      assert_includes result[0], 'and other locations'
     end
   end
 
@@ -226,20 +226,60 @@ class AlmaSruTest < ActiveSupport::TestCase
     ava_hash = {
       'c' => 'charlie',
       'd' => 'delta',
-      'e' => 'echo',
+      'e' => 'available',
       'q' => 'quebec'
     }
 
-    assert_equal('Echo at quebec charlie (delta)', AlmaSru.format_availability(ava_hash))
+    assert_equal(
+      "<i class='fa-sharp fa-solid fa-check' aria-hidden='true'></i> Available in <strong>quebec</strong> charlie (delta)",
+      AlmaSru.format_availability(ava_hash)
+    )
   end
 
   test 'format_availability returns a minimum statement if only e and q are present' do
+    ava_hash = {
+      'e' => 'available',
+      'q' => 'quebec'
+    }
+
+    assert_equal("<i class='fa-sharp fa-solid fa-check' aria-hidden='true'></i> Available in <strong>quebec</strong>",
+                 AlmaSru.format_availability(ava_hash))
+  end
+
+  test 'format_availability supports check_holdings status' do
+    ava_hash = {
+      'e' => 'check_holdings',
+      'q' => 'quebec'
+    }
+
+    assert_equal(
+      "<i class='fa-sharp fa-solid fa-question' aria-hidden='true'></i> May be available in <strong>quebec</strong>",
+      AlmaSru.format_availability(ava_hash)
+    )
+  end
+
+  test 'format_availability supports unavailable status' do
+    ava_hash = {
+      'e' => 'unavailable',
+      'q' => 'quebec'
+    }
+
+    assert_equal(
+      "<i class='fa-sharp fa-solid fa-times' aria-hidden='true'></i> Not currently available in <strong>quebec</strong>",
+      AlmaSru.format_availability(ava_hash)
+    )
+  end
+
+  test 'format_availability does not fail with unexpected status' do
     ava_hash = {
       'e' => 'echo',
       'q' => 'quebec'
     }
 
-    assert_equal('Echo at quebec', AlmaSru.format_availability(ava_hash))
+    assert_equal(
+      "<i class='fa-sharp fa-solid fa-question' aria-hidden='true'></i> Uncertain availability (Echo) in <strong>quebec</strong>",
+      AlmaSru.format_availability(ava_hash)
+    )
   end
 
   test 'format_availability returns an empty string without both e and q present' do

--- a/test/models/alma_sru_test.rb
+++ b/test/models/alma_sru_test.rb
@@ -148,59 +148,32 @@ class AlmaSruTest < ActiveSupport::TestCase
     end
   end
 
-  # validate_alma_id method
-  test 'validate_alma_id succeeds with valid numeric input' do
-    needle = '990002935920106761'
-    assert_nothing_raised do
-      AlmaSru.validate_alma_id(needle)
+  # valid_alma_id? method
+  test 'valid_alma_id? returns true for valid inputs' do
+    needles = [
+      990002935920106761,
+      '990002935920106761',
+      'alma990002935920106761'
+    ]
+
+    needles.each do |needle|
+      assert_equal(true, AlmaSru.valid_alma_id?(needle))
     end
   end
 
-  test 'validate_alma_id succeeds despite an "alma" prefix' do
-    needle = 'alma990002935920106761'
-    assert_nothing_raised do
-      AlmaSru.validate_alma_id(needle)
-    end
-  end
+  test 'valid_alma_id? returns false for invalid inputs' do
+    needles = [
+      nil,
+      'cdi_econis_primary_1902984668',   # wildly nonconforming
+      '99000293foo5920106761',           # non-numeric internals
+      '0002935920106761',                # missing start sequence
+      'alma0002935920106761',            # missing start sequence
+      '99000293592010',                  # missing end sequence
+      'alma99000293592010'               # missing end sequence
+    ]
 
-  test 'validate_alma_id raises InvalidAlmaId with non-numeric id' do
-    needle = '99000293foo5920106761'
-
-    assert_raises(AlmaSru::InvalidAlmaId) do
-      AlmaSru.validate_alma_id(needle)
-    end
-  end
-
-  test 'validate_alma_id raises InvalidAlmaId with a nil input' do
-    needle = nil
-    assert_raises(AlmaSru::InvalidAlmaId) do
-      AlmaSru.validate_alma_id(needle)
-    end
-  end
-
-  test 'validate_alma_id raises InvalidAlmaId without required start sequence' do
-    assert_raises(AlmaSru::InvalidAlmaId) do
-      AlmaSru.validate_alma_id('0002935920106761')
-    end
-
-    assert_raises(AlmaSru::InvalidAlmaId) do
-      AlmaSru.validate_alma_id('alma0002935920106761')
-    end
-  end
-
-  test 'validate_alma_id raises InvalidAlmaId without required end sequence' do
-    assert_raises(AlmaSru::InvalidAlmaId) do
-      AlmaSru.validate_alma_id('99000293592010')
-    end
-
-    assert_raises(AlmaSru::InvalidAlmaId) do
-      AlmaSru.validate_alma_id('alma99000293592010')
-    end
-  end
-
-  test 'validate_alma_id raises InvalidAlmaId with wildly invalid input' do
-    assert_raises(AlmaSru::InvalidAlmaId) do
-      AlmaSru.validate_alma_id('foo')
+    needles.each do |needle|
+      assert_equal(false, AlmaSru.valid_alma_id?(needle))
     end
   end
 

--- a/test/models/normalize_primo_record_test.rb
+++ b/test/models/normalize_primo_record_test.rb
@@ -272,26 +272,6 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
     assert_empty normalized[:subjects]
   end
 
-  test 'returns availability status' do
-    normalized = NormalizePrimoRecord.new(full_record, 'test').normalize
-    assert_equal 'available', normalized[:availability]
-  end
-
-  test 'handles missing availability' do
-    normalized = NormalizePrimoRecord.new(minimal_record, 'test').normalize
-    assert_nil normalized[:availability]
-  end
-
-  test 'detects other availability when multiple holdings exist' do
-    normalized = NormalizePrimoRecord.new(full_record, 'test').normalize
-    assert normalized[:other_availability]
-  end
-
-  test 'handles missing other availability' do
-    normalized = NormalizePrimoRecord.new(minimal_record, 'test').normalize
-    assert_nil normalized[:other_availability]
-  end
-
   test 'uses dedup URL as full record link for frbrized records' do
     normalized = NormalizePrimoRecord.new(full_record, 'test').normalize
     full_record_link = normalized[:links].find { |link| link['kind'] == 'full record' }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,10 @@ class ActiveSupport::TestCase
   setup do
     Rails.cache.clear
   end
+
+  def teardown
+    AlmaSru.remove_instance_variable(:@enabled) if AlmaSru.instance_variable_defined?(:@enabled)
+  end
 end
 
 # Helper factory to create simple stub fetchers for `MergedSearchService` tests.


### PR DESCRIPTION
This integrates the recently-added `AlmaSru` model with the UI, restoring the availability statements for users to see. This involves:

1. Defining a lookup route `/almasru` which invokes the lookup method
2. Adding a _trigger pattern on the Primo result partial that will invoke this lookup route when needed

In service of these goals, a few other changes get introduced:

3. The content loader stimulus controller gets added support for lazy loading, which gets activated by adding `data-content-loader-lazy-loading-value=""` to the tag which calls the controller.
4. The AlmaSru model gets its validation and extraction logic altered, so that there is an externally-callable `valid_alma_id?()` method. The UI leverages this to make sure we only ask for this lookup when the ID seems relevant (there's no way to know from just an identifier whether a record will _actually_ have an availability block - but we can tell when a record comes from Alma).

Side effects:
* The availability statement rendering gets moved outside of the div which contains all the fulfillment links, and the relevant `result_get?` helper method no longer checks for document ID format. This layout strategy was identified while pairing with Dave, and this feels like the best implementation option at the moment. We may need a ticket to return to the link styling in the future when Dave has more bandwidth.
* The guard clauses around this integration are a little inconsistent at the moment. I don't think any of the calculations are horribly inefficient, so I think it's probably fine - but I'd welcome some specific attention on this point.
* The "enabled?" method on `AlmaSru` gets renamed from `.alma_sru_enabled?` to just `.enabled?`
* I alphabetized the lookup routes in config/routes.rb

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [x] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Do searches in the review app (or when running locally), and watch the network traffic in your dev tools. You should see lazy-loading happening, and you should _only_ see this happening for records with Alma docIDs. This should happen across tabs.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
