### PR TITLE
Patch bugs in full-text links logic

### DIFF
--- a/app/javascript/controllers/content_loader_controller.js
+++ b/app/javascript/controllers/content_loader_controller.js
@@ -37,7 +37,7 @@ export default class extends Controller {
           if (parentElement.querySelector('.libkey-link')) {
             const resultGet = parentElement.closest('.result-get')
             if (resultGet) {
-              const primoLinks = resultGet.querySelectorAll('.primo-link')
+              const primoLinks = resultGet.querySelectorAll('.primo-link:not(.primo-link-preserve)')
               // removing instead of hiding to avoid layout issues when selecting which link to highlight
               primoLinks.forEach(link => link.remove())
             }

--- a/app/models/normalize_primo_record.rb
+++ b/app/models/normalize_primo_record.rb
@@ -131,12 +131,13 @@ class NormalizePrimoRecord
       end
     end
 
-    # Add Full-text options if pnx['links'] is nil and record has Alma-E (electronic availability)
-    full_record_link = record_link
-    if @record.dig('pnx', 'links').nil? &&
-       @record.dig('delivery', 'deliveryCategory')&.include?('Alma-E') &&
-       full_record_link.present?
-      links << { 'url' => "#{full_record_link}#nui.getit.service_viewit", 'kind' => 'Full-text options' }
+    # Add Full-text options when Alma-E is present and Primo does not provide direct PDF/HTML link
+    # fields.
+    has_direct_fulfillment = @record.dig('pnx', 'links', 'linktopdf').present? ||
+                             @record.dig('pnx', 'links', 'linktohtml').present?
+    if !has_direct_fulfillment &&
+       @record.dig('delivery', 'deliveryCategory')&.include?('Alma-E') && record_link.present?
+      links << { 'url' => "#{record_link}#nui.getit.service_viewit", 'kind' => 'Full-text options' }
     end
 
     # Return links if we found any

--- a/app/views/search/_result_primo.html.erb
+++ b/app/views/search/_result_primo.html.erb
@@ -92,9 +92,11 @@
                 <%= link_to 'View full record', link['url'], class: 'button', data: { content_piece: 'View Full Record' } %>
               <% end %>
             <%# Primo supplies PDF and HTML links in addition to the OpenURL variant that may be useful. %>
-            <%# We hide links with the `primo-link` css class if LibKey returns results. %>
+            <%# We hide most links with the `primo-link` css class if LibKey returns results. Keep Full-text options visible when available. %>
             <% else %>
-              <%= link_to link['kind'], link['url'], class: 'button primo-link', data: { content_piece: link['kind'] } %>
+              <% link_classes = ['button', 'primo-link'] %>
+              <% link_classes << 'primo-link-preserve' if link['kind'] == 'Full-text options' %>
+              <%= link_to link['kind'], link['url'], class: link_classes.join(' '), data: { content_piece: link['kind'] } %>
             <% end %>
           <% end %>
         <% end %>

--- a/test/models/normalize_primo_record_test.rb
+++ b/test/models/normalize_primo_record_test.rb
@@ -473,14 +473,25 @@ class NormalizePrimoRecordTest < ActiveSupport::TestCase
     assert_match(/#nui\.getit\.service_viewit$/, full_text_link['url'])
   end
 
-  test 'excludes Full-text options link when pnx[links] is present' do
+  test 'excludes Full-text options link when direct Primo PDF or HTML links are present' do
     record = full_record.deep_dup
-
-    # Add delivery category with electronic
     record['delivery']['deliveryCategory'] = %w[Alma-E]
+
     normalized = NormalizePrimoRecord.new(record, 'test').normalize
     full_text_link = normalized[:links].find { |link| link['kind'] == 'Full-text options' }
     assert_nil full_text_link
+  end
+
+  test 'includes Full-text options link when pnx[links] is present but has no usable links' do
+    record = alma_record.deep_dup
+    record['pnx']['links'] = {}
+    record['delivery']['deliveryCategory'] = %w[Alma-E]
+
+    normalized = NormalizePrimoRecord.new(record, 'test').normalize
+    full_text_link = normalized[:links].find { |link| link['kind'] == 'Full-text options' }
+    assert_not_nil full_text_link
+    assert_match %r{/discovery/fulldisplay\?}, full_text_link['url']
+    assert_match(/#nui\.getit\.service_viewit$/, full_text_link['url'])
   end
 
   test 'excludes Full-text options link when only Alma-P present' do


### PR DESCRIPTION
Why these changes are being introduced:

There are two uncaught edge cases in the full-text link logic:

1. Full-text options are removed when libkey links exist.
2. I a PNX record as an empty links object (rather than omitting it altogether), then full-text
options will not display.

Relevant ticket(s):

- [USE-663](https://mitlibraries.atlassian.net/browse/USE-663)

How this addresses that need:

This addresses the edge cases noted above.

Side effects of this change:

This change was prompted by full-text links not
appearing in staging, despite working properly in
local development environments. It's unclear
whether this change is what's required to fix
staging.

#### Developer

##### Accessibility

- [ ] ANDI or WAVE has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html).
- [ ] This PR contains no changes to the view layer.
- [ ] New issues flagged by ANDI or WAVE have been resolved.
- [ ] New issues flagged by ANDI or WAVE have been ticketed (link in the Pull Request details above).
- [ ] No new accessibility issues have been flagged.

##### New ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

##### Approval beyond code review

- [ ] UXWS/stakeholder approval has been confirmed.
- [ ] UXWS/stakeholder review will be completed retroactively.
- [ ] UXWS/stakeholder review is not needed.

##### Additional context needed to review

E.g., if the PR includes updated dependencies and/or data
migration, or how to confirm the feature is working.

#### Code Reviewer

##### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

##### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

##### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.


[USE-663]: https://mitlibraries.atlassian.net/browse/USE-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ