### PR TITLE
Add test coverage for cold cache TIMDEX calls

### DIFF
--- a/test/models/merged_search_service_test.rb
+++ b/test/models/merged_search_service_test.rb
@@ -31,7 +31,7 @@ class MergedSearchServiceTest < ActiveSupport::TestCase
     query = { q: 'test' }
 
     service = MergedSearchService.new(enhanced_query: query, active_tab: 'all',
-                      primo_fetcher: fake_fetcher, timdex_fetcher: fake_fetcher)
+                                      primo_fetcher: fake_fetcher, timdex_fetcher: fake_fetcher)
 
     # populate cache so service uses it instead of summary calls
     Rails.cache.write(service.send(:totals_cache_key), { primo: 50, timdex: 50 })
@@ -100,6 +100,31 @@ class MergedSearchServiceTest < ActiveSupport::TestCase
     assert res[:results].is_a?(Array)
   end
 
+  test 'all tab cold cache deeper page calls timdex twice' do
+    timdex_calls = []
+
+    fake_timdex = fake_fetcher(results: %w[t1 t2 t3 t4 t5], hits: 150, calls: timdex_calls)
+    fake_primo = fake_fetcher(results: %w[p1 p2 p3], hits: 100)
+    service = MergedSearchService.new(enhanced_query: { q: 'test' }, active_tab: 'all',
+                                      primo_fetcher: fake_primo, timdex_fetcher: fake_timdex)
+
+    # Verify cache is cold
+    assert_nil Rails.cache.read(service.send(:totals_cache_key))
+
+    # Fetch page 7, verify TIMDEX was called twice
+    service.fetch(page: 7, per_page: 10)
+    assert_equal 2, timdex_calls.length
+
+    # First call: summary (offset=0, per_page=1)
+    assert_equal({ offset: 0, per_page: 1 }, timdex_calls[0])
+
+    # Second call: page data (offset/per_page computed by MergedSearchPaginator)
+    paginator = MergedSearchPaginator.new(primo_total: 100, timdex_total: 150, current_page: 7, per_page: 10)
+    expected_offset = paginator.api_offsets[1]
+    expected_count = paginator.merge_plan.count(:timdex)
+    assert_equal({ offset: expected_offset, per_page: expected_count }, timdex_calls[1])
+  end
+
   test 'fetch_all_tab_page_chunks handles zero-count branches' do
     called = []
     primo_fetcher = lambda { |offset:, per_page:, query:|
@@ -145,7 +170,7 @@ class MergedSearchServiceTest < ActiveSupport::TestCase
     primo_results = %w[P1 P2 P3]
     timdex_results = %w[T1 T2 T3 T4 T5]
     svc = MergedSearchService.new(enhanced_query: { q: 'test' }, active_tab: 'all', primo_fetcher: fake_fetcher,
-                    timdex_fetcher: fake_fetcher)
+                                  timdex_fetcher: fake_fetcher)
     merged = svc.send(:merge_results, paginator, primo_results, timdex_results)
     expected = %w[P1 T1 P2 T2 P3 T3 T4 T5]
     assert_equal expected, merged
@@ -155,7 +180,7 @@ class MergedSearchServiceTest < ActiveSupport::TestCase
     primo_results = %w[P1 P2 P3 P4 P5]
     timdex_results = %w[T1 T2 T3]
     svc = MergedSearchService.new(enhanced_query: { q: 'test' }, active_tab: 'all', primo_fetcher: fake_fetcher,
-                    timdex_fetcher: fake_fetcher)
+                                  timdex_fetcher: fake_fetcher)
     merged = svc.send(:merge_results, paginator, primo_results, timdex_results)
     expected = %w[P1 T1 P2 T2 P3 T3 P4 P5]
     assert_equal expected, merged
@@ -165,7 +190,7 @@ class MergedSearchServiceTest < ActiveSupport::TestCase
     primo_results = (1..15).map { |i| "P#{i}" }
     timdex_results = (1..15).map { |i| "T#{i}" }
     svc = MergedSearchService.new(enhanced_query: { q: 'test' }, active_tab: 'all', primo_fetcher: fake_fetcher,
-                    timdex_fetcher: fake_fetcher)
+                                  timdex_fetcher: fake_fetcher)
     merged = svc.send(:merge_results, paginator, primo_results, timdex_results)
     assert_equal 20, merged.length
     assert_equal 'P1', merged[0]
@@ -178,7 +203,7 @@ class MergedSearchServiceTest < ActiveSupport::TestCase
     primo_results = []
     timdex_results = %w[T1 T2 T3]
     svc = MergedSearchService.new(enhanced_query: { q: 'test' }, active_tab: 'all', primo_fetcher: fake_fetcher,
-                    timdex_fetcher: fake_fetcher)
+                                  timdex_fetcher: fake_fetcher)
     merged = svc.send(:merge_results, paginator, primo_results, timdex_results)
     assert_equal %w[T1 T2 T3], merged
 
@@ -187,7 +212,7 @@ class MergedSearchServiceTest < ActiveSupport::TestCase
     primo_results = (1..7).map { |i| "P#{i}" }
     timdex_results = (1..11).map { |i| "T#{i}" }
     svc = MergedSearchService.new(enhanced_query: { q: 'test' }, active_tab: 'all', primo_fetcher: fake_fetcher,
-            timdex_fetcher: fake_fetcher)
+                                  timdex_fetcher: fake_fetcher)
     merged = svc.send(:merge_results, paginator, primo_results, timdex_results)
     expected = %w[P1 T1 P2 T2 P3 T3 P4 T4 P5 T5 P6 T6 P7 T7 T8 T9 T10 T11]
     assert_equal expected, merged

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,8 +74,16 @@ end
 
 # Helper factory to create simple stub fetchers for `MergedSearchService` tests.
 # Returns a lambda matching the fetcher signature: `(offset:, per_page:, query: nil)`.
-def fake_fetcher(results: [], hits: 0, errors: nil, show_continuation: false)
+#
+# @param results [Array] the results to return on each call (duplicated)
+# @param hits [Integer] the total hit count to return
+# @param errors [nil, Array] any errors to return
+# @param show_continuation [Boolean] set to true if the API has exhausted its practical offset limit
+# @param calls [Array, nil] optional array to track number of invocations. If provided, each call
+#        appends {offset:, per_page:}
+def fake_fetcher(results: [], hits: 0, errors: nil, show_continuation: false, calls: nil)
   lambda do |offset:, per_page:, query: nil|
+    calls << { offset:, per_page: } if calls
     { results: results.dup, hits: hits, errors: errors, show_continuation: show_continuation }
   end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

TIMDEX UI makes two calls for deeper-page fetches: one to page 1 to retrieve total hits, and another
to retrieve the results at the specified page.
This is not currently covered in our test suite.

#### Relevant ticket(s):

- [USE-605](https://mitlibraries.atlassian.net/browse/USE-605)

#### How this addresses that need:

This adds a test to verify that TIMDEX is called
twice under cold-cache circumstances, confirming
the page-1 and page-n calls.

#### Side effects of this change:

The `fake_fetcher` helper method has been updated
to accommodate the new test.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [x] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-605]: https://mitlibraries.atlassian.net/browse/USE-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ