### PR TITLE
Add tab for Digital Collections

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
   end
 
   def timdex_tabs
-    %w[aspace databases dspace geodata timdex timdex_alma website]
+    %w[aspace databases digital_collections dspace geodata timdex timdex_alma website]
   end
 
   def all_tabs

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -191,6 +191,7 @@ class SearchController < ApplicationController
     query[:sourceFilter] = ['DSpace@MIT'] if @active_tab == 'dspace'
     query[:sourceFilter] = ['Research Databases'] if @active_tab == 'databases'
     query[:sourceFilter] = ['OpenGeoMetadata GIS Resources', 'MIT GIS Resources'] if @active_tab == 'geodata'
+    query[:sourceFilter] = ['Digital Collections'] if @active_tab == 'digital_collections'
     query[:useGlobalScoring] = Feature.enabled?(:global_scoring)
 
     # We generate unique cache keys to avoid naming collisions.

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -33,9 +33,11 @@
 #
 class Feature
   # List of all valid features in the application
-  VALID_FEATURES = %i[bot_detection geodata boolean_picker global_scoring oa_always primo_nde_links
-                      simulate_search_latency tab_digital_collections tab_primo_all tab_timdex_all tab_timdex_alma record_link timdex_fulltext
-                      timdex_semantic_search].freeze
+  VALID_FEATURES = %i[
+    bot_detection geodata boolean_picker global_scoring oa_always primo_nde_links
+    simulate_search_latency tab_digital_collections tab_primo_all tab_timdex_all
+    tab_timdex_alma record_link timdex_fulltext timdex_semantic_search
+  ].freeze
 
   # Check if a feature is enabled by name
   #

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -34,7 +34,7 @@
 class Feature
   # List of all valid features in the application
   VALID_FEATURES = %i[bot_detection geodata boolean_picker global_scoring oa_always primo_nde_links
-                      simulate_search_latency tab_primo_all tab_timdex_all tab_timdex_alma record_link timdex_fulltext
+                      simulate_search_latency tab_digital_collections tab_primo_all tab_timdex_all tab_timdex_alma record_link timdex_fulltext
                       timdex_semantic_search].freeze
 
   # Check if a feature is enabled by name

--- a/app/views/search/_source_tabs.html.erb
+++ b/app/views/search/_source_tabs.html.erb
@@ -12,6 +12,10 @@
       <li><%= link_to_tab("Website") %></li>
 
       <%# Experimental tabs %>
+      <% if Feature.enabled?(:tab_digital_collections) %>
+        <li><%= link_to_tab("digital_collections", "Digital Collections") %></li>
+      <% end %>
+
       <% if Feature.enabled?(:tab_primo_all) %>
         <li><%= link_to_tab("Primo", "Articles and Catalog") %></li>
       <% end %>

--- a/test/controllers/application_controller_unit_test.rb
+++ b/test/controllers/application_controller_unit_test.rb
@@ -10,11 +10,11 @@ class ApplicationControllerUnitTest < ActionController::TestCase
   end
 
   test '#timdex_tabs returns expected tabs' do
-    assert_equal %w[aspace databases dspace geodata timdex timdex_alma website], @controller.timdex_tabs
+    assert_equal %w[aspace databases digital_collections dspace geodata timdex timdex_alma website], @controller.timdex_tabs
   end
 
   test '#all_tabs includes both primo and timdex tabs as well as all tab' do
-    expected = %w[all alma cdi primo aspace databases dspace geodata timdex timdex_alma website]
+    expected = %w[all alma cdi primo aspace databases digital_collections dspace geodata timdex timdex_alma website]
     assert_equal expected, @controller.all_tabs
   end
 

--- a/test/controllers/application_controller_unit_test.rb
+++ b/test/controllers/application_controller_unit_test.rb
@@ -10,7 +10,10 @@ class ApplicationControllerUnitTest < ActionController::TestCase
   end
 
   test '#timdex_tabs returns expected tabs' do
-    assert_equal %w[aspace databases digital_collections dspace geodata timdex timdex_alma website], @controller.timdex_tabs
+    assert_equal(
+      %w[aspace databases digital_collections dspace geodata timdex timdex_alma website],
+      @controller.timdex_tabs
+    )
   end
 
   test '#all_tabs includes both primo and timdex tabs as well as all tab' do


### PR DESCRIPTION
#### Why these changes are being introduced:

Digital Collections stakeholders would like an
easier way to view TIMDEX search results for that
platform.

#### Relevant ticket(s):

- [USE-570](https://mitlibraries.atlassian.net/browse/USE-570)

#### How this addresses that need:

This adds a Digital Collections tab that is
gated by the Feature class.

#### Side effects of this change:

None.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

The PR build is connected to TIMDEX dev, so Digital Collections results should be visible.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-570]: https://mitlibraries.atlassian.net/browse/USE-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ