### PR TITLE
Use domain cookies for nls opt-in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_natural_language_search_optin
-    @natural_language_search_optin = cookies[:natural_language_search_optin] == 'true'
+    @natural_language_search_optin = cookies[:nls_enabled] == 'true'
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,7 +17,7 @@ class SearchController < ApplicationController
     params[:booleanType] = cookies[:boolean_type] || 'AND'
 
     # inject hybrid queryMode if opted-in and no queryMode param provided
-    params[:queryMode] = 'hybrid' if params[:queryMode].blank? && cookies[:natural_language_search_optin] == 'true'
+    params[:queryMode] = 'hybrid' if params[:queryMode].blank? && cookies[:nls_enabled] == 'true'
 
     @enhanced_query = Enhancer.new(params).enhanced_query
     @show_nls_warning = show_nls_warning?

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -18,10 +18,16 @@ class StaticController < ApplicationController
   def natural_language_search_optin
     optin = params[:natural_language_search_optin]
     if %w[true false].include?(optin)
-      cookies[:natural_language_search_optin] = optin
+      nls_cookie_options = use_domain_cookies? ? { value: optin, domain: :all } : optin
+      cookies[:nls_enabled] = nls_cookie_options
     else
-      cookies.delete :natural_language_search_optin
+      cookies.delete :nls_enabled, domain: :all if use_domain_cookies?
+      cookies.delete :nls_enabled unless use_domain_cookies?
     end
+
+    # Clean up old cookie name for users migrating to domain cookies
+    # Note: delete this in a future release after users have had time to migrate
+    cookies.delete :natural_language_search_optin
 
     # Redirect to return_to param if it's a safe local path, otherwise root
     return_to = params[:return_to].presence
@@ -38,5 +44,12 @@ class StaticController < ApplicationController
       end
     end
     redirect_to(safe_return_to || root_path)
+  end
+
+  private
+
+  def use_domain_cookies?
+    host = request.host.to_s.downcase
+    host == 'libraries.mit.edu' || host.end_with?('.libraries.mit.edu')
   end
 end

--- a/test/controllers/natural_language_search_optin_test.rb
+++ b/test/controllers/natural_language_search_optin_test.rb
@@ -53,24 +53,24 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
   test 'route with natural_language_search_optin=true sets cookie' do
     get '/natural_language_search_optin?natural_language_search_optin=true'
     assert_response :redirect
-    assert_equal cookies['natural_language_search_optin'], 'true'
+    assert_equal cookies['nls_enabled'], 'true'
   end
 
   test 'route with natural_language_search_optin=false sets cookie to false' do
     get '/natural_language_search_optin?natural_language_search_optin=false'
     assert_response :redirect
-    assert_equal cookies['natural_language_search_optin'], 'false'
+    assert_equal cookies['nls_enabled'], 'false'
   end
 
   test 'route with no parameter deletes cookie' do
     get '/natural_language_search_optin?natural_language_search_optin=true'
-    assert_equal cookies['natural_language_search_optin'], 'true'
+    assert_equal cookies['nls_enabled'], 'true'
 
     get '/natural_language_search_optin'
     assert_response :redirect
 
     # Rails sets cookies to empty string when deleted via cookies.delete
-    assert(cookies['natural_language_search_optin'].blank?)
+    assert(cookies['nls_enabled'].blank?)
   end
 
   test 'route redirects to return_to when provided' do
@@ -162,24 +162,24 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
 
   test 'URL param queryMode overrides cookie' do
     get '/natural_language_search_optin?natural_language_search_optin=true'
-    assert_equal cookies['natural_language_search_optin'], 'true'
+    assert_equal cookies['nls_enabled'], 'true'
 
     mock_timdex_success
     get '/results?q=test&tab=timdex&queryMode=keyword'
 
     assert_response :success
-    assert_equal cookies['natural_language_search_optin'], 'true'
+    assert_equal cookies['nls_enabled'], 'true'
   end
 
   test 'cookie unchanged after search with URL param override' do
     get '/natural_language_search_optin?natural_language_search_optin=false'
-    assert_equal cookies['natural_language_search_optin'], 'false'
+    assert_equal cookies['nls_enabled'], 'false'
 
     mock_timdex_success
     get '/results?q=test&tab=timdex&queryMode=hybrid'
 
     assert_response :success
-    assert_equal cookies['natural_language_search_optin'], 'false'
+    assert_equal cookies['nls_enabled'], 'false'
   end
 
   test 'cookie=true, no param: user is opted-in' do
@@ -312,5 +312,25 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal controller.view_context.assigns['show_nls_warning'], false
+  end
+
+  test 'cookie is set with domain option on libraries.mit.edu' do
+    host! 'search.libraries.mit.edu'
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    # Check the Set-Cookie header includes domain=
+    set_cookie_header = response.headers['Set-Cookie']
+    assert_includes set_cookie_header, 'domain='
+    assert_equal cookies['nls_enabled'], 'true'
+  end
+
+  test 'cookie is set without domain option on non-MIT host' do
+    host! 'example.herokuapp.com'
+    get '/natural_language_search_optin?natural_language_search_optin=true'
+
+    # Check the Set-Cookie header does NOT include domain=
+    set_cookie_header = response.headers['Set-Cookie']
+    assert_not_includes set_cookie_header, 'domain='
+    assert_equal cookies['nls_enabled'], 'true'
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* We want WordPress/PHP to also be able to read this cookie

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/USE-637

How does this address that need:

* Changes to domain cookie and uses a different name to avoid conflicts with the existing cookie

Document any side effects to this change:

* Deleting the old cookie when toggling the new cookie. We will want to stop doing this at some point in the future.
* Users with a preference set will lose that value. We could support both values but it felt not worth it for this feature at this time.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
