### PR TITLE
Convert trigger partials to lazy-loading

### DIFF
--- a/app/views/search/_trigger_browzine.html.erb
+++ b/app/views/search/_trigger_browzine.html.erb
@@ -6,6 +6,7 @@
 
 <span class="libkey-container"
      data-controller="content-loader"
-     data-content-loader-url-value=<%= data_url %>>
+     data-content-loader-url-value="<%= data_url %>"
+     data-content-loader-lazy-loading-value="">
      <span class="skeleton-loader">&nbsp;</span>
 </span>

--- a/app/views/search/_trigger_libkey.html.erb
+++ b/app/views/search/_trigger_libkey.html.erb
@@ -6,6 +6,7 @@
 
 <span class="libkey-container"
      data-controller="content-loader"
-     data-content-loader-url-value=<%= data_url %>>
+     data-content-loader-url-value="<%= data_url %>"
+     data-content-loader-lazy-loading-value="">
      <span class="skeleton-loader">&nbsp;</span>
 </span>

--- a/app/views/search/_trigger_openalex.html.erb
+++ b/app/views/search/_trigger_openalex.html.erb
@@ -4,6 +4,7 @@
 
 <span class="openalex-container"
      data-controller="content-loader"
-     data-content-loader-url-value=<%= data_url %>>
+     data-content-loader-url-value="<%= data_url %>"
+     data-content-loader-lazy-loading-value="">
      <span class="skeleton-loader">&nbsp;</span>
 </span>


### PR DESCRIPTION
We recently added support for lazy loading to our content loading controller. This allows us to convert a number of partials that consult external APIs to lazy-loading, which will spread out (and likely lessen) the load on those APIs and make us a better consumer.

**Relevant ticket(s):**

https://mitlibraries.atlassian.net/browse/use-623

**How does this address that need:**

This adds the attribute for lazy-loading to the trigger partials for Browzine, Libkey, and Openalex.

**Document any side effects to this change:**

This also adds quotes around the data_url value used to specify the endpoint to be loaded. I was tempted to change how the URLs themselves are constructed (following the pattern of the almasru endpoint), but have decided not to pull that thread for now.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [x] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
       _(During review the lack of an alt attribute on the open access image was flagged - looking for a ticket for this now)_
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Open the network tab for the preview build, do some searches, and watch the lazy-loading happen. The URL paths to isolate are `/libkey?`, `/browzine?`, and `/oa_work?`

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
