### PR TITLE
Replace commas in author queries with U+2500

### DIFF
--- a/app/models/normalize_primo_record.rb
+++ b/app/models/normalize_primo_record.rb
@@ -277,9 +277,16 @@ class NormalizePrimoRecord
      '&tab=',
      ENV.fetch('PRIMO_TAB'),
      '&query=creator,exact,',
-     URI.encode_uri_component(author),
+     encode_author(author),
      '&offset=0',
      '&lang=en'].join
+  end
+
+  # Replace commas with box drawings light horizontal characters (Unicode U+2500) to avoid them
+  # being parsed as query separators.
+  def encode_author(author)
+    author_with_commas_replaced = author.gsub(',', '─')
+    URI.encode_uri_component(author_with_commas_replaced)
   end
 
   def thumbnail

--- a/test/models/normalize_primo_record_test.rb
+++ b/test/models/normalize_primo_record_test.rb
@@ -323,7 +323,7 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
   test 'constructs author search links' do
     normalized = NormalizePrimoRecord.new(full_record, 'test').normalize
     creator_link = normalized[:creators].first[:link]
-    assert_match 'nde/search?vid=01MIT_INST:NDE&search_scope=all&mode=advanced&tab=all&query=creator,exact,Smith%2C%20John%20A.&offset=0&lang=en',
+    assert_match 'nde/search?vid=01MIT_INST:NDE&search_scope=all&mode=advanced&tab=all&query=creator,exact,Smith%E2%94%80%20John%20A.&offset=0&lang=en',
                  creator_link
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

Primo NDE internally replaces commas in advanced
search query terms with the box drawings light
horizontal character (U+2500). It then converts
that character back into a comma for the search
summary.

In order for our author searches to
look normal in the NDE search summary, we need
to replace them with this specific character
in the URL.

#### Relevant ticket(s):

- [USE-681](https://mitlibraries.atlassian.net/browse/USE-681)

#### How this addresses that need:

This replaces commas with U+2500 in author link
search terms.

#### Side effects of this change:

Ex Libris will probably change this again someday
without telling anyone.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [x] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [x] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

When you follow a link to an author search in NDE, the search summary should show commas, not horizonal lines/emdashes or `search-advanced.boolOperator.option.`.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-681]: https://mitlibraries.atlassian.net/browse/USE-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ