### PR TITLE
USE-682: Adjust search box label and placeholder to match new homepage

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/rails/devcontainer/features/postgres-client": {
+      "version": "1.2.0",
+      "resolved": "ghcr.io/rails/devcontainer/features/postgres-client@sha256:7e6b118646d6e0d82a9ec06e81ad1b5406f7042f0279d35fff3a7a612be7a050",
+      "integrity": "sha256:7e6b118646d6e0d82a9ec06e81ad1b5406f7042f0279d35fff3a7a612be7a050"
+    },
+    "ghcr.io/rails/devcontainer/features/sqlite3": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/rails/devcontainer/features/sqlite3@sha256:fa4a12e87152158ed9b67acb819ad2e1bd78c7e3808ff08e786a76a677af2c58",
+      "integrity": "sha256:fa4a12e87152158ed9b67acb819ad2e1bd78c7e3808ff08e786a76a677af2c58"
+    }
+  }
+}

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -53,6 +53,10 @@
         width: 100%;
         padding-left: 46px;
         padding-right: 48px;
+
+        &::placeholder {
+          font-weight: $fw-normal;
+        }
       }
 
       #clear-search {

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -1,9 +1,9 @@
 <form id="search-form" action="<%= results_path %>" method="get" role="search">
-  <label for="basic-search-main">What can we help you find?</label>
+  <label for="basic-search-main">Search for books, articles, library services, and more</label>
   <div class="form-wrapper">
     <div class="search-input-wrapper">
       <i class="fa-regular fa-magnifying-glass"></i>
-      <input id="basic-search-main" type="search" class="field field-text basic-search-input" name="q" title="Keyword anywhere" value="<%= params[:q] %>" required>
+      <input id="basic-search-main" placeholder="Try a citation, topic, database, etc." type="search" class="field field-text basic-search-input" name="q" title="Keyword anywhere" value="<%= params[:q] %>" required>
       <button title="Clear search" aria-label="Clear search" type="button" id="clear-search">Clear search</button>
     </div>
     <input id="tab-to-target" type="hidden" name="tab" value="<%= @active_tab %>">


### PR DESCRIPTION
#### Developer
As part of our new homepage launch, we want the SML search box label and placeholder to match between Homepage <> SML. This work updates SML to match the language we've chosen for the homepage.

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [x] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

##### Approval beyond code review

- [x] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
