### PR TITLE
Apply requested changes to result callouts

### DIFF
--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -59,7 +59,7 @@ module ResultsHelper
                                           'op[]': ''
                                         })
 
-    'https://archivesspace.mit.edu/search?' + aspace_params
+    "https://archivesspace.mit.edu/search?#{aspace_params}"
   end
 
   # Creates WorldCat links based on current search term
@@ -68,7 +68,38 @@ module ResultsHelper
                                             queryString: params[:q]
                                           })
 
-    'https://mit.on.worldcat.org/search?' + worldcat_params
+    "https://mit.on.worldcat.org/search?#{worldcat_params}"
+  end
+
+  # Creates WorldCat links with book filter based on current search term
+  def search_worldcat_link_with_book_filter
+    worldcat_params = URI.encode_www_form({
+                                            queryString: params[:q],
+                                            dblist: '638'
+                                          })
+
+    "https://mit.on.worldcat.org/search?#{worldcat_params}"
+  end
+
+  # Creates DSpace@MIT search links based on current search term
+  def search_dspace_link
+    return 'https://dspace.mit.edu' if params[:q].blank?
+
+    "https://dspace.mit.edu/discover?query=#{URI.encode_www_form_component(params[:q])}"
+  end
+
+  # Creates Research Databases link based on current search term
+  def search_databases_link
+    return 'https://libguides.mit.edu/az/databases' if params[:q].blank?
+
+    "https://libguides.mit.edu/az/databases?q=#{URI.encode_www_form_component(params[:q])}"
+  end
+
+  # Creates MIT Geospatial Data search links based on current search term
+  def search_geodata_link
+    return 'https://geodata.libraries.mit.edu' if params[:q].blank?
+
+    "https://geodata.libraries.mit.edu/search?query=#{URI.encode_www_form_component(params[:q])}"
   end
 
   # Determines if a format value represents an article type

--- a/app/views/search/_results_callouts.html.erb
+++ b/app/views/search/_results_callouts.html.erb
@@ -1,20 +1,41 @@
 <div class="callout-wrapper" data-track-content data-content-name="Search Suggestions" data-matomo-seen="Search Suggestions, Search Suggestions Seen, Tab: {{getActiveTabName}}" data-matomo-click="Search Suggestions, Search Suggestions Engaged, Link: {{getElementText}}">
-  <% if ['cdi', 'alma', 'all'].include?(@active_tab) %>
+  <!-- ALL TAB -->
+  <% if @active_tab == 'all' %>
     <%= render partial: "results_callout_component", locals: {
       fa_name: 'magnifying-glass',
-      heading: 'Refine your search',
+      heading: 'Advanced search for articles & books',
       blurb: 'Use advanced search features to expand or filter your search.',
       link_url: search_primo_link,
-      link_text: 'Search the catalog' } %>
+      link_text: 'Run advanced search' } %>
+  <% end %>
+
+  <!-- CDI / ARTICLES TAB -->
+  <% if @active_tab == 'cdi' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'magnifying-glass',
+      heading: 'Advanced search for articles & books',
+      blurb: 'Use advanced search features to expand or filter your search.',
+      link_url: search_primo_link,
+      link_text: 'Run advanced search' } %>
+  <% end %>
+
+  <!-- ALMA / BOOKS & MEDIA TAB -->
+  <% if @active_tab == 'alma' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'magnifying-glass',
+      heading: 'Advanced search for articles & books',
+      blurb: 'Use advanced search features to expand or filter your search.',
+      link_url: search_primo_link,
+      link_text: 'Run advanced search' } %>
   <% end %>
 
   <% if @active_tab == 'all' %>
     <%= render partial: "results_callout_component", locals: {
       fa_name: 'file-xmark',
-      heading: 'Can’t find what you are looking for?',
-      blurb: 'Use specialized search tools for books, articles, databases, and more',
-      link_url: 'http://libraries.mit.edu/search',
-      link_text: 'More search options' } %>
+      heading: "Can't find what you are looking for?",
+      blurb: 'Get help to find, request, and get the materials you need',
+      link_url: 'https://libraries.mit.edu/research-support/get-materials-via-the-libraries/',
+      link_text: 'Get materials via the MIT Libraries' } %>
   <% end %>
 
   <% if @active_tab == 'cdi' %>
@@ -29,19 +50,20 @@
   <% if @active_tab == 'alma' %>
     <%= render partial: "results_callout_component", locals: {
       fa_name: 'book',
-      heading: 'Can’t find a book?',
-      blurb: 'If we don’t own it you can often request it from another library.',
-      link_url: search_worldcat_link,
-      link_text: 'Search WorldCat' } %>
+      heading: "Can't find a book?",
+      blurb: "If we don't own it you can request it from another library.",
+      link_url: search_worldcat_link_with_book_filter,
+      link_text: "Can't find a book?" } %>
   <% end %>
 
+  <!-- ASPACE / MIT ARCHIVES TAB -->
   <% if @active_tab == 'aspace' %>
     <%= render partial: "results_callout_component", locals: {
       fa_name: 'magnifying-glass',
-      heading: 'Refine your search',
-      blurb: 'Use advanced search features to expand or filter your search.',
+      heading: 'Expand your search',
+      blurb: 'Find more content and use advanced features to filter your search.',
       link_url: search_aspace_link,
-      link_text: 'Search ArchivesSpace' } %>
+      link_text: 'Run search in Archives & Manuscripts' } %>
   <% end %>
 
   <% if @active_tab == 'aspace' %>
@@ -53,6 +75,64 @@
       link_text: 'Ask Distinctive Collections' } %>
   <% end %>
 
+  <!-- DSPACE / MIT SCHOLARSHIP TAB -->
+  <% if @active_tab == 'dspace' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'magnifying-glass',
+      heading: 'Refine your search',
+      blurb: 'Use advanced search features to expand or filter your search.',
+      link_url: search_dspace_link,
+      link_text: 'Run search in MIT Open Scholarship' } %>
+  <% end %>
+
+  <% if @active_tab == 'dspace' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'bell-concierge',
+      heading: 'Need help?',
+      blurb: 'Our staff can help you',
+      link_url: 'https://libanswers.mit.edu/ask-dspace',
+      link_text: 'Ask us! MIT Open Scholarship' } %>
+  <% end %>
+
+  <!-- DATABASES / RESEARCH DATABASES TAB -->
+  <% if @active_tab == 'databases' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'magnifying-glass',
+      heading: 'Refine your search',
+      blurb: 'Use advanced search features to expand or filter your search.',
+      link_url: search_databases_link,
+      link_text: 'Run search in Research Databases' } %>
+  <% end %>
+
+  <% if @active_tab == 'databases' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'messages',
+      heading: 'Want to talk to us?',
+      blurb: 'Get help, give us feedback, use the staff directory.',
+      link_url: 'https://libguides.mit.edu/directory',
+      link_text: 'Contact us' } %>
+  <% end %>
+
+  <!-- GEODATA / GEOSPATIAL DATA TAB -->
+  <% if @active_tab == 'geodata' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'magnifying-glass',
+      heading: 'Refine your search',
+      blurb: 'Use advanced search features to expand or filter your search.',
+      link_url: search_geodata_link,
+      link_text: 'Run search in Geospatial Data' } %>
+  <% end %>
+
+  <% if @active_tab == 'geodata' %>
+    <%= render partial: "results_callout_component", locals: {
+      fa_name: 'bell-concierge',
+      heading: 'Need help?',
+      blurb: 'Our staff can help you',
+      link_url: 'https://libanswers.mit.edu/ask-gis/',
+      link_text: 'Ask GIS' } %>
+  <% end %>
+
+  <!-- WEBSITE TAB -->
   <% if @active_tab == 'website' %>
     <%= render partial: "results_callout_component", locals: {
       fa_name: 'messages',

--- a/test/helpers/results_helper_test.rb
+++ b/test/helpers/results_helper_test.rb
@@ -225,4 +225,53 @@ class ResultsHelperTest < ActionView::TestCase
     result = { links: nil }
     assert_nil full_record_url(result)
   end
+
+  test 'search_worldcat_link_with_book_filter returns a valid worldcat search URL with book filter' do
+    params[:q] = 'climate change'
+    link = search_worldcat_link_with_book_filter
+
+    assert_equal 'https://mit.on.worldcat.org/search?queryString=climate+change&dblist=638', link
+  end
+
+  test 'search_dspace_link returns a valid MIT Open Scholarship search URL' do
+    params[:q] = 'MIT research'
+    link = search_dspace_link
+
+    assert_equal 'https://dspace.mit.edu/discover?query=MIT+research', link
+  end
+
+  test 'search_dspace_link returns landing page when no search term' do
+    params[:q] = nil
+    link = search_dspace_link
+
+    assert_equal 'https://dspace.mit.edu', link
+  end
+
+  test 'search_databases_link returns a valid research databases URL with query' do
+    params[:q] = 'climate databases'
+    link = search_databases_link
+
+    assert_equal 'https://libguides.mit.edu/az/databases?q=climate+databases', link
+  end
+
+  test 'search_databases_link returns landing page when no search term' do
+    params[:q] = nil
+    link = search_databases_link
+
+    assert_equal 'https://libguides.mit.edu/az/databases', link
+  end
+
+  test 'search_geodata_link returns a valid MIT Geospatial Data search URL' do
+    params[:q] = 'boston area'
+    link = search_geodata_link
+
+    assert_equal 'https://geodata.libraries.mit.edu/search?query=boston+area', link
+  end
+
+  test 'search_geodata_link returns landing page when no search term' do
+    params[:q] = nil
+    link = search_geodata_link
+
+    assert_equal 'https://geodata.libraries.mit.edu', link
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

UXWS has suggested several changes to the result
callouts partial to make this content more useful.

#### Relevant ticket(s):

- [USE-620](https://mitlibraries.atlassian.net/browse/USE-620)

#### How this addresses that need:

This implements the suggested changes.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Check the Google doc linked in the ticket for the list of changes. (I will tag UXWS to confirm that the changes are as expected.)

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-620]: https://mitlibraries.atlassian.net/browse/USE-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ