### PR TITLE
Add full-text options to relevant Alma records

### DIFF
--- a/app/models/normalize_primo_record.rb
+++ b/app/models/normalize_primo_record.rb
@@ -131,6 +131,13 @@ class NormalizePrimoRecord
       end
     end
 
+    # Add Full-text options if pnx['links'] is nil and record has Alma-E (electronic availability)
+    if @record['pnx']['links'].nil? &&
+       @record['delivery']['deliveryCategory']&.include?('Alma-E') &&
+       record_link.present?
+      links << { 'url' => "#{record_link}#nui.getit.service_viewit", 'kind' => 'Full-text options' }
+    end
+
     # Return links if we found any
     links.any? ? links : []
   end
@@ -327,8 +334,8 @@ class NormalizePrimoRecord
   # FRBR Group check based on:
   # https://knowledge.exlibrisgroup.com/Primo/Knowledge_Articles/Primo_Search_API_-_how_to_get_FRBR_Group_members_after_a_search
   def frbrized?
-    return unless @record['pnx']['facets']
-    return unless @record['pnx']['facets']['frbrtype']
+    return false unless @record['pnx']['facets']
+    return false unless @record['pnx']['facets']['frbrtype']
 
     @record['pnx']['facets']['frbrtype'].join == '5'
   end

--- a/app/models/normalize_primo_record.rb
+++ b/app/models/normalize_primo_record.rb
@@ -132,10 +132,11 @@ class NormalizePrimoRecord
     end
 
     # Add Full-text options if pnx['links'] is nil and record has Alma-E (electronic availability)
-    if @record['pnx']['links'].nil? &&
-       @record['delivery']['deliveryCategory']&.include?('Alma-E') &&
-       record_link.present?
-      links << { 'url' => "#{record_link}#nui.getit.service_viewit", 'kind' => 'Full-text options' }
+    full_record_link = record_link
+    if @record.dig('pnx', 'links').nil? &&
+       @record.dig('delivery', 'deliveryCategory')&.include?('Alma-E') &&
+       full_record_link.present?
+      links << { 'url' => "#{full_record_link}#nui.getit.service_viewit", 'kind' => 'Full-text options' }
     end
 
     # Return links if we found any

--- a/test/models/normalize_primo_record_test.rb
+++ b/test/models/normalize_primo_record_test.rb
@@ -458,6 +458,60 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
     assert_not normalized[:dedup_record]
   end
 
+  test 'includes Full-text options link when pnx[links] is nil and both Alma-P and Alma-E present' do
+    record = alma_record.deep_dup
+
+    # Ensure no direct links
+    record['pnx']['links'] = nil
+
+    # Add delivery category with both physical and electronic
+    record['delivery']['deliveryCategory'] = %w[Alma-P Alma-E]
+    normalized = NormalizePrimoRecord.new(record, 'test').normalize
+    full_text_link = normalized[:links].find { |link| link['kind'] == 'Full-text options' }
+    assert_not_nil full_text_link
+    assert_match %r{/discovery/fulldisplay\?}, full_text_link['url']
+    assert_match(/#nui\.getit\.service_viewit$/, full_text_link['url'])
+  end
+
+  test 'excludes Full-text options link when pnx[links] is present' do
+    record = full_record.deep_dup
+
+    # Add delivery category with electronic
+    record['delivery']['deliveryCategory'] = %w[Alma-E]
+    normalized = NormalizePrimoRecord.new(record, 'test').normalize
+    full_text_link = normalized[:links].find { |link| link['kind'] == 'Full-text options' }
+    assert_nil full_text_link
+  end
+
+  test 'excludes Full-text options link when only Alma-P present' do
+    record = alma_record.deep_dup
+    record['pnx']['links'] = nil
+    record['delivery']['deliveryCategory'] = ['Alma-P']
+    normalized = NormalizePrimoRecord.new(record, 'test').normalize
+    full_text_link = normalized[:links].find { |link| link['kind'] == 'Full-text options' }
+    assert_nil full_text_link
+  end
+
+  test 'includes Full-text options link when only Alma-E present' do
+    record = alma_record.deep_dup
+    record['pnx']['links'] = nil
+    record['delivery']['deliveryCategory'] = ['Alma-E']
+    normalized = NormalizePrimoRecord.new(record, 'test').normalize
+    full_text_link = normalized[:links].find { |link| link['kind'] == 'Full-text options' }
+    assert_not_nil full_text_link
+    assert_match %r{/discovery/fulldisplay\?}, full_text_link['url']
+    assert_match(/#nui\.getit\.service_viewit$/, full_text_link['url'])
+  end
+
+  test 'excludes Full-text options link when no delivery category present' do
+    record = alma_record.deep_dup
+    record['pnx']['links'] = nil
+    record['delivery']['deliveryCategory'] = nil
+    normalized = NormalizePrimoRecord.new(record, 'test').normalize
+    full_text_link = normalized[:links].find { |link| link['kind'] == 'Full-text options' }
+    assert_nil full_text_link
+  end
+
   test 'dedup_url requires both frbrized and alma_record conditions' do
     # CDI record that is frbrized - should return nil
     normalizer = NormalizePrimoRecord.new(cdi_record, 'test')


### PR DESCRIPTION
Why these changes are being introduced:

Certain catalog records include an electronic
holding that is not included in the `links`
`object of the PNX metadata. For these records,
Primo displays a 'Full-text options' section with
the e-resource link, but SML displays nothing
because it only checks `links` for this
information.

Relevant ticket(s):

- [USE-663](https://mitlibraries.atlassian.net/browse/USE-663)

How this addresses that need:

This adds 'Full-text options' to a result's
`links` object, provided the result meets the
following conditions:

- pnx['links'] is nil
- pnx['deliveryCategory'] includes Alma-E

The 'Full-text options' link resolves to the
corresponding section of the Primo record.

Side effects of this change:

This decision infers that all Primo records that
meet the two conditions above will have a
'Full-text options' section. If this assumption
is incorrect, it will result in a confusing user
experience.

#### Developer

##### Accessibility

- [x] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

Searching for "Sea otters: a history" in the PR build will return as the top result a record that should include the 'Full-text options' link.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-663]: https://mitlibraries.atlassian.net/browse/USE-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ