### PR TITLE
Renames nls_enabled cookie to STYXKEY_nls_enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,9 +43,9 @@ class ApplicationController < ActionController::Base
   #
   # Returns the value from the current STYXKEY_nls_enabled cookie, or falls back to
   # the old nls_enabled cookie for backward compatibility during the transition period.
-  # Max future date we need this fall back is 2027-07-01, when all old cookies will have expired.
-  # All previous cookie names were session cookies, so we no longer support them at all.
+  # Max future date we need this fallback is 2027-07-01, when all legacy nls_enabled cookies will have expired.
+  # All other previous cookie names were session cookies, so we no longer support them at all.
   def nls_enabled_value
-    cookies['STYXKEY_nls_enabled'] || cookies[:nls_enabled]
+    cookies['STYXKEY_nls_enabled'].presence || cookies[:nls_enabled].presence
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,18 @@ class ApplicationController < ActionController::Base
     all_tabs.include?(tab)
   end
 
+  # Set the natural language search opt-in state for the current request.
   def set_natural_language_search_optin
-    @natural_language_search_optin = cookies[:nls_enabled] == 'true'
+    @natural_language_search_optin = nls_enabled_value == 'true'
+  end
+
+  # Get the natural language search opt-in value with fallback support.
+  #
+  # Returns the value from the current STYXKEY_nls_enabled cookie, or falls back to
+  # the old nls_enabled cookie for backward compatibility during the transition period.
+  # Max future date we need this fall back is 2027-07-01, when all old cookies will have expired.
+  # All previous cookie names were session cookies, so we no longer support them at all.
+  def nls_enabled_value
+    cookies['STYXKEY_nls_enabled'] || cookies[:nls_enabled]
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,7 +17,7 @@ class SearchController < ApplicationController
     params[:booleanType] = cookies[:boolean_type] || 'AND'
 
     # inject hybrid queryMode if opted-in and no queryMode param provided
-    params[:queryMode] = 'hybrid' if params[:queryMode].blank? && cookies[:nls_enabled] == 'true'
+    params[:queryMode] = 'hybrid' if params[:queryMode].blank? && nls_enabled_value == 'true'
 
     @enhanced_query = Enhancer.new(params).enhanced_query
     @show_nls_warning = show_nls_warning?

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -23,15 +23,16 @@ class StaticController < ApplicationController
                            else
                              { value: optin, expires: 1.year.from_now }
                            end
-      cookies[:nls_enabled] = nls_cookie_options
+      cookies['STYXKEY_nls_enabled'] = nls_cookie_options
     else
-      cookies.delete :nls_enabled, domain: '.libraries.mit.edu' if use_domain_cookies?
-      cookies.delete :nls_enabled unless use_domain_cookies?
+      cookies.delete 'STYXKEY_nls_enabled', domain: '.libraries.mit.edu' if use_domain_cookies?
+      cookies.delete 'STYXKEY_nls_enabled' unless use_domain_cookies?
     end
 
-    # Clean up old cookie name for users migrating to domain cookies
-    # Note: delete this in a future release after users have had time to migrate
-    cookies.delete :natural_language_search_optin
+    # Clean up old cookie names no longer in use
+    # Note: max date nls_enabled will be needed is 2027-07-01, when all old cookies will have expired.
+    cookies.delete :nls_enabled, domain: '.libraries.mit.edu' if use_domain_cookies?
+    cookies.delete :nls_enabled unless use_domain_cookies?
 
     # Redirect to return_to param if it's a safe local path, otherwise root
     return_to = params[:return_to].presence

--- a/test/controllers/natural_language_search_optin_test.rb
+++ b/test/controllers/natural_language_search_optin_test.rb
@@ -208,6 +208,55 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
     assert_equal controller.view_context.assigns['natural_language_search_optin'], false
   end
 
+  # Backward compatibility tests for legacy nls_enabled cookie
+  # These verify that existing users with the old cookie are still honored during transition
+
+  test 'legacy nls_enabled cookie=true is honored' do
+    # Manually set legacy cookie without going through the opt-in route
+    cookies['nls_enabled'] = 'true'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], true
+  end
+
+  test 'legacy nls_enabled cookie=false is honored' do
+    # Manually set legacy cookie without going through the opt-in route
+    cookies['nls_enabled'] = 'false'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], false
+  end
+
+  test 'legacy nls_enabled cookie shows toggled-on state' do
+    # Manually set legacy cookie without going through the opt-in route
+    cookies['nls_enabled'] = 'true'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    assert_select 'div.semantic-search-toggle.toggled-on'
+  end
+
+  test 'new STYXKEY_nls_enabled cookie takes precedence over legacy' do
+    # Set both cookies: new should take precedence
+    cookies['STYXKEY_nls_enabled'] = 'true'
+    cookies['nls_enabled'] = 'false'
+
+    mock_timdex_success
+    get '/results?q=test&tab=timdex'
+
+    assert_response :success
+    # Should honor the new cookie value of true
+    assert_equal controller.view_context.assigns['natural_language_search_optin'], true
+  end
+
   test 'cookie-driven queryMode works on timdex tab' do
     get '/natural_language_search_optin?natural_language_search_optin=true'
     mock_timdex_success

--- a/test/controllers/natural_language_search_optin_test.rb
+++ b/test/controllers/natural_language_search_optin_test.rb
@@ -53,24 +53,24 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
   test 'route with natural_language_search_optin=true sets cookie' do
     get '/natural_language_search_optin?natural_language_search_optin=true'
     assert_response :redirect
-    assert_equal cookies['nls_enabled'], 'true'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'true'
   end
 
   test 'route with natural_language_search_optin=false sets cookie to false' do
     get '/natural_language_search_optin?natural_language_search_optin=false'
     assert_response :redirect
-    assert_equal cookies['nls_enabled'], 'false'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'false'
   end
 
   test 'route with no parameter deletes cookie' do
     get '/natural_language_search_optin?natural_language_search_optin=true'
-    assert_equal cookies['nls_enabled'], 'true'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'true'
 
     get '/natural_language_search_optin'
     assert_response :redirect
 
     # Rails sets cookies to empty string when deleted via cookies.delete
-    assert(cookies['nls_enabled'].blank?)
+    assert(cookies['STYXKEY_nls_enabled'].blank?)
   end
 
   test 'route redirects to return_to when provided' do
@@ -162,24 +162,24 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
 
   test 'URL param queryMode overrides cookie' do
     get '/natural_language_search_optin?natural_language_search_optin=true'
-    assert_equal cookies['nls_enabled'], 'true'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'true'
 
     mock_timdex_success
     get '/results?q=test&tab=timdex&queryMode=keyword'
 
     assert_response :success
-    assert_equal cookies['nls_enabled'], 'true'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'true'
   end
 
   test 'cookie unchanged after search with URL param override' do
     get '/natural_language_search_optin?natural_language_search_optin=false'
-    assert_equal cookies['nls_enabled'], 'false'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'false'
 
     mock_timdex_success
     get '/results?q=test&tab=timdex&queryMode=hybrid'
 
     assert_response :success
-    assert_equal cookies['nls_enabled'], 'false'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'false'
   end
 
   test 'cookie=true, no param: user is opted-in' do
@@ -321,7 +321,7 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
     # Check the Set-Cookie header includes domain=libraries.mit.edu
     set_cookie_header = response.headers['Set-Cookie']
     assert_includes set_cookie_header, 'domain=.libraries.mit.edu'
-    assert_equal cookies['nls_enabled'], 'true'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'true'
   end
 
   test 'cookie is set without domain option on non-MIT host' do
@@ -331,6 +331,6 @@ class NaturalLanguageSearchOptinTest < ActionDispatch::IntegrationTest
     # Check the Set-Cookie header does NOT include domain=
     set_cookie_header = response.headers['Set-Cookie']
     assert_not_includes set_cookie_header, 'domain='
-    assert_equal cookies['nls_enabled'], 'true'
+    assert_equal cookies['STYXKEY_nls_enabled'], 'true'
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Pantheon cache only allows through cookies that are prefixed with STYXKEY_ for caching purposes

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/USE-631

How does this address that need:

* Updates the cookie name to STYXKEY_nls_enabled and adds a fallback to the old cookie name for backward compatibility during the transition period.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

##### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
