### PR TITLE
Populate hit counts in JSON results format across load-more feature settings

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,13 +45,20 @@ class SearchController < ApplicationController
 
     # Render the response in HTML or JSON format
     respond_to do |format|
-      format.json { render json: { results: @results, pagination: @pagination, errors: @errors } }
+      format.json { render json: { results: @results, pagination: hit_count, errors: @errors } }
       format.turbo_stream { render :results }
       format.html { render :results }
     end
   end
 
   private
+
+  # This returns the total result count from whichever instance variable is present
+  def hit_count
+    return @pagination unless pagination_load_more_enabled?
+
+    { hits: @load_more[:total_hits] }
+  end
 
   # Sleep to simulate latency for testing loading indicators when responses are fast
   def sleep_if_too_fast

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,7 +45,7 @@ class SearchController < ApplicationController
 
     # Render the response in HTML or JSON format
     respond_to do |format|
-      format.json { render json: { results: @results, pagination: hit_count, errors: @errors } }
+      format.json { render json: { results: @results, hits: hit_count, errors: @errors } }
       format.turbo_stream { render :results }
       format.html { render :results }
     end
@@ -55,9 +55,11 @@ class SearchController < ApplicationController
 
   # This returns the total result count from whichever instance variable is present
   def hit_count
-    return @pagination unless pagination_load_more_enabled?
-
-    { hits: @load_more[:total_hits] }
+    if @pagination_load_more_enabled
+      @load_more&.[](:total_hits) || 0
+    else
+      @pagination&.[](:hits) || 0
+    end
   end
 
   # Sleep to simulate latency for testing loading indicators when responses are fast

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1264,6 +1264,10 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       get "/results?q=test&format=json&format_token=#{secret_value}", headers: { 'HTTP_USER_AGENT' => quepid_ua }
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
+      response_json = JSON.parse(response.body)
+      assert_equal ['results', 'pagination', 'errors'], response_json.keys
+      assert_instance_of Array, response_json["results"]
+      assert_instance_of Integer, response_json["pagination"]["hits"]
     end
   end
 
@@ -1276,6 +1280,25 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       get "/results?q=test&format=json&format_token=#{secret_value}", headers: { 'HTTP_USER_AGENT' => quepid_ua }
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
+      response_json = JSON.parse(response.body)
+      assert_equal ['results', 'pagination', 'errors'], response_json.keys
+      assert_instance_of Array, response_json["results"]
+      assert_instance_of Integer, response_json["pagination"]["hits"]
+    end
+  end
+
+  test 'results can be returned in JSON format when env is set while load-more pagination is enabled' do
+    secret_value = 'sooper_sekret'
+    quepid_ua = 'Quepid/1.0 (Web Scraper)'
+    ClimateControl.modify(FORMAT_TOKEN: secret_value, FEATURE_PAGINATION_LOAD_MORE: 'true') do
+      mock_timdex_search_with_hits(10)
+      get "/results?q=test&format=json&format_token=#{secret_value}", headers: { 'HTTP_USER_AGENT' => quepid_ua }
+      assert_response :success
+      assert_equal 'application/json; charset=utf-8', response.content_type
+      response_json = JSON.parse(response.body)
+      assert_equal ['results', 'pagination', 'errors'], response_json.keys
+      assert_instance_of Array, response_json["results"]
+      assert_instance_of Integer, response_json["pagination"]["hits"]
     end
   end
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1265,9 +1265,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
       response_json = JSON.parse(response.body)
-      assert_equal ['results', 'pagination', 'errors'], response_json.keys
-      assert_instance_of Array, response_json["results"]
-      assert_instance_of Integer, response_json["pagination"]["hits"]
+      assert_equal %w[results pagination errors], response_json.keys
+      assert_instance_of Array, response_json['results']
+      assert_instance_of Integer, response_json['pagination']['hits']
     end
   end
 
@@ -1281,9 +1281,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
       response_json = JSON.parse(response.body)
-      assert_equal ['results', 'pagination', 'errors'], response_json.keys
-      assert_instance_of Array, response_json["results"]
-      assert_instance_of Integer, response_json["pagination"]["hits"]
+      assert_equal %w[results pagination errors], response_json.keys
+      assert_instance_of Array, response_json['results']
+      assert_instance_of Integer, response_json['pagination']['hits']
     end
   end
 
@@ -1296,9 +1296,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
       response_json = JSON.parse(response.body)
-      assert_equal ['results', 'pagination', 'errors'], response_json.keys
-      assert_instance_of Array, response_json["results"]
-      assert_instance_of Integer, response_json["pagination"]["hits"]
+      assert_equal %w[results pagination errors], response_json.keys
+      assert_instance_of Array, response_json['results']
+      assert_instance_of Integer, response_json['pagination']['hits']
     end
   end
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1265,9 +1265,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
       response_json = JSON.parse(response.body)
-      assert_equal %w[results pagination errors], response_json.keys
+      assert_equal %w[results hits errors], response_json.keys
       assert_instance_of Array, response_json['results']
-      assert_instance_of Integer, response_json['pagination']['hits']
+      assert_instance_of Integer, response_json['hits']
     end
   end
 
@@ -1281,9 +1281,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
       response_json = JSON.parse(response.body)
-      assert_equal %w[results pagination errors], response_json.keys
+      assert_equal %w[results hits errors], response_json.keys
       assert_instance_of Array, response_json['results']
-      assert_instance_of Integer, response_json['pagination']['hits']
+      assert_instance_of Integer, response_json['hits']
     end
   end
 
@@ -1296,9 +1296,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal 'application/json; charset=utf-8', response.content_type
       response_json = JSON.parse(response.body)
-      assert_equal %w[results pagination errors], response_json.keys
+      assert_equal %w[results hits errors], response_json.keys
       assert_instance_of Array, response_json['results']
-      assert_instance_of Integer, response_json['pagination']['hits']
+      assert_instance_of Integer, response_json['hits']
     end
   end
 


### PR DESCRIPTION
This restores an attribute in our search results - specific to the JSON format response - upon which our relevance platform depends, but which is going to go away with the next release of the application.

The change follows a TDD pattern of development: the first commit expands our test suite to reveal the problem (the loss of "hit counts" in the response, which will cause a problem with our Quepid platform). The second commit resolves the problem by restoring the value in the two conditions across which the application will likely operate.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
